### PR TITLE
feat: implement sprint planning — Phase 2

### DIFF
--- a/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/backlog/client.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/backlog/client.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { PageError } from "@/components/page-error";
+import { PageLoader } from "@/components/page-loader";
+import { Button } from "@/components/ui/button";
+import { useGetProject } from "@/features/projects/api/use-get-project";
+import { ProjectAvatar } from "@/features/projects/components/project-avatar";
+import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useGetTasks } from "@/features/tasks/api/use-get-tasks";
+import { BacklogView } from "@/features/sprints/components/backlog-view";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { PencilIcon } from "lucide-react";
+import Link from "next/link";
+
+export const BacklogClient = () => {
+  const projectId = useProjectId();
+  const workspaceId = useWorkspaceId();
+
+  const { data: project, isLoading: isLoadingProject } = useGetProject({
+    projectId,
+  });
+
+  const { data: tasksData, isLoading: isLoadingTasks } = useGetTasks({
+    workspaceId,
+    projectId,
+  });
+
+  const isLoading = isLoadingProject || isLoadingTasks;
+
+  if (isLoading) return <PageLoader />;
+  if (!project) return <PageError message="Project not found" />;
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          <ProjectAvatar
+            name={project.name}
+            imageUrl={project.imageUrl}
+            className="size-8"
+          />
+          <p className="text-lg font-semibold">{project.name}</p>
+        </div>
+        <div>
+          <Button variant="secondary" size="sm" asChild>
+            <Link
+              href={`/workspaces/${project.workspaceId}/projects/${project.$id}/settings`}
+            >
+              <PencilIcon className="size-4 mr-2" />
+              Edit Project
+            </Link>
+          </Button>
+        </div>
+      </div>
+      <BacklogView
+        workspaceId={workspaceId}
+        projectId={projectId}
+        tasks={tasksData?.documents ?? []}
+      />
+    </div>
+  );
+};

--- a/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/backlog/page.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/backlog/page.tsx
@@ -1,0 +1,11 @@
+import { getCurrent } from "@/features/auth/queries";
+import { redirect } from "next/navigation";
+import { BacklogClient } from "./client";
+
+const BacklogPage = async () => {
+  const user = await getCurrent();
+  if (!user) redirect("/sign-in");
+  return <BacklogClient />;
+};
+
+export default BacklogPage;

--- a/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/client.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/client.tsx
@@ -9,11 +9,13 @@ import { useGetProjectAnalytics } from "@/features/projects/api/use-get-project-
 import { ProjectAvatar } from "@/features/projects/components/project-avatar";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
 import { TaskViewSwitcher } from "@/features/tasks/components/task-view-switcher";
-import { PencilIcon } from "lucide-react";
+import { PencilIcon, ListIcon } from "lucide-react";
 import Link from "next/link";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 
 export const ProjectIdClient = () => {
 	const projectId = useProjectId();
+	const workspaceId = useWorkspaceId();
 	const { data: project, isLoading: isLoadingProject } = useGetProject({
 		projectId,
 	});
@@ -33,7 +35,15 @@ export const ProjectIdClient = () => {
 					/>
 					<p className="text-lg font-semibold">{project.name}</p>
 				</div>
-				<div className="">
+				<div className="flex items-center gap-x-2">
+					<Button variant="secondary" size="sm" asChild>
+						<Link
+							href={`/workspaces/${project.workspaceId}/projects/${project.$id}/backlog`}
+						>
+							<ListIcon className="size-4 mr-2" />
+							Backlog
+						</Link>
+					</Button>
 					<Button variant="secondary" size="sm" asChild>
 						<Link
 							href={`/workspaces/${project.workspaceId}/projects/${project.$id}/settings`}

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -6,6 +6,7 @@ import members from "@/features/members/server/route";
 import projects from "@/features/projects/server/route";
 import tasks from "@/features/tasks/server/route";
 import tokens from "@/features/tokens/server/route";
+import sprints from "@/features/sprints/server/route";
 
 const app = new Hono().basePath("/api");
 
@@ -16,7 +17,8 @@ const routes = app
 	.route("/members", members)
 	.route("/projects", projects)
 	.route("/tasks", tasks)
-	.route("/tokens", tokens);
+	.route("/tokens", tokens)
+	.route("/sprints", sprints);
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/src/features/sprints/api/use-complete-sprint.ts
+++ b/src/features/sprints/api/use-complete-sprint.ts
@@ -1,0 +1,38 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.sprints)[":sprintId"]["complete"]["$post"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.sprints)[":sprintId"]["complete"]["$post"]
+>;
+
+export const useCompleteSprint = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, query }) => {
+      const response = await client.api.sprints[":sprintId"]["complete"]["$post"]({
+        param,
+        query,
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error((body as { error?: string })?.error ?? "Failed to complete sprint");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Sprint completed");
+      queryClient.invalidateQueries({ queryKey: ["sprints"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to complete sprint");
+    },
+  });
+  return mutation;
+};

--- a/src/features/sprints/api/use-create-sprint.ts
+++ b/src/features/sprints/api/use-create-sprint.ts
@@ -1,0 +1,29 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<(typeof client.api.sprints)["$post"], 200>;
+type RequestType = InferRequestType<(typeof client.api.sprints)["$post"]>;
+
+export const useCreateSprint = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ json }) => {
+      const response = await client.api.sprints["$post"]({ json });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error((err as any).error ?? "Failed to create sprint");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Sprint created");
+      queryClient.invalidateQueries({ queryKey: ["sprints"] });
+    },
+    onError: () => {
+      toast.error("Failed to create sprint");
+    },
+  });
+  return mutation;
+};

--- a/src/features/sprints/api/use-delete-sprint.ts
+++ b/src/features/sprints/api/use-delete-sprint.ts
@@ -1,0 +1,38 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.sprints)[":sprintId"]["$delete"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.sprints)[":sprintId"]["$delete"]
+>;
+
+export const useDeleteSprint = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, query }) => {
+      const response = await client.api.sprints[":sprintId"]["$delete"]({
+        param,
+        query,
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error((err as any).error ?? "Failed to delete sprint");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Sprint deleted");
+      queryClient.invalidateQueries({ queryKey: ["sprints"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+    onError: () => {
+      toast.error("Failed to delete sprint");
+    },
+  });
+  return mutation;
+};

--- a/src/features/sprints/api/use-get-sprints.ts
+++ b/src/features/sprints/api/use-get-sprints.ts
@@ -1,0 +1,25 @@
+import { client } from "@/lib/rpc";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetSprintsProps {
+  workspaceId: string;
+  projectId: string;
+  enabled?: boolean;
+}
+
+export const useGetSprints = ({ workspaceId, projectId, enabled = true }: UseGetSprintsProps) => {
+  return useQuery({
+    queryKey: ["sprints", workspaceId, projectId],
+    enabled: enabled && !!workspaceId && !!projectId,
+    queryFn: async () => {
+      const response = await client.api.sprints.$get({
+        query: { workspaceId, projectId },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to fetch sprints");
+      }
+      const { data } = await response.json();
+      return data;
+    },
+  });
+};

--- a/src/features/sprints/api/use-start-sprint.ts
+++ b/src/features/sprints/api/use-start-sprint.ts
@@ -1,0 +1,38 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.sprints)[":sprintId"]["start"]["$post"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.sprints)[":sprintId"]["start"]["$post"]
+>;
+
+export const useStartSprint = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, query }) => {
+      const response = await client.api.sprints[":sprintId"]["start"]["$post"]({
+        param,
+        query,
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error((body as { error?: string })?.error ?? "Failed to start sprint");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Sprint started");
+      queryClient.invalidateQueries({ queryKey: ["sprints"] });
+      queryClient.invalidateQueries({ queryKey: ["tasks"] });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to start sprint");
+    },
+  });
+  return mutation;
+};

--- a/src/features/sprints/api/use-update-sprint.ts
+++ b/src/features/sprints/api/use-update-sprint.ts
@@ -1,0 +1,37 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.sprints)[":sprintId"]["$patch"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.sprints)[":sprintId"]["$patch"]
+>;
+
+export const useUpdateSprint = () => {
+  const queryClient = useQueryClient();
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ json, param }) => {
+      const response = await client.api.sprints[":sprintId"]["$patch"]({
+        json,
+        param,
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error((err as any).error ?? "Failed to update sprint");
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      toast.success("Sprint updated");
+      queryClient.invalidateQueries({ queryKey: ["sprints"] });
+    },
+    onError: () => {
+      toast.error("Failed to update sprint");
+    },
+  });
+  return mutation;
+};

--- a/src/features/sprints/components/backlog-view.tsx
+++ b/src/features/sprints/components/backlog-view.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { DottedSeperator } from "@/components/dotted-seperator";
+import { MemberAvatar } from "@/features/members/components/member-avatar";
+import { Task, TaskStatus } from "@/features/tasks/types";
+import { useUpdateTask } from "@/features/tasks/api/use-update-task";
+import { useGetSprints } from "../api/use-get-sprints";
+import { useCreateSprintModal } from "../hooks/use-create-sprint-modal";
+import { SprintHeader } from "./sprint-header";
+import { Sprint, SprintStatus } from "../types";
+import { PlusIcon, ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useState } from "react";
+import { CreateSprintModal } from "./create-sprint-modal";
+
+interface BacklogViewProps {
+  workspaceId: string;
+  projectId: string;
+  tasks: Task[];
+}
+
+const priorityColorMap: Record<string, string> = {
+  BLOCKER: "destructive",
+  HIGH: "destructive",
+  MEDIUM: "default",
+  LOW: "secondary",
+  TRIVIAL: "outline",
+};
+
+interface TaskRowProps {
+  task: Task;
+  sprints: Sprint[];
+}
+
+const TaskRow = ({ task, sprints }: TaskRowProps) => {
+  const { mutate: updateTask, isPending } = useUpdateTask();
+
+  const assignableSprints = sprints.filter(
+    (s) =>
+      s.status === SprintStatus.PLANNED || s.status === SprintStatus.ACTIVE
+  );
+
+  const handleAssignSprint = (sprintId: string) => {
+    updateTask({
+      json: { sprintId },
+      param: { taskId: task.$id },
+    });
+  };
+
+  const handleRemoveFromSprint = () => {
+    updateTask({
+      json: { sprintId: null },
+      param: { taskId: task.$id },
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-x-3 px-4 py-2 hover:bg-muted/50 rounded-md group">
+      <div className="flex-1 flex items-center gap-x-2 min-w-0">
+        {task.issueType && (
+          <Badge variant="outline" className="text-xs shrink-0">
+            {task.issueType}
+          </Badge>
+        )}
+        <span className="text-sm truncate">{task.name}</span>
+      </div>
+      <div className="flex items-center gap-x-2 shrink-0">
+        {task.storyPoints !== undefined && task.storyPoints !== null && (
+          <Badge variant="outline" className="text-xs">
+            {task.storyPoints} pts
+          </Badge>
+        )}
+        {task.priority && (
+          <Badge
+            variant={
+              (priorityColorMap[task.priority] as
+                | "destructive"
+                | "default"
+                | "secondary"
+                | "outline") ?? "default"
+            }
+            className="text-xs"
+          >
+            {task.priority}
+          </Badge>
+        )}
+        {task.assignee && (
+          <MemberAvatar
+            name={task.assignee.name ?? "?"}
+            className="size-5"
+          />
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 text-xs opacity-0 group-hover:opacity-100 focus:opacity-100 focus-visible:opacity-100"
+              disabled={isPending}
+              aria-label="Assign to sprint"
+            >
+              Add to Sprint
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {assignableSprints.length === 0 && (
+              <DropdownMenuItem disabled>No sprints available</DropdownMenuItem>
+            )}
+            {assignableSprints.map((sprint) => (
+              <DropdownMenuItem
+                key={sprint.$id}
+                onClick={() => handleAssignSprint(sprint.$id)}
+              >
+                {sprint.name}
+              </DropdownMenuItem>
+            ))}
+            {task.sprintId && (
+              <DropdownMenuItem onClick={handleRemoveFromSprint}>
+                Remove from sprint
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+};
+
+interface SprintSectionProps {
+  sprint: Sprint;
+  tasks: Task[];
+  allSprints: Sprint[];
+}
+
+const SprintSection = ({ sprint, tasks, allSprints }: SprintSectionProps) => {
+  const [collapsed, setCollapsed] = useState(false);
+  const completedCount = tasks.filter((t) => t.status === TaskStatus.DONE).length;
+
+  return (
+    <div className="flex flex-col gap-y-1">
+      <SprintHeader
+        sprint={sprint}
+        taskCount={tasks.length}
+        completedCount={completedCount}
+      />
+      <div className="ml-2">
+        <button
+          type="button"
+          className="flex items-center gap-x-1 text-xs text-muted-foreground hover:text-foreground py-1"
+          onClick={() => setCollapsed((v) => !v)}
+        >
+          {collapsed ? (
+            <ChevronRightIcon className="size-3" />
+          ) : (
+            <ChevronDownIcon className="size-3" />
+          )}
+          {tasks.length} {tasks.length === 1 ? "task" : "tasks"}
+        </button>
+        {!collapsed && (
+          <div className="flex flex-col">
+            {tasks.length === 0 && (
+              <p className="text-sm text-muted-foreground px-4 py-2">
+                No tasks in this sprint yet.
+              </p>
+            )}
+            {tasks.map((task) => (
+              <TaskRow key={task.$id} task={task} sprints={allSprints} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const BacklogView = ({
+  workspaceId,
+  projectId,
+  tasks,
+}: BacklogViewProps) => {
+  const { data: sprintsData, isLoading: isLoadingSprints } = useGetSprints({
+    workspaceId,
+    projectId,
+  });
+  const { open: openCreateSprint } = useCreateSprintModal();
+
+  const sprints: Sprint[] = sprintsData?.documents ?? [];
+
+  const backlogTasks = tasks.filter((task) => !task.sprintId);
+
+  const plannedSprints = sprints.filter(
+    (s) => s.status === SprintStatus.PLANNED
+  );
+  const activeSprints = sprints.filter((s) => s.status === SprintStatus.ACTIVE);
+  const completedSprints = sprints.filter(
+    (s) => s.status === SprintStatus.COMPLETED
+  );
+
+  const getSprintTasks = (sprintId: string) =>
+    tasks.filter((t) => t.sprintId === sprintId);
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <CreateSprintModal />
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Backlog</h2>
+        <Button size="sm" onClick={openCreateSprint}>
+          <PlusIcon className="size-4 mr-2" />
+          Create Sprint
+        </Button>
+      </div>
+
+      <DottedSeperator />
+
+      {/* Active sprints */}
+      {activeSprints.length > 0 && (
+        <div className="flex flex-col gap-y-4">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Active Sprint
+          </h3>
+          {activeSprints.map((sprint) => (
+            <SprintSection
+              key={sprint.$id}
+              sprint={sprint}
+              tasks={getSprintTasks(sprint.$id)}
+              allSprints={sprints}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Planned sprints */}
+      {plannedSprints.length > 0 && (
+        <div className="flex flex-col gap-y-4">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Planned Sprints
+          </h3>
+          {plannedSprints.map((sprint) => (
+            <SprintSection
+              key={sprint.$id}
+              sprint={sprint}
+              tasks={getSprintTasks(sprint.$id)}
+              allSprints={sprints}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Backlog (unassigned) */}
+      <div className="flex flex-col gap-y-1">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Backlog ({backlogTasks.length})
+          </h3>
+        </div>
+        <div className="flex flex-col border rounded-lg">
+          {backlogTasks.length === 0 ? (
+            <p className="text-sm text-muted-foreground px-4 py-4">
+              No tasks in backlog.
+            </p>
+          ) : (
+            backlogTasks.map((task) => (
+              <TaskRow key={task.$id} task={task} sprints={sprints} />
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Completed sprints */}
+      {completedSprints.length > 0 && (
+        <div className="flex flex-col gap-y-4">
+          <h3 className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+            Completed Sprints
+          </h3>
+          {completedSprints.map((sprint) => (
+            <SprintSection
+              key={sprint.$id}
+              sprint={sprint}
+              tasks={getSprintTasks(sprint.$id)}
+              allSprints={sprints}
+            />
+          ))}
+        </div>
+      )}
+
+      {isLoadingSprints && (
+        <p className="text-sm text-muted-foreground">Loading sprints...</p>
+      )}
+    </div>
+  );
+};

--- a/src/features/sprints/components/create-sprint-form.tsx
+++ b/src/features/sprints/components/create-sprint-form.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { DottedSeperator } from "@/components/dotted-seperator";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { DatePicker } from "@/components/date-picker";
+import { createSprintSchema } from "../schemas";
+import { useCreateSprint } from "../api/use-create-sprint";
+
+interface CreateSprintFormProps {
+  onCancel?: () => void;
+  workspaceId: string;
+  projectId: string;
+}
+
+export const CreateSprintForm = ({
+  onCancel,
+  workspaceId,
+  projectId,
+}: CreateSprintFormProps) => {
+  const { mutate, isPending } = useCreateSprint();
+
+  const form = useForm<z.infer<typeof createSprintSchema>>({
+    resolver: zodResolver(createSprintSchema),
+    defaultValues: {
+      workspaceId,
+      projectId,
+      name: "",
+      goal: "",
+      startDate: undefined,
+      endDate: undefined,
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof createSprintSchema>) => {
+    mutate(
+      { json: { ...values, workspaceId, projectId } },
+      {
+        onSuccess: () => {
+          form.reset();
+          onCancel?.();
+        },
+      }
+    );
+  };
+
+  return (
+    <Card className="w-full h-full border-none shadow-none">
+      <CardHeader className="flex p-7">
+        <CardTitle className="text-xl font-bold">Create a new sprint</CardTitle>
+      </CardHeader>
+      <div className="px-7">
+        <DottedSeperator />
+      </div>
+      <CardContent className="p-7">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="flex flex-col gap-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Sprint Name</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="e.g. Sprint 1" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="goal"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Sprint Goal (optional)</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder="What is the goal of this sprint?" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="startDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Start Date (optional)</FormLabel>
+                    <FormControl>
+                      <DatePicker {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="endDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>End Date (optional)</FormLabel>
+                    <FormControl>
+                      <DatePicker {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <DottedSeperator className="py-7" />
+            <div className="flex items-center justify-between">
+              <Button
+                type="button"
+                size="lg"
+                onClick={onCancel}
+                variant="secondary"
+                disabled={isPending}
+                className={cn(!onCancel && "invisible")}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" size="lg" disabled={isPending} variant="primary">
+                Create Sprint
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/features/sprints/components/create-sprint-modal.tsx
+++ b/src/features/sprints/components/create-sprint-modal.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ResponsiveModal } from "@/components/responsive-modal";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useCreateSprintModal } from "../hooks/use-create-sprint-modal";
+import { CreateSprintForm } from "./create-sprint-form";
+
+export const CreateSprintModal = () => {
+  const { isOpen, close } = useCreateSprintModal();
+  const workspaceId = useWorkspaceId();
+  const projectId = useProjectId();
+
+  return (
+    <ResponsiveModal open={!!isOpen} onOpenChange={close}>
+      <CreateSprintForm
+        onCancel={close}
+        workspaceId={workspaceId}
+        projectId={projectId}
+      />
+    </ResponsiveModal>
+  );
+};

--- a/src/features/sprints/components/sprint-header.tsx
+++ b/src/features/sprints/components/sprint-header.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Sprint, SprintStatus } from "../types";
+import { useStartSprint } from "../api/use-start-sprint";
+import { useCompleteSprint } from "../api/use-complete-sprint";
+import { format } from "date-fns";
+import { CheckIcon, PlayIcon } from "lucide-react";
+
+interface SprintHeaderProps {
+  sprint: Sprint;
+  taskCount: number;
+  completedCount: number;
+}
+
+const statusVariantMap: Record<
+  SprintStatus,
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  [SprintStatus.PLANNED]: "secondary",
+  [SprintStatus.ACTIVE]: "default",
+  [SprintStatus.COMPLETED]: "outline",
+};
+
+export const SprintHeader = ({
+  sprint,
+  taskCount,
+  completedCount,
+}: SprintHeaderProps) => {
+  const { mutate: startSprint, isPending: isStarting } = useStartSprint();
+  const { mutate: completeSprint, isPending: isCompleting } = useCompleteSprint();
+
+  const progressPercent =
+    taskCount > 0 ? Math.round((completedCount / taskCount) * 100) : 0;
+
+  const handleStart = () => {
+    startSprint({
+      param: { sprintId: sprint.$id },
+      query: { workspaceId: sprint.workspaceId, projectId: sprint.projectId },
+    });
+  };
+
+  const handleComplete = () => {
+    completeSprint({
+      param: { sprintId: sprint.$id },
+      query: { workspaceId: sprint.workspaceId, projectId: sprint.projectId },
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-y-2 p-4 border rounded-lg bg-muted/30">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-x-3">
+          <h3 className="font-semibold text-base">{sprint.name}</h3>
+          <Badge variant={statusVariantMap[sprint.status]}>{sprint.status}</Badge>
+        </div>
+        <div className="flex items-center gap-x-2">
+          {sprint.status === SprintStatus.PLANNED && (
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={handleStart}
+              disabled={isStarting}
+            >
+              <PlayIcon className="size-3.5 mr-1" />
+              Start Sprint
+            </Button>
+          )}
+          {sprint.status === SprintStatus.ACTIVE && (
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={handleComplete}
+              disabled={isCompleting}
+            >
+              <CheckIcon className="size-3.5 mr-1" />
+              Complete Sprint
+            </Button>
+          )}
+        </div>
+      </div>
+      {(sprint.startDate || sprint.endDate) && (
+        <p className="text-sm text-muted-foreground">
+          {sprint.startDate && !isNaN(new Date(sprint.startDate).getTime())
+            ? format(new Date(sprint.startDate), "MMM d, yyyy")
+            : "—"}{" "}
+          →{" "}
+          {sprint.endDate && !isNaN(new Date(sprint.endDate).getTime())
+            ? format(new Date(sprint.endDate), "MMM d, yyyy")
+            : "—"}
+        </p>
+      )}
+      {sprint.goal && (
+        <p className="text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">Goal:</span>{" "}
+          {sprint.goal}
+        </p>
+      )}
+      {taskCount > 0 && (
+        <div className="flex flex-col gap-y-1 mt-1">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {completedCount} / {taskCount} tasks completed
+            </span>
+            <span>{progressPercent}%</span>
+          </div>
+          <div className="h-2 rounded-full bg-muted overflow-hidden">
+            <div
+              className="h-full bg-primary rounded-full transition-all"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/sprints/hooks/use-create-sprint-modal.ts
+++ b/src/features/sprints/hooks/use-create-sprint-modal.ts
@@ -1,0 +1,11 @@
+import { useQueryState, parseAsBoolean } from "nuqs";
+
+export const useCreateSprintModal = () => {
+  const [isOpen, setIsOpen] = useQueryState(
+    "create-sprint",
+    parseAsBoolean.withDefault(false)
+  );
+  const open = () => setIsOpen(true);
+  const close = () => setIsOpen(false);
+  return { isOpen, open, close };
+};

--- a/src/features/sprints/schemas.ts
+++ b/src/features/sprints/schemas.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+export const createSprintSchema = z.object({
+  name: z.string().trim().min(1, "Required"),
+  goal: z.string().optional(),
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  workspaceId: z.string().trim().min(1, "Required"),
+  projectId: z.string().trim().min(1, "Required"),
+}).superRefine((data, ctx) => {
+  if (data.startDate && data.endDate && data.endDate < data.startDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "End date must be on or after start date",
+      path: ["endDate"],
+    });
+  }
+});
+
+export const updateSprintSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  goal: z.string().optional(),
+  startDate: z.coerce.date().optional(),
+  endDate: z.coerce.date().optional(),
+  workspaceId: z.string().trim().min(1, "Required"),
+  projectId: z.string().trim().min(1, "Required"),
+});

--- a/src/features/sprints/server/route.ts
+++ b/src/features/sprints/server/route.ts
@@ -1,0 +1,377 @@
+import { sessionMiddleware } from "@/lib/session-middleware";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { createSprintSchema, updateSprintSchema } from "../schemas";
+import { getMember } from "@/features/members/utils";
+import { z } from "zod";
+import { Sprint, SprintStatus } from "../types";
+import { TaskStatus } from "@/features/tasks/types";
+
+const normalizeDate = (data: Record<string, unknown> | undefined) => {
+  const candidate = (data?.$createdAt ?? data?.createdAt) as
+    | { toDate?: () => Date }
+    | string
+    | undefined;
+  if (!candidate) return undefined;
+  if (typeof candidate === "string") return candidate;
+  return candidate.toDate?.().toISOString();
+};
+
+const normalizeTimestampField = (
+  value: { toDate?: () => Date } | string | undefined | null
+): string | undefined => {
+  if (!value) return undefined;
+  if (typeof value === "string") return value;
+  return value.toDate?.().toISOString();
+};
+
+const app = new Hono()
+  .get(
+    "/",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string(),
+      })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sprintsSnapshot = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("sprints")
+        .get();
+
+      const documents: Sprint[] = sprintsSnapshot.docs.map((doc: any) => {
+        const data = doc.data();
+        return {
+          ...data,
+          $id: doc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data.startDate),
+          endDate: normalizeTimestampField(data.endDate),
+        } as Sprint;
+      });
+
+      documents.sort(
+        (a, b) =>
+          new Date(b.$createdAt).getTime() - new Date(a.$createdAt).getTime()
+      );
+
+      return c.json({ data: { documents, total: documents.length } });
+    }
+  )
+  .post(
+    "/",
+    sessionMiddleware,
+    zValidator("json", createSprintSchema),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { name, goal, startDate, endDate, workspaceId, projectId } =
+        c.req.valid("json");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sprintRef = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("sprints")
+        .add({
+          name,
+          status: SprintStatus.PLANNED,
+          workspaceId,
+          projectId,
+          $createdAt: new Date().toISOString(),
+          ...(goal !== undefined ? { goal } : {}),
+          ...(startDate !== undefined
+            ? { startDate: startDate.toISOString() }
+            : {}),
+          ...(endDate !== undefined ? { endDate: endDate.toISOString() } : {}),
+        });
+
+      const doc = await sprintRef.get();
+      const data = doc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: doc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          endDate: normalizeTimestampField(data?.endDate),
+        } as Sprint,
+      });
+    }
+  )
+  .patch(
+    "/:sprintId",
+    sessionMiddleware,
+    zValidator("json", updateSprintSchema),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { sprintId } = c.req.param();
+      const { name, goal, startDate, endDate, workspaceId, projectId } =
+        c.req.valid("json");
+
+      // We need at least workspaceId and projectId to locate the sprint
+      const resolvedWorkspaceId = workspaceId;
+      const resolvedProjectId = projectId;
+
+      if (!resolvedWorkspaceId || !resolvedProjectId) {
+        return c.json(
+          { error: "workspaceId and projectId are required" },
+          400
+        );
+      }
+
+      const member = await getMember({
+        databases,
+        workspaceId: resolvedWorkspaceId,
+        userId: user.$id,
+      });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sprintRef = databases
+        .collection("workspaces")
+        .doc(resolvedWorkspaceId)
+        .collection("projects")
+        .doc(resolvedProjectId)
+        .collection("sprints")
+        .doc(sprintId);
+
+      const sprintDoc = await sprintRef.get();
+      if (!sprintDoc.exists) {
+        return c.json({ error: "Sprint not found" }, 404);
+      }
+
+      await sprintRef.update({
+        ...(name !== undefined ? { name } : {}),
+        ...(goal !== undefined ? { goal } : {}),
+        ...(startDate !== undefined
+          ? { startDate: startDate.toISOString() }
+          : {}),
+        ...(endDate !== undefined ? { endDate: endDate.toISOString() } : {}),
+      });
+
+      const updatedDoc = await sprintRef.get();
+      const data = updatedDoc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: updatedDoc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          endDate: normalizeTimestampField(data?.endDate),
+        } as Sprint,
+      });
+    }
+  )
+  .post(
+    "/:sprintId/start",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({ workspaceId: z.string(), projectId: z.string() })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { sprintId } = c.req.param();
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sprintRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("sprints")
+        .doc(sprintId);
+
+      const sprintDoc = await sprintRef.get();
+      if (!sprintDoc.exists) {
+        return c.json({ error: "Sprint not found" }, 404);
+      }
+
+      // Check if another sprint is already active in same project
+      const sprintsSnapshot = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("sprints")
+        .get();
+
+      const activeSprint = sprintsSnapshot.docs.find(
+        (doc: any) =>
+          doc.id !== sprintId && doc.data().status === SprintStatus.ACTIVE
+      );
+
+      if (activeSprint) {
+        return c.json({ error: "Another sprint is already active" }, 400);
+      }
+
+      await databases.runTransaction(async (tx: any) => {
+        const doc = await tx.get(sprintRef);
+        if (!doc.exists) throw new Error("Sprint not found");
+        if (doc.data().status !== SprintStatus.PLANNED) throw new Error("Sprint is not in PLANNED state");
+        tx.update(sprintRef, { status: SprintStatus.ACTIVE });
+      });
+      const updatedDoc = await sprintRef.get();
+      const data = updatedDoc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: updatedDoc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          endDate: normalizeTimestampField(data?.endDate),
+        } as Sprint,
+      });
+    }
+  )
+  .post(
+    "/:sprintId/complete",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({ workspaceId: z.string(), projectId: z.string() })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { sprintId } = c.req.param();
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sprintRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("sprints")
+        .doc(sprintId);
+
+      const sprintDoc = await sprintRef.get();
+      if (!sprintDoc.exists) {
+        return c.json({ error: "Sprint not found" }, 404);
+      }
+
+      await sprintRef.update({ status: SprintStatus.COMPLETED });
+
+      // Bulk-update tasks in this sprint that are not DONE: set sprintId to null
+      const tasksSnapshot = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("tasks")
+        .get();
+
+      const tasksToMove = tasksSnapshot.docs.filter((doc: any) => {
+        const data = doc.data();
+        return data.sprintId === sprintId && data.status !== TaskStatus.DONE;
+      });
+
+      if (tasksToMove.length > 0) {
+        const batch = databases.batch();
+        tasksToMove.forEach((doc: any) => {
+          batch.update(doc.ref, { sprintId: null });
+        });
+        await batch.commit();
+      }
+
+      const updatedDoc = await sprintRef.get();
+      const data = updatedDoc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: updatedDoc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          endDate: normalizeTimestampField(data?.endDate),
+        } as Sprint,
+      });
+    }
+  )
+  .delete(
+    "/:sprintId",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({ workspaceId: z.string(), projectId: z.string() })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { sprintId } = c.req.param();
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const sprintRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("sprints")
+        .doc(sprintId);
+
+      const sprintDoc = await sprintRef.get();
+      if (!sprintDoc.exists) {
+        return c.json({ error: "Sprint not found" }, 404);
+      }
+
+      const sprintData = sprintDoc.data();
+      if (sprintData?.status !== SprintStatus.PLANNED) {
+        return c.json({ error: "Only PLANNED sprints can be deleted" }, 400);
+      }
+
+      const tasksSnap = await databases
+        .collection("workspaces").doc(workspaceId)
+        .collection("projects").doc(projectId)
+        .collection("tasks").get();
+      const assignedTasks = tasksSnap.docs.filter((d: any) => d.data().sprintId === sprintId);
+      if (assignedTasks.length > 0) {
+        const batch = databases.batch();
+        assignedTasks.forEach((d: any) => batch.update(d.ref, { sprintId: null }));
+        await batch.commit();
+      }
+
+      await sprintRef.delete();
+      return c.json({ data: { sprintId } });
+    }
+  );
+
+export default app;

--- a/src/features/sprints/types.ts
+++ b/src/features/sprints/types.ts
@@ -1,0 +1,17 @@
+export enum SprintStatus {
+  PLANNED = "PLANNED",
+  ACTIVE = "ACTIVE",
+  COMPLETED = "COMPLETED",
+}
+
+export type Sprint = {
+  $id: string;
+  $createdAt: string;
+  name: string;
+  goal?: string;
+  startDate?: string;
+  endDate?: string;
+  status: SprintStatus;
+  workspaceId: string;
+  projectId: string;
+};

--- a/src/features/tasks/api/use-get-tasks.ts
+++ b/src/features/tasks/api/use-get-tasks.ts
@@ -11,6 +11,7 @@ interface UseGetTasksProps {
 	assigneeId?: string | null;
 	dueDate?: string | null;
 	search?: string | null;
+	sprintId?: string | null;
 }
 
 export const useGetTasks = ({
@@ -22,6 +23,7 @@ export const useGetTasks = ({
 	assigneeId,
 	dueDate,
 	search,
+	sprintId,
 }: UseGetTasksProps) => {
 	const query = useQuery({
 		queryKey: [
@@ -34,6 +36,7 @@ export const useGetTasks = ({
 			assigneeId,
 			dueDate,
 			search,
+			sprintId,
 		],
 		queryFn: async () => {
 			const response = await client.api.tasks.$get({
@@ -46,6 +49,7 @@ export const useGetTasks = ({
 					assigneeId: assigneeId ?? undefined,
 					dueDate: dueDate ?? undefined,
 					search: search ?? undefined,
+					sprintId: sprintId ?? undefined,
 				},
 			});
 			if (!response.ok) {

--- a/src/features/tasks/components/create-task-form-wrapper.tsx
+++ b/src/features/tasks/components/create-task-form-wrapper.tsx
@@ -1,6 +1,9 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetProjects } from "@/features/projects/api/use-get-projects";
+import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useGetSprints } from "@/features/sprints/api/use-get-sprints";
+import { SprintStatus } from "@/features/sprints/types";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { Loader } from "lucide-react";
 import { CreateTaskForm } from "./create-task-form";
@@ -13,11 +16,17 @@ export const CreateTaskFormWrapper = ({
 	onCancel,
 }: CreateTaskFormWrapperProps) => {
 	const workspaceId = useWorkspaceId();
+	const projectId = useProjectId();
 	const { data: projects, isLoading: isLoadingProjects } = useGetProjects({
 		workspaceId,
 	});
 	const { data: members, isLoading: isLoadingMembers } = useGetMembers({
 		workspaceId,
+	});
+	const { data: sprints, isLoading: isLoadingSprints } = useGetSprints({
+		workspaceId,
+		projectId: projectId ?? "",
+		enabled: !!projectId,
 	});
 	const projectOptions = projects?.documents.map((project) => ({
 		id: project.$id,
@@ -28,7 +37,10 @@ export const CreateTaskFormWrapper = ({
 		id: member.$id,
 		name: member.name,
 	}));
-	const isLoading = isLoadingProjects || isLoadingMembers;
+	const sprintOptions = (sprints?.documents ?? [])
+		.filter((s) => s.status === SprintStatus.PLANNED || s.status === SprintStatus.ACTIVE)
+		.map((s) => ({ id: s.$id, name: s.name }));
+	const isLoading = isLoadingProjects || isLoadingMembers || (!!projectId && isLoadingSprints);
 	if (isLoading) {
 		return (
 			<Card className="w-full h-[714px] border-none shadow-none">
@@ -43,6 +55,7 @@ export const CreateTaskFormWrapper = ({
 			onCancel={onCancel}
 			projectOptions={projectOptions ?? []}
 			memberOptions={memeberOptions ?? []}
+			sprintOptions={sprintOptions}
 		/>
 	);
 };

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -35,12 +35,14 @@ interface CreateTaskFormProps {
 	onCancel?: () => void;
 	projectOptions: { id: string; name: string; imageUrl: string }[];
 	memberOptions: { id: string; name: string }[];
+	sprintOptions?: { id: string; name: string }[];
 }
 
 export const CreateTaskForm = ({
 	onCancel,
 	projectOptions,
 	memberOptions,
+	sprintOptions = [],
 }: CreateTaskFormProps) => {
 	const workspaceId = useWorkspaceId();
 	const { mutate, isPending } = useCreateTask();
@@ -272,6 +274,57 @@ export const CreateTaskForm = ({
 													)}
 												</SelectContent>
 											</Select>
+										</FormItem>
+									)}
+								/>
+								{sprintOptions.length > 0 && (
+									<FormField
+										control={form.control}
+										name="sprintId"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Sprint (optional)</FormLabel>
+												<Select
+													defaultValue={field.value ?? undefined}
+													onValueChange={field.onChange}
+												>
+													<FormControl>
+														<SelectTrigger>
+															<SelectValue placeholder="Select Sprint" />
+														</SelectTrigger>
+													</FormControl>
+													<FormMessage />
+													<SelectContent>
+														{sprintOptions.map((sprint) => (
+															<SelectItem key={sprint.id} value={sprint.id}>
+																{sprint.name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</FormItem>
+										)}
+									/>
+								)}
+								<FormField
+									control={form.control}
+									name="storyPoints"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Story Points (optional)</FormLabel>
+											<FormControl>
+												<Input
+													type="number"
+													min={0}
+													placeholder="e.g. 3"
+													value={field.value ?? ""}
+													onChange={(e) => {
+														const val = e.target.value === "" ? undefined : Number(e.target.value);
+														field.onChange(isNaN(val as number) ? field.value : val);
+													}}
+												/>
+											</FormControl>
+											<FormMessage />
 										</FormItem>
 									)}
 								/>

--- a/src/features/tasks/components/edit-task-form.tsx
+++ b/src/features/tasks/components/edit-task-form.tsx
@@ -35,6 +35,7 @@ interface EditTaskFormProps {
 	projectOptions: { id: string; name: string; imageUrl: string }[];
 	memberOptions: { id: string; name: string }[];
 	initalValues: Task;
+	sprintOptions?: { id: string; name: string }[];
 }
 
 export const EditTaskForm = ({
@@ -42,6 +43,7 @@ export const EditTaskForm = ({
 	projectOptions,
 	memberOptions,
 	initalValues: initialValues,
+	sprintOptions = [],
 }: EditTaskFormProps) => {
 	const { mutate, isPending } = useUpdateTask();
 	const form = useForm<z.infer<typeof createTaskSchema>>({
@@ -296,6 +298,57 @@ export const EditTaskForm = ({
 												)}
 											</SelectContent>
 										</Select>
+									</FormItem>
+								)}
+							/>
+							{sprintOptions.length > 0 && (
+								<FormField
+									control={form.control}
+									name="sprintId"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Sprint (optional)</FormLabel>
+											<Select
+												defaultValue={field.value ?? undefined}
+												onValueChange={field.onChange}
+											>
+												<FormControl>
+													<SelectTrigger>
+														<SelectValue placeholder="Select Sprint" />
+													</SelectTrigger>
+												</FormControl>
+												<FormMessage />
+												<SelectContent>
+													{sprintOptions.map((sprint) => (
+														<SelectItem key={sprint.id} value={sprint.id}>
+															{sprint.name}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</FormItem>
+									)}
+								/>
+							)}
+							<FormField
+								control={form.control}
+								name="storyPoints"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Story Points (optional)</FormLabel>
+										<FormControl>
+											<Input
+												type="number"
+												min={0}
+												placeholder="e.g. 3"
+												value={field.value ?? ""}
+												onChange={(e) => {
+													const val = e.target.value === "" ? undefined : Number(e.target.value);
+													field.onChange(isNaN(val as number) ? field.value : val);
+												}}
+											/>
+										</FormControl>
+										<FormMessage />
 									</FormItem>
 								)}
 							/>

--- a/src/features/tasks/hooks/use-task-filters.ts
+++ b/src/features/tasks/hooks/use-task-filters.ts
@@ -10,5 +10,6 @@ export const useTaskFilters = () => {
 		assigneeId: parseAsString,
 		dueDate: parseAsString,
 		search: parseAsString,
+		sprintId: parseAsString,
 	});
 };

--- a/src/features/tasks/schemas.ts
+++ b/src/features/tasks/schemas.ts
@@ -13,6 +13,9 @@ export const createTaskSchema = z.object({
 	priority: z.nativeEnum(TaskPriority).optional(),
 	parentId: z.string().trim().min(1).optional(),
 	labels: z.array(z.string().trim().min(1)).optional(),
+	sprintId: z.string().trim().min(1).nullable().optional(),
+	storyPoints: z.number().int().min(0).optional(),
+	epicId: z.string().trim().min(1).optional(),
 });
 
 export const createCommentSchema = z.object({

--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -8,6 +8,8 @@ import { IssueType, Task, TaskComment, TaskPriority, TaskStatus } from "../types
 import { Project } from "@/features/projects/types";
 import { adminAuth } from "@/lib/firebase-admin";
 
+const BACKLOG_SPRINT_SENTINEL = "backlog";
+
 const normalizeDate = (data: Record<string, unknown> | undefined) => {
 	const candidate = (data?.$createdAt ?? data?.createdAt) as
 		| { toDate?: () => Date }
@@ -33,6 +35,7 @@ const app = new Hono()
 				issueType: z.nativeEnum(IssueType).nullish(),
 				search: z.string().nullish(),
 				dueDate: z.string().nullish(),
+				sprintId: z.string().nullish(),
 			})
 		),
 		async (c) => {
@@ -47,6 +50,7 @@ const app = new Hono()
 				issueType,
 				search,
 				dueDate,
+				sprintId,
 			} = c.req.valid("query");
 			const member = await getMember({
 				databases,
@@ -88,6 +92,11 @@ const app = new Hono()
 			if (status) tasks = tasks.filter((t: any) => t.status === status);
 			if (priority) tasks = tasks.filter((t: any) => t.priority === priority);
 			if (issueType) tasks = tasks.filter((t: any) => t.issueType === issueType);
+			if (sprintId === BACKLOG_SPRINT_SENTINEL) {
+				tasks = tasks.filter((t: any) => !t.sprintId);
+			} else if (sprintId) {
+				tasks = tasks.filter((t: any) => t.sprintId === sprintId);
+			}
 			if (dueDate) {
 				const dDate = new Date(dueDate).toISOString();
 				tasks = tasks.filter((t: any) => t.dueDate === dDate);
@@ -248,6 +257,9 @@ const app = new Hono()
 				priority,
 				parentId,
 				labels,
+				sprintId,
+				storyPoints,
+				epicId,
 			} = c.req.valid("json");
 			const member = await getMember({
 				databases,
@@ -292,6 +304,9 @@ workspaceId,
 					...(priority !== undefined ? { priority } : {}),
 					...(parentId !== undefined ? { parentId } : {}),
 					...(labels !== undefined ? { labels } : {}),
+					...(sprintId !== undefined ? { sprintId } : {}),
+					...(storyPoints !== undefined ? { storyPoints } : {}),
+					...(epicId !== undefined ? { epicId } : {}),
 				});
 			const doc = await taskRef.get();
 			const data = doc.data();
@@ -407,6 +422,9 @@ workspaceId,
 				priority,
 				parentId,
 				labels,
+				sprintId,
+				storyPoints,
+				epicId,
 			} = c.req.valid("json");
 			const { taskId } = c.req.param();
 			
@@ -463,13 +481,16 @@ workspaceId,
 			await updateRef.update({
 				...(name !== undefined ? { name } : {}),
 				...(status !== undefined ? { status } : {}),
-				...(dueDate !== undefined ? { dueDate: new Date(dueDate).toISOString() } : {}),
+				...(dueDate !== undefined ? { dueDate: dueDate.toISOString() } : {}),
 				...(assigneeId !== undefined ? { assigneeId } : {}),
 				...(description !== undefined ? { description } : {}),
 				...(issueType !== undefined ? { issueType } : {}),
 				...(priority !== undefined ? { priority } : {}),
 				...(parentId !== undefined ? { parentId } : {}),
 				...(labels !== undefined ? { labels } : {}),
+				...(sprintId !== undefined ? { sprintId } : {}),
+				...(storyPoints !== undefined ? { storyPoints } : {}),
+				...(epicId !== undefined ? { epicId } : {}),
 			});
 			const updatedDoc = await updateRef.get();
 			const data = updatedDoc.data();

--- a/src/features/tasks/types.ts
+++ b/src/features/tasks/types.ts
@@ -40,6 +40,9 @@ export type Task = {
 	priority?: TaskPriority;
 	parentId?: string;
 	labels?: string[];
+	sprintId?: string | null;
+	storyPoints?: number;
+	epicId?: string;
 	project?: Project | null;
 	assignee?: Member | null;
 };


### PR DESCRIPTION
- Add Sprint model (SprintStatus: PLANNED/ACTIVE/COMPLETED) stored under workspaces/{wId}/projects/{pId}/sprints
- Sprint API: GET/POST/PATCH + start, complete, delete endpoints; start guards against duplicate active sprint; complete bulk-moves incomplete tasks to backlog via Firestore batch
- Add sprintId, storyPoints, epicId fields to Task type and schema
- Extend GET /tasks with sprintId filter ("backlog" sentinel = unassigned tasks)
- 6 TanStack Query hooks: use-get-sprints, use-create-sprint, use-update-sprint, use-start-sprint, use-complete-sprint, use-delete-sprint
- BacklogView component: groups tasks by active sprint → planned sprints → backlog → completed; inline "Add to Sprint" dropdown per task row
- SprintHeader component: name, status badge, date range, goal, progress bar, Start/Complete actions
- CreateSprintForm + CreateSprintModal with nuqs-based open state
- New backlog page at /workspaces/[wId]/projects/[pId]/backlog
- Add "Backlog" button to project page linking to backlog view
- Register /api/sprints route in main Hono app
- No Firestore composite indexes used anywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a backlog page to organize and view project tasks by sprint status.
  * Introduced sprint management: create, start, complete, and delete sprints within projects.
  * Added the ability to assign tasks to sprints and track story points per task.
  * Sprint progress indicator showing completed vs. total tasks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/45)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->