### PR TITLE
feat: file upload, versions/releases & time tracking (Phase 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "file-type": "^22.0.1",
         "firebase": "^12.13.0",
         "firebase-admin": "^13.9.0",
         "hono": "^4.6.4",
@@ -114,6 +115,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -3132,6 +3143,29 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
@@ -6118,6 +6152,24 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -7108,6 +7160,26 @@
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
       "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
       "license": "ISC"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -10680,6 +10752,22 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -10964,6 +11052,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -11165,6 +11271,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "file-type": "^22.0.1",
     "firebase": "^12.13.0",
     "firebase-admin": "^13.9.0",
     "hono": "^4.6.4",

--- a/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/versions/client.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/versions/client.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { VersionsList } from "@/features/versions/components/versions-list";
+
+export const VersionsPageClient = () => {
+  const workspaceId = useWorkspaceId();
+  const projectId = useProjectId();
+
+  return (
+    <div className="flex flex-col gap-y-4 max-w-2xl mx-auto py-6">
+      <VersionsList workspaceId={workspaceId} projectId={projectId} />
+    </div>
+  );
+};

--- a/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/versions/page.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/projects/[projectId]/versions/page.tsx
@@ -1,0 +1,5 @@
+import { VersionsPageClient } from "./client";
+
+export default function VersionsPage() {
+  return <VersionsPageClient />;
+}

--- a/src/app/(dashboard)/workspaces/[workspaceId]/tasks/[taskId]/client.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/tasks/[taskId]/client.tsx
@@ -11,6 +11,7 @@ import { TaskComments } from "@/features/tasks/components/task-comments";
 import { TaskLinks } from "@/features/tasks/components/task-links";
 import { TaskAttachments } from "@/features/tasks/components/task-attachments";
 import { TaskActivity } from "@/features/tasks/components/task-activity";
+import { TaskTimeTracking } from "@/features/tasks/components/task-time-tracking";
 import { useTaskId } from "@/features/tasks/hooks/use-task-id";
 
 export const TaskIdClient = () => {
@@ -33,6 +34,13 @@ export const TaskIdClient = () => {
 				<TaskLinks taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
 				<TaskAttachments taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
 			</div>
+			<DottedSeperator className="my-6" />
+			<TaskTimeTracking
+				taskId={data.$id}
+				workspaceId={data.workspaceId}
+				projectId={data.projectId}
+				task={data}
+			/>
 			<DottedSeperator className="my-6" />
 			<TaskActivity taskId={data.$id} />
 		</div>

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -7,6 +7,7 @@ import projects from "@/features/projects/server/route";
 import tasks from "@/features/tasks/server/route";
 import tokens from "@/features/tokens/server/route";
 import sprints from "@/features/sprints/server/route";
+import versions from "@/features/versions/server/route";
 
 const app = new Hono().basePath("/api");
 
@@ -18,7 +19,8 @@ const routes = app
 	.route("/projects", projects)
 	.route("/tasks", tasks)
 	.route("/tokens", tokens)
-	.route("/sprints", sprints);
+	.route("/sprints", sprints)
+	.route("/versions", versions);
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/src/features/tasks/api/use-add-attachment.ts
+++ b/src/features/tasks/api/use-add-attachment.ts
@@ -1,34 +1,59 @@
-import { client } from "@/lib/rpc";
+"use client";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { InferRequestType, InferResponseType } from "hono";
 import { toast } from "sonner";
 
-type ResponseType = InferResponseType<
-	(typeof client.api.tasks)[":taskId"]["attachments"]["$post"],
-	200
->;
-type RequestType = InferRequestType<
-	(typeof client.api.tasks)[":taskId"]["attachments"]["$post"]
->;
+interface AddAttachmentParams {
+  taskId: string;
+  workspaceId: string;
+  projectId: string;
+  file: File;
+}
+
+interface AddAttachmentResponse {
+  data: {
+    $id: string;
+    $createdAt: string;
+    taskId: string;
+    url: string;
+    name: string;
+    fileType?: string;
+    fileSize?: number;
+    storagePath?: string;
+    uploadedByMemberId: string;
+  };
+}
 
 export const useAddAttachment = () => {
-	const queryClient = useQueryClient();
-	return useMutation<ResponseType, Error, RequestType>({
-		mutationFn: async ({ param, json }) => {
-			const response = await client.api.tasks[":taskId"]["attachments"]["$post"]({
-				param,
-				json,
-			});
-			if (!response.ok) throw new Error("Failed to add attachment");
-			return response.json();
-		},
-		onSuccess: (_data, { param }) => {
-			toast.success("Attachment added");
-			queryClient.invalidateQueries({ queryKey: ["attachments", param.taskId] });
-			queryClient.invalidateQueries({ queryKey: ["activity", param.taskId] });
-		},
-		onError: () => {
-			toast.error("Failed to add attachment");
-		},
-	});
+  const queryClient = useQueryClient();
+  return useMutation<AddAttachmentResponse, Error, AddAttachmentParams>({
+    mutationFn: async ({ taskId, workspaceId, projectId, file }) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("workspaceId", workspaceId);
+      formData.append("projectId", projectId);
+
+      const response = await fetch(`/api/tasks/${taskId}/attachments`, {
+        method: "POST",
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          (errorData as { error?: string }).error || "Failed to upload attachment"
+        );
+      }
+
+      return response.json();
+    },
+    onSuccess: (_data, { taskId }) => {
+      toast.success("Attachment uploaded");
+      queryClient.invalidateQueries({ queryKey: ["attachments", taskId] });
+      queryClient.invalidateQueries({ queryKey: ["activity", taskId] });
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to upload attachment");
+    },
+  });
 };

--- a/src/features/tasks/api/use-delete-worklog.ts
+++ b/src/features/tasks/api/use-delete-worklog.ts
@@ -1,0 +1,34 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.tasks)[":taskId"]["worklogs"][":worklogId"]["$delete"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.tasks)[":taskId"]["worklogs"][":worklogId"]["$delete"]
+>;
+
+export const useDeleteWorklog = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param }) => {
+      const response = await client.api.tasks[":taskId"]["worklogs"][":worklogId"]["$delete"]({
+        param,
+      });
+      if (!response.ok) throw new Error("Failed to delete worklog");
+      return response.json();
+    },
+    onSuccess: (_data, { param }) => {
+      toast.success("Work log deleted");
+      queryClient.invalidateQueries({ queryKey: ["worklogs", param.taskId] });
+      queryClient.invalidateQueries({ queryKey: ["task", param.taskId] });
+      queryClient.invalidateQueries({ queryKey: ["activity", param.taskId] });
+    },
+    onError: () => {
+      toast.error("Failed to delete work log");
+    },
+  });
+};

--- a/src/features/tasks/api/use-get-worklogs.ts
+++ b/src/features/tasks/api/use-get-worklogs.ts
@@ -1,0 +1,22 @@
+import { client } from "@/lib/rpc";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetWorklogsProps {
+  taskId: string;
+}
+
+export const useGetWorklogs = ({ taskId }: UseGetWorklogsProps) => {
+  return useQuery({
+    queryKey: ["worklogs", taskId],
+    queryFn: async () => {
+      const response = await client.api.tasks[":taskId"]["worklogs"]["$get"]({
+        param: { taskId },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to fetch worklogs");
+      }
+      const { data } = await response.json();
+      return data;
+    },
+  });
+};

--- a/src/features/tasks/api/use-log-work.ts
+++ b/src/features/tasks/api/use-log-work.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.tasks)[":taskId"]["worklogs"]["$post"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.tasks)[":taskId"]["worklogs"]["$post"]
+>;
+
+export const useLogWork = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, json }) => {
+      const response = await client.api.tasks[":taskId"]["worklogs"]["$post"]({
+        param,
+        json,
+      });
+      if (!response.ok) throw new Error("Failed to log work");
+      return response.json();
+    },
+    onSuccess: (_data, { param }) => {
+      toast.success("Work logged");
+      queryClient.invalidateQueries({ queryKey: ["worklogs", param.taskId] });
+      queryClient.invalidateQueries({ queryKey: ["task", param.taskId] });
+      queryClient.invalidateQueries({ queryKey: ["activity", param.taskId] });
+    },
+    onError: () => {
+      toast.error("Failed to log work");
+    },
+  });
+};

--- a/src/features/tasks/components/create-task-form-wrapper.tsx
+++ b/src/features/tasks/components/create-task-form-wrapper.tsx
@@ -4,6 +4,8 @@ import { useGetProjects } from "@/features/projects/api/use-get-projects";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
 import { useGetSprints } from "@/features/sprints/api/use-get-sprints";
 import { SprintStatus } from "@/features/sprints/types";
+import { useGetVersions } from "@/features/versions/api/use-get-versions";
+import { VersionStatus } from "@/features/versions/types";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { Loader } from "lucide-react";
 import { CreateTaskForm } from "./create-task-form";
@@ -28,6 +30,11 @@ export const CreateTaskFormWrapper = ({
 		projectId: projectId ?? "",
 		enabled: !!projectId,
 	});
+	const { data: versions, isLoading: isLoadingVersions } = useGetVersions({
+		workspaceId,
+		projectId: projectId ?? "",
+		enabled: !!projectId,
+	});
 	const projectOptions = projects?.documents.map((project) => ({
 		id: project.$id,
 		name: project.name,
@@ -40,7 +47,10 @@ export const CreateTaskFormWrapper = ({
 	const sprintOptions = (sprints?.documents ?? [])
 		.filter((s) => s.status === SprintStatus.PLANNED || s.status === SprintStatus.ACTIVE)
 		.map((s) => ({ id: s.$id, name: s.name }));
-	const isLoading = isLoadingProjects || isLoadingMembers || (!!projectId && isLoadingSprints);
+	const versionOptions = (versions?.documents ?? [])
+		.filter((v) => v.status === VersionStatus.UNRELEASED)
+		.map((v) => ({ id: v.$id, name: v.name }));
+	const isLoading = isLoadingProjects || isLoadingMembers || (!!projectId && (isLoadingSprints || isLoadingVersions));
 	if (isLoading) {
 		return (
 			<Card className="w-full h-[714px] border-none shadow-none">
@@ -56,6 +66,7 @@ export const CreateTaskFormWrapper = ({
 			projectOptions={projectOptions ?? []}
 			memberOptions={memeberOptions ?? []}
 			sprintOptions={sprintOptions}
+			versionOptions={versionOptions}
 		/>
 	);
 };

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -36,6 +36,7 @@ interface CreateTaskFormProps {
 	projectOptions: { id: string; name: string; imageUrl: string }[];
 	memberOptions: { id: string; name: string }[];
 	sprintOptions?: { id: string; name: string }[];
+	versionOptions?: { id: string; name: string }[];
 }
 
 export const CreateTaskForm = ({
@@ -43,6 +44,7 @@ export const CreateTaskForm = ({
 	projectOptions,
 	memberOptions,
 	sprintOptions = [],
+	versionOptions = [],
 }: CreateTaskFormProps) => {
 	const workspaceId = useWorkspaceId();
 	const { mutate, isPending } = useCreateTask();
@@ -328,6 +330,36 @@ export const CreateTaskForm = ({
 										</FormItem>
 									)}
 								/>
+								{versionOptions.length > 0 && (
+									<FormField
+										control={form.control}
+										name="fixVersionId"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Version (optional)</FormLabel>
+												<Select
+													defaultValue={field.value ?? undefined}
+													onValueChange={(value) => field.onChange(value === "none" ? undefined : value)}
+												>
+													<FormControl>
+														<SelectTrigger>
+															<SelectValue placeholder="Select Version" />
+														</SelectTrigger>
+													</FormControl>
+													<FormMessage />
+													<SelectContent>
+														<SelectItem value="none">No version</SelectItem>
+														{versionOptions.map((v) => (
+															<SelectItem key={v.id} value={v.id}>
+																{v.name}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+											</FormItem>
+										)}
+									/>
+								)}
 						</div>
 						<DottedSeperator className="py-7" />
 						<div className="flex items-center justify-between">

--- a/src/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/src/features/tasks/components/edit-task-form-wrapper.tsx
@@ -5,6 +5,8 @@ import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { Loader } from "lucide-react";
 import { useGetTask } from "../api/use-get-task";
 import { EditTaskForm } from "./edit-task-form";
+import { useGetVersions } from "@/features/versions/api/use-get-versions";
+import { VersionStatus } from "@/features/versions/types";
 
 interface EditTaskFormWrapperProps {
 	onCancel: () => void;
@@ -25,6 +27,12 @@ export const EditTaskFormWrapper = ({
 	const { data: members, isLoading: isLoadingMembers } = useGetMembers({
 		workspaceId,
 	});
+	const projectId = initialValues?.projectId ?? "";
+	const { data: versions, isLoading: isLoadingVersions } = useGetVersions({
+		workspaceId,
+		projectId,
+		enabled: !!projectId,
+	});
 	const projectOptions = projects?.documents.map((project) => ({
 		id: project.$id,
 		name: project.name,
@@ -34,7 +42,10 @@ export const EditTaskFormWrapper = ({
 		id: member.$id,
 		name: member.name,
 	}));
-	const isLoading = isLoadingProjects || isLoadingMembers || isLoadingTask;
+	const versionOptions = (versions?.documents ?? [])
+		.filter((v) => v.status === VersionStatus.UNRELEASED || v.$id === initialValues?.fixVersionId)
+		.map((v) => ({ id: v.$id, name: v.name }));
+	const isLoading = isLoadingProjects || isLoadingMembers || isLoadingTask || (!!projectId && isLoadingVersions);
 	if (isLoading) {
 		return (
 			<Card className="w-full h-[714px] border-none shadow-none">
@@ -53,6 +64,7 @@ export const EditTaskFormWrapper = ({
 			onCancel={onCancel}
 			projectOptions={projectOptions ?? []}
 			memberOptions={memeberOptions ?? []}
+			versionOptions={versionOptions}
 		/>
 	);
 };

--- a/src/features/tasks/components/edit-task-form.tsx
+++ b/src/features/tasks/components/edit-task-form.tsx
@@ -36,6 +36,7 @@ interface EditTaskFormProps {
 	memberOptions: { id: string; name: string }[];
 	initalValues: Task;
 	sprintOptions?: { id: string; name: string }[];
+	versionOptions?: { id: string; name: string }[];
 }
 
 export const EditTaskForm = ({
@@ -44,6 +45,7 @@ export const EditTaskForm = ({
 	memberOptions,
 	initalValues: initialValues,
 	sprintOptions = [],
+	versionOptions = [],
 }: EditTaskFormProps) => {
 	const { mutate, isPending } = useUpdateTask();
 	const form = useForm<z.infer<typeof createTaskSchema>>({
@@ -352,6 +354,35 @@ export const EditTaskForm = ({
 									</FormItem>
 								)}
 							/>
+							{versionOptions.length > 0 && (
+								<FormField
+									control={form.control}
+									name="fixVersionId"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Version (optional)</FormLabel>
+											<Select
+												defaultValue={field.value ?? undefined}
+												onValueChange={field.onChange}
+											>
+												<FormControl>
+													<SelectTrigger>
+														<SelectValue placeholder="Select Version" />
+													</SelectTrigger>
+												</FormControl>
+												<FormMessage />
+												<SelectContent>
+													{versionOptions.map((v) => (
+														<SelectItem key={v.id} value={v.id}>
+															{v.name}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</FormItem>
+									)}
+								/>
+							)}
 						</div>
 						<DottedSeperator className="py-7" />
 						<div className="flex items-center justify-between">

--- a/src/features/tasks/components/log-work-modal.tsx
+++ b/src/features/tasks/components/log-work-modal.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useLogWork } from "../api/use-log-work";
+
+interface LogWorkModalProps {
+  open: boolean;
+  onClose: () => void;
+  taskId: string;
+  workspaceId: string;
+  projectId: string;
+}
+
+export const LogWorkModal = ({
+  open,
+  onClose,
+  taskId,
+  workspaceId,
+  projectId,
+}: LogWorkModalProps) => {
+  const [hours, setHours] = useState("");
+  const [date, setDate] = useState(new Date().toISOString().split("T")[0]);
+  const [description, setDescription] = useState("");
+
+  const { mutate: logWork, isPending } = useLogWork();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const hoursNum = parseFloat(hours);
+    if (isNaN(hoursNum) || hoursNum <= 0) return;
+    const timeSpentMinutes = Math.round(hoursNum * 60);
+
+    logWork(
+      {
+        param: { taskId },
+        json: {
+          timeSpent: timeSpentMinutes,
+          date: new Date(date),
+          workspaceId,
+          projectId,
+          ...(description.trim() ? { description: description.trim() } : {}),
+        },
+      },
+      {
+        onSuccess: () => {
+          setHours("");
+          setDate(new Date().toISOString().split("T")[0]);
+          setDescription("");
+          onClose();
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Log Work</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-4 mt-2">
+          <div className="flex flex-col gap-y-1">
+            <Label htmlFor="hours">Time Spent (hours)</Label>
+            <Input
+              id="hours"
+              type="number"
+              min={0.1}
+              step={0.25}
+              placeholder="e.g. 1.5"
+              value={hours}
+              onChange={(e) => setHours(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-y-1">
+            <Label htmlFor="date">Date</Label>
+            <Input
+              id="date"
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              required
+            />
+          </div>
+          <div className="flex flex-col gap-y-1">
+            <Label htmlFor="description">Description (optional)</Label>
+            <Textarea
+              id="description"
+              placeholder="What did you work on?"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+            />
+          </div>
+          <div className="flex justify-end gap-x-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="primary"
+              disabled={isPending || !hours || parseFloat(hours) <= 0}
+            >
+              {isPending ? "Logging..." : "Log Work"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/features/tasks/components/task-attachments.tsx
+++ b/src/features/tasks/components/task-attachments.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { DottedSeperator } from "@/components/dotted-seperator";
-import { TrashIcon, PlusIcon, ExternalLinkIcon, PaperclipIcon } from "lucide-react";
+import {
+	TrashIcon,
+	PlusIcon,
+	ExternalLinkIcon,
+	PaperclipIcon,
+	FileTextIcon,
+	FileIcon,
+	ImageIcon,
+	UploadIcon,
+} from "lucide-react";
 import { useGetAttachments } from "../api/use-get-attachments";
 import { useAddAttachment } from "../api/use-add-attachment";
 import { useRemoveAttachment } from "../api/use-remove-attachment";
@@ -17,61 +25,96 @@ interface TaskAttachmentsProps {
 	projectId: string;
 }
 
-const isValidUrl = (value: string) => {
-	try {
-		const url = new URL(value);
-		return url.protocol === "http:" || url.protocol === "https:";
-	} catch {
-		return false;
-	}
+const ACCEPTED_TYPES =
+	"image/*,application/pdf,text/plain,application/zip,application/x-zip-compressed,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/msword";
+
+const formatFileSize = (bytes: number): string => {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const getFileIcon = (fileType?: string) => {
+	if (!fileType) return <FileIcon className="size-4 shrink-0 text-muted-foreground" />;
+	if (fileType.startsWith("image/"))
+		return <ImageIcon className="size-4 shrink-0 text-blue-500" />;
+	if (fileType === "application/pdf")
+		return <FileTextIcon className="size-4 shrink-0 text-red-500" />;
+	return <PaperclipIcon className="size-4 shrink-0 text-muted-foreground" />;
 };
 
 export const TaskAttachments = ({ taskId, workspaceId, projectId }: TaskAttachmentsProps) => {
-	const [showForm, setShowForm] = useState(false);
-	const [url, setUrl] = useState("");
-	const [name, setName] = useState("");
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [selectedFile, setSelectedFile] = useState<File | null>(null);
 	const [removingId, setRemovingId] = useState<string | null>(null);
 
 	const { data, isLoading } = useGetAttachments({ taskId });
-	const { mutate: addAttachment, isPending: isAdding } = useAddAttachment();
+	const { mutate: addAttachment, isPending: isUploading } = useAddAttachment();
 	const { mutate: removeAttachment } = useRemoveAttachment();
 
-	const urlValid = isValidUrl(url);
+	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0] ?? null;
+		if (!file) return;
+		if (file.size > 10 * 1024 * 1024) {
+			toast.error("File exceeds the 10 MB limit");
+			return;
+		}
+		setSelectedFile(file);
+	};
 
-	const handleAdd = () => {
-		if (!urlValid || !name.trim()) return;
+	const handleUpload = () => {
+		if (!selectedFile) return;
 		addAttachment(
-			{ param: { taskId }, json: { url: url.trim(), name: name.trim(), workspaceId, projectId } },
+			{ taskId, workspaceId, projectId, file: selectedFile },
 			{
 				onSuccess: () => {
-					setUrl("");
-					setName("");
-					setShowForm(false);
+					setSelectedFile(null);
+					if (fileInputRef.current) fileInputRef.current.value = "";
 				},
 			}
 		);
+	};
+
+	const handleCancel = () => {
+		setSelectedFile(null);
+		if (fileInputRef.current) fileInputRef.current.value = "";
 	};
 
 	return (
 		<div className="p-4 border rounded-lg">
 			<div className="flex items-center justify-between">
 				<p className="text-lg font-semibold">Attachments</p>
-				<Button size="sm" variant="secondary" onClick={() => setShowForm((v) => !v)}>
+				<Button
+					size="sm"
+					variant="secondary"
+					onClick={() => fileInputRef.current?.click()}
+					disabled={isUploading}
+				>
 					<PlusIcon className="size-4 mr-1" />
 					Add Attachment
 				</Button>
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept={ACCEPTED_TYPES}
+					className="hidden"
+					onChange={handleFileChange}
+				/>
 			</div>
 			<DottedSeperator className="my-4" />
 
 			{isLoading && <p className="text-sm text-muted-foreground">Loading...</p>}
-			{!isLoading && (!data?.documents || data.documents.length === 0) && !showForm && (
+			{!isLoading && (!data?.documents || data.documents.length === 0) && !selectedFile && (
 				<p className="text-sm text-muted-foreground">No attachments yet.</p>
 			)}
 
 			<div className="flex flex-col gap-y-2">
 				{(data?.documents as TaskAttachment[] | undefined)?.map((attachment) => (
-					<div key={attachment.$id} className="flex items-center gap-x-2 p-2 rounded-md border bg-muted/30">
-						<PaperclipIcon className="size-4 shrink-0 text-muted-foreground" />
+					<div
+						key={attachment.$id}
+						className="flex items-center gap-x-2 p-2 rounded-md border bg-muted/30"
+					>
+						{getFileIcon(attachment.fileType)}
 						<div className="flex-1 min-w-0">
 							<a
 								href={attachment.url}
@@ -82,6 +125,11 @@ export const TaskAttachments = ({ taskId, workspaceId, projectId }: TaskAttachme
 								{attachment.name}
 								<ExternalLinkIcon className="size-3 shrink-0" />
 							</a>
+							{attachment.fileSize !== undefined && (
+								<p className="text-xs text-muted-foreground">
+									{formatFileSize(attachment.fileSize)}
+								</p>
+							)}
 						</div>
 						<Button
 							size="sm"
@@ -108,34 +156,30 @@ export const TaskAttachments = ({ taskId, workspaceId, projectId }: TaskAttachme
 				))}
 			</div>
 
-			{showForm && (
+			{selectedFile && (
 				<>
 					{data?.documents && data.documents.length > 0 && <DottedSeperator className="my-4" />}
-					<div className="flex flex-col gap-y-2 mt-2">
-						<Input
-							placeholder="URL (https://...)"
-							value={url}
-							onChange={(e) => setUrl(e.target.value)}
-							className="h-8 text-sm"
-						/>
-						{url && !urlValid && (
-							<p className="text-xs text-destructive">Invalid URL</p>
-						)}
-						<Input
-							placeholder="Display name"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							className="h-8 text-sm"
-						/>
+					<div className="mt-2 p-3 rounded-md border bg-muted/20 flex flex-col gap-y-2">
+						<div className="flex items-center gap-x-2">
+							{getFileIcon(selectedFile.type)}
+							<div className="flex-1 min-w-0">
+								<p className="text-sm font-medium truncate">{selectedFile.name}</p>
+								<p className="text-xs text-muted-foreground">
+									{formatFileSize(selectedFile.size)}
+								</p>
+							</div>
+						</div>
 						<div className="flex gap-x-2">
 							<Button
 								size="sm"
-								onClick={handleAdd}
-								disabled={isAdding || !urlValid || !name.trim()}
+								onClick={handleUpload}
+								disabled={isUploading}
+								variant="primary"
 							>
-								{isAdding ? "Adding..." : "Add"}
+								<UploadIcon className="size-3 mr-1" />
+								{isUploading ? "Uploading..." : "Upload"}
 							</Button>
-							<Button size="sm" variant="outline" onClick={() => setShowForm(false)}>
+							<Button size="sm" variant="outline" onClick={handleCancel} disabled={isUploading}>
 								Cancel
 							</Button>
 						</div>

--- a/src/features/tasks/components/task-overview.tsx
+++ b/src/features/tasks/components/task-overview.tsx
@@ -14,6 +14,7 @@ import { TaskPriority } from "../types";
 import { useCurrent } from "@/features/auth/api/use-current";
 import { useGetMembers } from "@/features/members/api/use-get-members";
 import { TaskWatchers } from "./task-watchers";
+import { useGetVersions } from "@/features/versions/api/use-get-versions";
 
 interface TaskOverviewProps {
 	task: Task;
@@ -23,10 +24,18 @@ export const TaskOverview = ({ task }: TaskOverviewProps) => {
 	const { open } = useEditTaskModal();
 	const { data: currentUser } = useCurrent();
 	const { data: membersData } = useGetMembers({ workspaceId: task.workspaceId });
+	const { data: versionsData } = useGetVersions({
+		workspaceId: task.workspaceId,
+		projectId: task.projectId,
+		enabled: !!task.fixVersionId,
+	});
 	const currentMember = membersData?.documents?.find(
 		(m) => m.userId === currentUser?.$id
 	);
 	const currentMemberId = currentMember?.$id ?? "";
+	const fixVersionName = task.fixVersionId
+		? versionsData?.documents?.find((v) => v.$id === task.fixVersionId)?.name
+		: undefined;
 	return (
 		<div className="flex flex-col gap-y-4 col-span-1">
 			<div className="bg-muted rounded-lg p-4">
@@ -74,6 +83,13 @@ export const TaskOverview = ({ task }: TaskOverviewProps) => {
 						<OverviewProperty label="Priority">
 							<Badge variant={task.priority as TaskPriority}>
 								{snakeCaseToTitleCase(task.priority)}
+							</Badge>
+						</OverviewProperty>
+					)}
+					{task.fixVersionId && (
+						<OverviewProperty label="Version">
+							<Badge variant="outline">
+								{fixVersionName ?? task.fixVersionId}
 							</Badge>
 						</OverviewProperty>
 					)}

--- a/src/features/tasks/components/task-time-tracking.tsx
+++ b/src/features/tasks/components/task-time-tracking.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { DottedSeperator } from "@/components/dotted-seperator";
+import { ClockIcon, PlusIcon, TrashIcon, PencilIcon, CheckIcon, XIcon } from "lucide-react";
+import { useGetWorklogs } from "../api/use-get-worklogs";
+import { useDeleteWorklog } from "../api/use-delete-worklog";
+import { useUpdateTask } from "../api/use-update-task";
+import { Task, WorkLog } from "../types";
+import { LogWorkModal } from "./log-work-modal";
+import { useCurrent } from "@/features/auth/api/use-current";
+import { useGetMembers } from "@/features/members/api/use-get-members";
+
+interface TaskTimeTrackingProps {
+  taskId: string;
+  workspaceId: string;
+  projectId: string;
+  task: Task;
+}
+
+const formatMinutes = (minutes: number): string => {
+  if (minutes < 60) return `${minutes}m`;
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+};
+
+export const TaskTimeTracking = ({
+  taskId,
+  workspaceId,
+  projectId,
+  task,
+}: TaskTimeTrackingProps) => {
+  const [logWorkOpen, setLogWorkOpen] = useState(false);
+  const [editingEstimate, setEditingEstimate] = useState<"original" | "remaining" | null>(null);
+  const [estimateInput, setEstimateInput] = useState("");
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const { data, isLoading } = useGetWorklogs({ taskId });
+  const { mutate: deleteWorklog } = useDeleteWorklog();
+  const { mutate: updateTask } = useUpdateTask();
+  const { data: currentUser } = useCurrent();
+  const { data: membersData } = useGetMembers({ workspaceId });
+
+  const currentMember = membersData?.documents?.find(
+    (m) => m.userId === currentUser?.$id
+  );
+
+  const worklogs = (data?.documents as WorkLog[] | undefined) ?? [];
+  const totalTimeSpent = worklogs.reduce((sum, wl) => sum + wl.timeSpent, 0);
+
+  const originalEstimate = task.originalEstimate ?? 0;
+  const remainingEstimate = task.remainingEstimate;
+
+  const trackingTotal =
+    originalEstimate > 0
+      ? originalEstimate
+      : remainingEstimate !== undefined
+      ? totalTimeSpent + remainingEstimate
+      : totalTimeSpent;
+
+  const progressPercent =
+    trackingTotal > 0
+      ? Math.min(100, Math.round((totalTimeSpent / trackingTotal) * 100))
+      : 0;
+
+  const startEditing = (type: "original" | "remaining") => {
+    setEditingEstimate(type);
+    const currentVal =
+      type === "original" ? task.originalEstimate : task.remainingEstimate;
+    setEstimateInput(
+      currentVal !== undefined ? String(Math.round(currentVal / 60 * 100) / 100) : ""
+    );
+  };
+
+  const saveEstimate = () => {
+    if (!editingEstimate) return;
+    const hoursNum = parseFloat(estimateInput);
+    const minutes = isNaN(hoursNum) || hoursNum < 0 ? 0 : Math.round(hoursNum * 60);
+
+    updateTask({
+      json:
+        editingEstimate === "original"
+          ? { originalEstimate: minutes }
+          : { remainingEstimate: minutes },
+      param: { taskId },
+    });
+    setEditingEstimate(null);
+    setEstimateInput("");
+  };
+
+  return (
+    <>
+      <LogWorkModal
+        open={logWorkOpen}
+        onClose={() => setLogWorkOpen(false)}
+        taskId={taskId}
+        workspaceId={workspaceId}
+        projectId={projectId}
+      />
+      <div className="p-4 border rounded-lg">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-x-2">
+            <ClockIcon className="size-5 text-muted-foreground" />
+            <p className="text-lg font-semibold">Time Tracking</p>
+          </div>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => setLogWorkOpen(true)}
+          >
+            <PlusIcon className="size-4 mr-1" />
+            Log Work
+          </Button>
+        </div>
+        <DottedSeperator className="my-4" />
+
+        {/* Progress bar */}
+        <div className="flex flex-col gap-y-2 mb-4">
+          <div className="flex justify-between text-xs text-muted-foreground">
+            <span>Logged: {formatMinutes(totalTimeSpent)}</span>
+            {trackingTotal > 0 && (
+              <span>{progressPercent}%</span>
+            )}
+          </div>
+          <div className="w-full bg-muted rounded-full h-2">
+            <div
+              className="bg-blue-500 h-2 rounded-full transition-all"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        </div>
+
+        {/* Estimates */}
+        <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm mb-4">
+          {/* Original Estimate */}
+          <div className="flex flex-col gap-y-0.5">
+            <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+              Original Estimate
+            </span>
+            {editingEstimate === "original" ? (
+              <div className="flex items-center gap-x-1">
+                <Input
+                  className="h-7 text-sm w-24"
+                  type="number"
+                  min={0}
+                  step={0.25}
+                  placeholder="hours"
+                  value={estimateInput}
+                  onChange={(e) => setEstimateInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveEstimate();
+                    if (e.key === "Escape") setEditingEstimate(null);
+                  }}
+                  autoFocus
+                />
+                <Button size="sm" variant="ghost" className="size-7 p-0" onClick={saveEstimate}>
+                  <CheckIcon className="size-3" />
+                </Button>
+                <Button size="sm" variant="ghost" className="size-7 p-0" onClick={() => setEditingEstimate(null)}>
+                  <XIcon className="size-3" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-x-1">
+                <span>{originalEstimate > 0 ? formatMinutes(originalEstimate) : "—"}</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-6 p-0 text-muted-foreground"
+                  onClick={() => startEditing("original")}
+                >
+                  <PencilIcon className="size-3" />
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* Remaining Estimate */}
+          <div className="flex flex-col gap-y-0.5">
+            <span className="text-xs text-muted-foreground font-medium uppercase tracking-wide">
+              Remaining Estimate
+            </span>
+            {editingEstimate === "remaining" ? (
+              <div className="flex items-center gap-x-1">
+                <Input
+                  className="h-7 text-sm w-24"
+                  type="number"
+                  min={0}
+                  step={0.25}
+                  placeholder="hours"
+                  value={estimateInput}
+                  onChange={(e) => setEstimateInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") saveEstimate();
+                    if (e.key === "Escape") setEditingEstimate(null);
+                  }}
+                  autoFocus
+                />
+                <Button size="sm" variant="ghost" className="size-7 p-0" onClick={saveEstimate}>
+                  <CheckIcon className="size-3" />
+                </Button>
+                <Button size="sm" variant="ghost" className="size-7 p-0" onClick={() => setEditingEstimate(null)}>
+                  <XIcon className="size-3" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex items-center gap-x-1">
+                <span>
+                  {remainingEstimate !== undefined
+                    ? formatMinutes(remainingEstimate)
+                    : "—"}
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-6 p-0 text-muted-foreground"
+                  onClick={() => startEditing("remaining")}
+                >
+                  <PencilIcon className="size-3" />
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Worklog list */}
+        {isLoading && (
+          <p className="text-sm text-muted-foreground">Loading work logs...</p>
+        )}
+        {!isLoading && worklogs.length === 0 && (
+          <p className="text-sm text-muted-foreground">No work logged yet.</p>
+        )}
+        {worklogs.length > 0 && (
+          <div className="flex flex-col gap-y-2">
+            {worklogs.map((wl) => (
+              <div
+                key={wl.$id}
+                className="flex items-start gap-x-2 p-2 rounded-md border bg-muted/20 text-sm"
+              >
+                <ClockIcon className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-x-1 flex-wrap">
+                    <span className="font-medium">{formatMinutes(wl.timeSpent)}</span>
+                    <span className="text-muted-foreground">by {wl.memberName}</span>
+                    <span className="text-muted-foreground">
+                      on {new Date(wl.date).toLocaleDateString()}
+                    </span>
+                  </div>
+                  {wl.description && (
+                    <p className="text-muted-foreground text-xs mt-0.5 truncate">
+                      {wl.description}
+                    </p>
+                  )}
+                </div>
+                {currentMember && wl.memberId === currentMember.$id && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="size-7 p-0 text-muted-foreground hover:text-destructive shrink-0"
+                    disabled={deletingId === wl.$id}
+                    onClick={() => {
+                      setDeletingId(wl.$id);
+                      deleteWorklog(
+                        { param: { taskId, worklogId: wl.$id } },
+                        {
+                          onSuccess: () => setDeletingId(null),
+                          onError: () => setDeletingId(null),
+                        }
+                      );
+                    }}
+                  >
+                    <TrashIcon className="size-3" />
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/src/features/tasks/schemas.ts
+++ b/src/features/tasks/schemas.ts
@@ -16,6 +16,9 @@ export const createTaskSchema = z.object({
 	sprintId: z.string().trim().min(1).nullable().optional(),
 	storyPoints: z.number().int().min(0).optional(),
 	epicId: z.string().trim().min(1).optional(),
+	fixVersionId: z.string().trim().min(1).optional(),
+	originalEstimate: z.number().int().min(0).optional(),
+	remainingEstimate: z.number().int().min(0).optional(),
 });
 
 export const createCommentSchema = z.object({
@@ -50,6 +53,14 @@ export const addAttachmentSchema = z.object({
 });
 
 export const watchTaskSchema = z.object({
+	workspaceId: z.string().trim().min(1, "Required"),
+	projectId: z.string().trim().min(1, "Required"),
+});
+
+export const logWorkSchema = z.object({
+	timeSpent: z.number().int().min(1, "Must be at least 1 minute"),
+	date: z.coerce.date(),
+	description: z.string().optional(),
 	workspaceId: z.string().trim().min(1, "Required"),
 	projectId: z.string().trim().min(1, "Required"),
 });

--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -1,13 +1,30 @@
 import { sessionMiddleware } from "@/lib/session-middleware";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
-import { addAttachmentSchema, addLinkSchema, createCommentSchema, createTaskSchema, watchTaskSchema } from "../schemas";
+import { addLinkSchema, createCommentSchema, createTaskSchema, logWorkSchema, watchTaskSchema } from "../schemas";
 import { getMember } from "@/features/members/utils";
 import { z } from "zod";
 import { IssueType, Task, TaskComment, TaskPriority, TaskStatus } from "../types";
 import { Project } from "@/features/projects/types";
-import { adminAuth } from "@/lib/firebase-admin";
+import { adminAuth, adminStorage } from "@/lib/firebase-admin";
 import { FieldValue } from "firebase-admin/firestore";
+import { fileTypeFromBuffer } from "file-type";
+
+const ALLOWED_MIME_TYPES = new Set([
+	"image/jpeg",
+	"image/png",
+	"image/gif",
+	"image/webp",
+	"image/svg+xml",
+	"application/pdf",
+	"text/plain",
+	"application/zip",
+	"application/x-zip-compressed",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	"application/msword",
+]);
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
 const BACKLOG_SPRINT_SENTINEL = "backlog";
 
@@ -271,6 +288,9 @@ const app = new Hono()
 				sprintId,
 				storyPoints,
 				epicId,
+				fixVersionId,
+				originalEstimate,
+				remainingEstimate,
 			} = c.req.valid("json");
 			const member = await getMember({
 				databases,
@@ -318,6 +338,9 @@ workspaceId,
 					...(sprintId !== undefined ? { sprintId } : {}),
 					...(storyPoints !== undefined ? { storyPoints } : {}),
 					...(epicId !== undefined ? { epicId } : {}),
+					...(fixVersionId !== undefined ? { fixVersionId } : {}),
+					...(originalEstimate !== undefined ? { originalEstimate } : {}),
+					...(remainingEstimate !== undefined ? { remainingEstimate } : {}),
 				});
 			const doc = await taskRef.get();
 			const data = doc.data();
@@ -436,6 +459,9 @@ workspaceId,
 				sprintId,
 				storyPoints,
 				epicId,
+				fixVersionId,
+				originalEstimate,
+				remainingEstimate,
 			} = c.req.valid("json");
 			const { taskId } = c.req.param();
 			
@@ -525,6 +551,9 @@ workspaceId,
 				...(sprintId !== undefined ? { sprintId } : {}),
 				...(storyPoints !== undefined ? { storyPoints } : {}),
 				...(epicId !== undefined ? { epicId } : {}),
+				...(fixVersionId !== undefined ? { fixVersionId } : {}),
+				...(originalEstimate !== undefined ? { originalEstimate } : {}),
+				...(remainingEstimate !== undefined ? { remainingEstimate } : {}),
 			});
 
 			// Write activity entries after main update
@@ -1002,12 +1031,43 @@ workspaceId,
 	.post(
 		"/:taskId/attachments",
 		sessionMiddleware,
-		zValidator("json", addAttachmentSchema),
 		async (c) => {
 			const { taskId } = c.req.param();
 			const currentUser = c.get("user");
 			const databases = c.get("databases");
-			const { url, name, workspaceId, projectId } = c.req.valid("json");
+
+			let formData: FormData;
+			try {
+				formData = await c.req.formData();
+			} catch {
+				return c.json({ error: "Expected multipart/form-data" }, 400);
+			}
+
+			const file = formData.get("file") as File | null;
+			const workspaceId = formData.get("workspaceId") as string | null;
+			const projectId = formData.get("projectId") as string | null;
+
+			if (!file || !(file instanceof File)) {
+				return c.json({ error: "file is required" }, 400);
+			}
+			if (!workspaceId || !projectId) {
+				return c.json({ error: "workspaceId and projectId are required" }, 400);
+			}
+			if (file.size > MAX_FILE_SIZE) {
+				return c.json({ error: "File exceeds 10 MB limit" }, 400);
+			}
+			if (file.size === 0) {
+				return c.json({ error: "File is empty" }, 400);
+			}
+
+			const arrayBuffer = await file.arrayBuffer();
+			const buffer = Buffer.from(arrayBuffer);
+
+			const fileTypeResult = await fileTypeFromBuffer(buffer);
+			const detectedMime = fileTypeResult?.mime;
+			if (!detectedMime || !ALLOWED_MIME_TYPES.has(detectedMime)) {
+				return c.json({ error: `File type ${detectedMime ?? "unknown"} is not allowed` }, 400);
+			}
 
 			const member = await getMember({ databases, workspaceId, userId: currentUser.$id });
 			if (!member) return c.json({ error: "Unauthorized" }, 401);
@@ -1016,11 +1076,32 @@ workspaceId,
 			const taskDoc = await taskRef.get();
 			if (!taskDoc.exists) return c.json({ error: "Task not found" }, 404);
 
+			const timestamp = Date.now();
+			const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+			const storagePath = `attachments/${workspaceId}/${taskId}/${timestamp}-${safeName}`;
+
+			const bucket = adminStorage.bucket();
+			const fileRef = bucket.file(storagePath);
+
+			await fileRef.save(buffer, {
+				metadata: { contentType: detectedMime },
+			});
+
+			const expiresAt = new Date();
+			expiresAt.setDate(expiresAt.getDate() + 7);
+			const [signedUrl] = await fileRef.getSignedUrl({
+				action: "read",
+				expires: expiresAt,
+			});
+
 			const memberName = await resolveMemberName(currentUser.$id);
 			const attachRef = await taskRef.collection("attachments").add({
 				taskId,
-				url,
-				name,
+				url: signedUrl,
+				name: file.name,
+				fileType: detectedMime,
+				fileSize: buffer.length,
+				storagePath,
 				uploadedByMemberId: member.$id,
 				$createdAt: new Date().toISOString(),
 			});
@@ -1030,7 +1111,7 @@ workspaceId,
 				memberId: member.$id,
 				memberName,
 				type: "ATTACHMENT_ADDED",
-				newValue: name,
+				newValue: file.name,
 				$createdAt: new Date().toISOString(),
 			});
 
@@ -1069,7 +1150,17 @@ workspaceId,
 			return c.json({ error: "Forbidden" }, 403);
 		}
 		const attachName = attachDoc.data()?.name ?? attachmentId;
+		const storagePath = attachDoc.data()?.storagePath;
 		const memberName = await resolveMemberName(currentUser.$id);
+
+		// Delete from Firebase Storage if a path is recorded
+		if (storagePath) {
+			try {
+				await adminStorage.bucket().file(storagePath).delete();
+			} catch {
+				// Non-fatal: file may have already been deleted
+			}
+		}
 
 		await taskRef.collection("attachments").doc(attachmentId).delete();
 		await taskRef.collection("activity").add({
@@ -1143,6 +1234,151 @@ workspaceId,
 
 			return c.json({ data: { memberId: member.$id } });
 		}
-	);
+	)
+	// ── Worklogs ──────────────────────────────────────────────────────────────
+	.get("/:taskId/worklogs", sessionMiddleware, async (c) => {
+		const { taskId } = c.req.param();
+		const currentUser = c.get("user");
+		const databases = c.get("databases");
+
+		const membersSnapshot = await databases.collection("members").where("userId", "==", currentUser.$id).get();
+		const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
+
+		let taskRef = null;
+		for (const wId of workspaceIds) {
+			const projectsSnapshot = await databases.collection("workspaces").doc(wId).collection("projects").get();
+			for (const pDoc of projectsSnapshot.docs) {
+				const tDoc = await databases.collection("workspaces").doc(wId).collection("projects").doc(pDoc.id).collection("tasks").doc(taskId).get();
+				if (tDoc.exists) { taskRef = tDoc.ref; break; }
+			}
+			if (taskRef) break;
+		}
+		if (!taskRef) return c.json({ error: "Not found" }, 404);
+
+		const worklogsSnapshot = await taskRef.collection("worklogs").get();
+		const documents = worklogsSnapshot.docs
+			.map((doc: any) => {
+				const data = doc.data();
+				return { ...data, $id: doc.id, $createdAt: normalizeDate(data) };
+			})
+			.sort((a: any, b: any) => {
+				const aTime = a.$createdAt ? new Date(a.$createdAt).getTime() : 0;
+				const bTime = b.$createdAt ? new Date(b.$createdAt).getTime() : 0;
+				return bTime - aTime;
+			});
+
+		return c.json({ data: { documents, total: documents.length } });
+	})
+	.post(
+		"/:taskId/worklogs",
+		sessionMiddleware,
+		zValidator("json", logWorkSchema),
+		async (c) => {
+			const { taskId } = c.req.param();
+			const currentUser = c.get("user");
+			const databases = c.get("databases");
+			const { timeSpent, date, description, workspaceId, projectId } = c.req.valid("json");
+
+			const member = await getMember({ databases, workspaceId, userId: currentUser.$id });
+			if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+			const taskRef = databases.collection("workspaces").doc(workspaceId).collection("projects").doc(projectId).collection("tasks").doc(taskId);
+			const taskDoc = await taskRef.get();
+			if (!taskDoc.exists) return c.json({ error: "Task not found" }, 404);
+
+			const taskData = taskDoc.data();
+			const currentTimeSpent = taskData?.timeSpent ?? 0;
+			const currentRemaining = taskData?.remainingEstimate ?? null;
+
+			const memberName = await resolveMemberName(currentUser.$id);
+			const worklogRef = await taskRef.collection("worklogs").add({
+				taskId,
+				memberId: member.$id,
+				memberName,
+				timeSpent,
+				date: date.toISOString(),
+				$createdAt: new Date().toISOString(),
+				...(description !== undefined ? { description } : {}),
+			});
+
+			const newTimeSpent = currentTimeSpent + timeSpent;
+			const updates: Record<string, unknown> = { timeSpent: newTimeSpent };
+			if (currentRemaining !== null) {
+				updates.remainingEstimate = Math.max(0, currentRemaining - timeSpent);
+			}
+			await taskRef.update(updates);
+
+			await taskRef.collection("activity").add({
+				taskId,
+				memberId: member.$id,
+				memberName,
+				type: "WORK_LOGGED",
+				newValue: String(timeSpent),
+				$createdAt: new Date().toISOString(),
+			});
+
+			const worklogDoc = await worklogRef.get();
+			const data = worklogDoc.data();
+			return c.json({ data: { ...data, $id: worklogDoc.id, $createdAt: normalizeDate(data) } });
+		}
+	)
+	.delete("/:taskId/worklogs/:worklogId", sessionMiddleware, async (c) => {
+		const { taskId, worklogId } = c.req.param();
+		const currentUser = c.get("user");
+		const databases = c.get("databases");
+
+		const membersSnapshot = await databases.collection("members").where("userId", "==", currentUser.$id).get();
+		const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
+
+		let taskRef = null;
+		let foundWorkspaceId: string | null = null;
+		for (const wId of workspaceIds) {
+			const projectsSnapshot = await databases.collection("workspaces").doc(wId).collection("projects").get();
+			for (const pDoc of projectsSnapshot.docs) {
+				const tDoc = await databases.collection("workspaces").doc(wId).collection("projects").doc(pDoc.id).collection("tasks").doc(taskId).get();
+				if (tDoc.exists) { taskRef = tDoc.ref; foundWorkspaceId = wId; break; }
+			}
+			if (taskRef) break;
+		}
+		if (!taskRef || !foundWorkspaceId) return c.json({ error: "Not found" }, 404);
+
+		const member = await getMember({ databases, workspaceId: foundWorkspaceId, userId: currentUser.$id });
+		if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+		const worklogDoc = await taskRef.collection("worklogs").doc(worklogId).get();
+		if (!worklogDoc.exists) return c.json({ error: "Not found" }, 404);
+
+		const worklogData = worklogDoc.data();
+		const worklogMemberId = worklogData?.memberId;
+		const deletedTimeSpent = worklogData?.timeSpent ?? 0;
+		if (worklogMemberId && worklogMemberId !== member.$id && member.role !== "ADMIN") {
+			return c.json({ error: "Forbidden" }, 403);
+		}
+
+		const memberName = await resolveMemberName(currentUser.$id);
+		await taskRef.collection("worklogs").doc(worklogId).delete();
+
+		const taskDoc = await taskRef.get();
+		const taskData = taskDoc.data();
+		const currentTimeSpent = taskData?.timeSpent ?? 0;
+		const currentRemaining = taskData?.remainingEstimate ?? null;
+		const newTimeSpent = Math.max(0, currentTimeSpent - deletedTimeSpent);
+		const updates: Record<string, unknown> = { timeSpent: newTimeSpent };
+		if (currentRemaining !== null) {
+			updates.remainingEstimate = currentRemaining + deletedTimeSpent;
+		}
+		await taskRef.update(updates);
+
+		await taskRef.collection("activity").add({
+			taskId,
+			memberId: member.$id,
+			memberName,
+			type: "WORKLOG_DELETED",
+			oldValue: worklogId,
+			$createdAt: new Date().toISOString(),
+		});
+
+		return c.json({ data: { worklogId } });
+	});
 
 export default app;

--- a/src/features/tasks/types.ts
+++ b/src/features/tasks/types.ts
@@ -43,6 +43,10 @@ export type Task = {
 	sprintId?: string | null;
 	storyPoints?: number;
 	epicId?: string;
+	fixVersionId?: string;
+	originalEstimate?: number;  // minutes
+	remainingEstimate?: number; // minutes
+	timeSpent?: number;         // computed from worklogs (for display)
 	project?: Project | null;
 	assignee?: Member | null;
 	watcherIds?: string[];
@@ -83,7 +87,21 @@ export type TaskAttachment = {
 	taskId: string;
 	url: string;
 	name: string;
+	fileType?: string;
+	fileSize?: number;
+	storagePath?: string;
 	uploadedByMemberId: string;
+};
+
+export type WorkLog = {
+	$id: string;
+	$createdAt: string;
+	taskId: string;
+	memberId: string;
+	memberName: string;
+	timeSpent: number;  // minutes
+	date: string;       // ISO date
+	description?: string;
 };
 
 export type TaskActivity = {
@@ -100,7 +118,9 @@ export type TaskActivity = {
 		| "WATCHER_ADDED"
 		| "WATCHER_REMOVED"
 		| "LINK_ADDED"
-		| "LINK_REMOVED";
+		| "LINK_REMOVED"
+		| "WORK_LOGGED"
+		| "WORKLOG_DELETED";
 	field?: string;
 	oldValue?: string;
 	newValue?: string;

--- a/src/features/versions/api/use-archive-version.ts
+++ b/src/features/versions/api/use-archive-version.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.versions)[":versionId"]["archive"]["$post"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.versions)[":versionId"]["archive"]["$post"]
+>;
+
+export const useArchiveVersion = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, query }) => {
+      const response = await client.api.versions[":versionId"]["archive"]["$post"]({
+        param,
+        query,
+      });
+      if (!response.ok) throw new Error("Failed to archive version");
+      return response.json();
+    },
+    onSuccess: (_data, request) => {
+      toast.success("Version archived");
+      queryClient.invalidateQueries({
+        queryKey: ["versions", request.query.workspaceId, request.query.projectId],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to archive version");
+    },
+  });
+};

--- a/src/features/versions/api/use-create-version.ts
+++ b/src/features/versions/api/use-create-version.ts
@@ -1,0 +1,27 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<typeof client.api.versions.$post, 200>;
+type RequestType = InferRequestType<typeof client.api.versions.$post>;
+
+export const useCreateVersion = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ json }) => {
+      const response = await client.api.versions.$post({ json });
+      if (!response.ok) throw new Error("Failed to create version");
+      return response.json();
+    },
+    onSuccess: (_data, { json }) => {
+      toast.success("Version created");
+      queryClient.invalidateQueries({
+        queryKey: ["versions", json.workspaceId, json.projectId],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to create version");
+    },
+  });
+};

--- a/src/features/versions/api/use-delete-version.ts
+++ b/src/features/versions/api/use-delete-version.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.versions)[":versionId"]["$delete"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.versions)[":versionId"]["$delete"]
+>;
+
+export const useDeleteVersion = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, query }) => {
+      const response = await client.api.versions[":versionId"]["$delete"]({
+        param,
+        query,
+      });
+      if (!response.ok) throw new Error("Failed to delete version");
+      return response.json();
+    },
+    onSuccess: (_data, request) => {
+      toast.success("Version deleted");
+      queryClient.invalidateQueries({
+        queryKey: ["versions", request.query.workspaceId, request.query.projectId],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to delete version");
+    },
+  });
+};

--- a/src/features/versions/api/use-get-versions.ts
+++ b/src/features/versions/api/use-get-versions.ts
@@ -1,0 +1,25 @@
+import { client } from "@/lib/rpc";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetVersionsProps {
+  workspaceId: string;
+  projectId: string;
+  enabled?: boolean;
+}
+
+export const useGetVersions = ({ workspaceId, projectId, enabled = true }: UseGetVersionsProps) => {
+  return useQuery({
+    queryKey: ["versions", workspaceId, projectId],
+    enabled: enabled && !!workspaceId && !!projectId,
+    queryFn: async () => {
+      const response = await client.api.versions.$get({
+        query: { workspaceId, projectId },
+      });
+      if (!response.ok) {
+        throw new Error("Failed to fetch versions");
+      }
+      const { data } = await response.json();
+      return data;
+    },
+  });
+};

--- a/src/features/versions/api/use-release-version.ts
+++ b/src/features/versions/api/use-release-version.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.versions)[":versionId"]["release"]["$post"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.versions)[":versionId"]["release"]["$post"]
+>;
+
+export const useReleaseVersion = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, query }) => {
+      const response = await client.api.versions[":versionId"]["release"]["$post"]({
+        param,
+        query,
+      });
+      if (!response.ok) throw new Error("Failed to release version");
+      return response.json();
+    },
+    onSuccess: (_data, request) => {
+      toast.success("Version released");
+      queryClient.invalidateQueries({
+        queryKey: ["versions", request.query.workspaceId, request.query.projectId],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to release version");
+    },
+  });
+};

--- a/src/features/versions/api/use-update-version.ts
+++ b/src/features/versions/api/use-update-version.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+import { toast } from "sonner";
+
+type ResponseType = InferResponseType<
+  (typeof client.api.versions)[":versionId"]["$patch"],
+  200
+>;
+type RequestType = InferRequestType<
+  (typeof client.api.versions)[":versionId"]["$patch"]
+>;
+
+export const useUpdateVersion = () => {
+  const queryClient = useQueryClient();
+  return useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async ({ param, json }) => {
+      const response = await client.api.versions[":versionId"]["$patch"]({
+        param,
+        json,
+      });
+      if (!response.ok) throw new Error("Failed to update version");
+      return response.json();
+    },
+    onSuccess: (_data, { json }) => {
+      toast.success("Version updated");
+      queryClient.invalidateQueries({
+        queryKey: ["versions", json.workspaceId, json.projectId],
+      });
+    },
+    onError: () => {
+      toast.error("Failed to update version");
+    },
+  });
+};

--- a/src/features/versions/components/create-version-form.tsx
+++ b/src/features/versions/components/create-version-form.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateVersion } from "../api/use-create-version";
+
+interface CreateVersionFormProps {
+  workspaceId: string;
+  projectId: string;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+}
+
+export const CreateVersionForm = ({
+  workspaceId,
+  projectId,
+  onCancel,
+  onSuccess,
+}: CreateVersionFormProps) => {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [releaseDate, setReleaseDate] = useState("");
+  const [error, setError] = useState("");
+
+  const { mutate: createVersion, isPending } = useCreateVersion();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    if (releaseDate && startDate && new Date(releaseDate) < new Date(startDate)) {
+      setError("Release date must be on or after start date");
+      return;
+    }
+
+    setError("");
+    createVersion(
+      {
+        json: {
+          name: name.trim(),
+          workspaceId,
+          projectId,
+          ...(description.trim() ? { description: description.trim() } : {}),
+          ...(startDate ? { startDate: new Date(startDate + "T00:00:00Z") } : {}),
+          ...(releaseDate ? { releaseDate: new Date(releaseDate + "T00:00:00Z") } : {}),
+        },
+      },
+      {
+        onSuccess: () => {
+          setName("");
+          setDescription("");
+          setStartDate("");
+          setReleaseDate("");
+          setError("");
+          onSuccess?.();
+        },
+      }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-1">
+        <Label htmlFor="version-name">Name *</Label>
+        <Input
+          id="version-name"
+          placeholder="e.g. v1.0.0"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-y-1">
+        <Label htmlFor="version-description">Description (optional)</Label>
+        <Textarea
+          id="version-description"
+          placeholder="Version description..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={2}
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-x-4">
+        <div className="flex flex-col gap-y-1">
+          <Label htmlFor="version-start">Start Date (optional)</Label>
+          <Input
+            id="version-start"
+            type="date"
+            value={startDate}
+            onChange={(e) => {
+              setStartDate(e.target.value);
+              setError("");
+            }}
+          />
+        </div>
+        <div className="flex flex-col gap-y-1">
+          <Label htmlFor="version-release">Release Date (optional)</Label>
+          <Input
+            id="version-release"
+            type="date"
+            value={releaseDate}
+            onChange={(e) => {
+              setReleaseDate(e.target.value);
+              setError("");
+            }}
+          />
+        </div>
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <div className="flex justify-end gap-x-2">
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" variant="primary" disabled={isPending || !name.trim()}>
+          {isPending ? "Creating..." : "Create Version"}
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/src/features/versions/components/versions-list.tsx
+++ b/src/features/versions/components/versions-list.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { DottedSeperator } from "@/components/dotted-seperator";
+import {
+  PlusIcon,
+  TrashIcon,
+  RocketIcon,
+  ArchiveIcon,
+  PencilIcon,
+  CheckIcon,
+  XIcon,
+} from "lucide-react";
+import { useGetVersions } from "../api/use-get-versions";
+import { useCreateVersion } from "../api/use-create-version";
+import { useUpdateVersion } from "../api/use-update-version";
+import { useDeleteVersion } from "../api/use-delete-version";
+import { useReleaseVersion } from "../api/use-release-version";
+import { useArchiveVersion } from "../api/use-archive-version";
+import { Version, VersionStatus } from "../types";
+import { CreateVersionForm } from "./create-version-form";
+
+interface VersionsListProps {
+  workspaceId: string;
+  projectId: string;
+}
+
+const statusVariant: Record<
+  VersionStatus,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  [VersionStatus.UNRELEASED]: "default",
+  [VersionStatus.RELEASED]: "secondary",
+  [VersionStatus.ARCHIVED]: "outline",
+};
+
+const statusLabel: Record<VersionStatus, string> = {
+  [VersionStatus.UNRELEASED]: "Unreleased",
+  [VersionStatus.RELEASED]: "Released",
+  [VersionStatus.ARCHIVED]: "Archived",
+};
+
+export const VersionsList = ({ workspaceId, projectId }: VersionsListProps) => {
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const { data, isLoading } = useGetVersions({ workspaceId, projectId });
+  const { mutate: updateVersion } = useUpdateVersion();
+  const { mutate: deleteVersion } = useDeleteVersion();
+  const { mutate: releaseVersion } = useReleaseVersion();
+  const { mutate: archiveVersion } = useArchiveVersion();
+
+  const startEdit = (version: Version) => {
+    setEditingId(version.$id);
+    setEditName(version.name);
+  };
+
+  const saveEdit = (version: Version) => {
+    if (!editName.trim()) return;
+    updateVersion(
+      {
+        param: { versionId: version.$id },
+        json: { name: editName.trim(), workspaceId, projectId },
+      },
+      {
+        onSuccess: () => {
+          setEditingId(null);
+          setEditName("");
+        },
+      }
+    );
+  };
+
+  return (
+    <div className="p-4 border rounded-lg">
+      <div className="flex items-center justify-between">
+        <p className="text-lg font-semibold">Versions / Releases</p>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => setShowCreateForm((v) => !v)}
+        >
+          <PlusIcon className="size-4 mr-1" />
+          Create Version
+        </Button>
+      </div>
+      <DottedSeperator className="my-4" />
+
+      {showCreateForm && (
+        <>
+          <CreateVersionForm
+            workspaceId={workspaceId}
+            projectId={projectId}
+            onCancel={() => setShowCreateForm(false)}
+            onSuccess={() => setShowCreateForm(false)}
+          />
+          <DottedSeperator className="my-4" />
+        </>
+      )}
+
+      {isLoading && (
+        <p className="text-sm text-muted-foreground">Loading versions...</p>
+      )}
+      {!isLoading && (!data?.documents || data.documents.length === 0) && (
+        <p className="text-sm text-muted-foreground">No versions yet.</p>
+      )}
+
+      <div className="flex flex-col gap-y-2">
+        {(data?.documents as Version[] | undefined)?.map((version) => (
+          <div
+            key={version.$id}
+            className="flex items-start gap-x-2 p-3 rounded-md border bg-muted/20"
+          >
+            <div className="flex-1 min-w-0">
+              {editingId === version.$id ? (
+                <div className="flex items-center gap-x-1">
+                  <Input
+                    className="h-7 text-sm"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") saveEdit(version);
+                      if (e.key === "Escape") setEditingId(null);
+                    }}
+                    autoFocus
+                  />
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="size-7 p-0"
+                    onClick={() => saveEdit(version)}
+                  >
+                    <CheckIcon className="size-3" />
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="size-7 p-0"
+                    onClick={() => setEditingId(null)}
+                  >
+                    <XIcon className="size-3" />
+                  </Button>
+                </div>
+              ) : (
+                <div className="flex items-center gap-x-2 flex-wrap">
+                  <span className="text-sm font-medium">{version.name}</span>
+                  <Badge variant={statusVariant[version.status]}>
+                    {statusLabel[version.status]}
+                  </Badge>
+                </div>
+              )}
+              {version.description && editingId !== version.$id && (
+                <p className="text-xs text-muted-foreground mt-0.5 truncate">
+                  {version.description}
+                </p>
+              )}
+              {version.releaseDate && editingId !== version.$id && (
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Release: {new Date(version.releaseDate).toLocaleDateString()}
+                </p>
+              )}
+            </div>
+
+            <div className="flex items-center gap-x-1 shrink-0">
+              {version.status === VersionStatus.UNRELEASED && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-7 p-0 text-muted-foreground hover:text-green-600"
+                  title="Release"
+                  onClick={() =>
+                    releaseVersion({
+                      param: { versionId: version.$id },
+                      query: { workspaceId, projectId },
+                    })
+                  }
+                >
+                  <RocketIcon className="size-3" />
+                </Button>
+              )}
+              {version.status === VersionStatus.RELEASED && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-7 p-0 text-muted-foreground hover:text-yellow-600"
+                  title="Archive"
+                  onClick={() =>
+                    archiveVersion({
+                      param: { versionId: version.$id },
+                      query: { workspaceId, projectId },
+                    })
+                  }
+                >
+                  <ArchiveIcon className="size-3" />
+                </Button>
+              )}
+              {editingId !== version.$id && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="size-7 p-0 text-muted-foreground"
+                  title="Edit"
+                  onClick={() => startEdit(version)}
+                >
+                  <PencilIcon className="size-3" />
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                className="size-7 p-0 text-muted-foreground hover:text-destructive"
+                title="Delete"
+                disabled={deletingId === version.$id}
+                onClick={() => {
+                  setDeletingId(version.$id);
+                  deleteVersion(
+                    {
+                      param: { versionId: version.$id },
+                      query: { workspaceId, projectId },
+                    },
+                    {
+                      onSuccess: () => setDeletingId(null),
+                      onError: () => setDeletingId(null),
+                    }
+                  );
+                }}
+              >
+                <TrashIcon className="size-3" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/features/versions/schemas.ts
+++ b/src/features/versions/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { VersionStatus } from "./types";
+
+export const createVersionSchema = z.object({
+  name: z.string().trim().min(1, "Required"),
+  workspaceId: z.string().trim().min(1, "Required"),
+  projectId: z.string().trim().min(1, "Required"),
+  description: z.string().optional(),
+  startDate: z.coerce.date().optional(),
+  releaseDate: z.coerce.date().optional(),
+});
+
+export const updateVersionSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  description: z.string().optional(),
+  startDate: z.coerce.date().optional(),
+  releaseDate: z.coerce.date().optional(),
+  status: z.nativeEnum(VersionStatus).optional(),
+});

--- a/src/features/versions/server/route.ts
+++ b/src/features/versions/server/route.ts
@@ -1,0 +1,334 @@
+import { sessionMiddleware } from "@/lib/session-middleware";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { createVersionSchema, updateVersionSchema } from "../schemas";
+import { getMember } from "@/features/members/utils";
+import { z } from "zod";
+import { Version, VersionStatus } from "../types";
+
+const normalizeDate = (data: Record<string, unknown> | undefined) => {
+  const candidate = (data?.$createdAt ?? data?.createdAt) as
+    | { toDate?: () => Date }
+    | string
+    | undefined;
+  if (!candidate) return undefined;
+  if (typeof candidate === "string") return candidate;
+  return candidate.toDate?.().toISOString();
+};
+
+const normalizeTimestampField = (
+  value: { toDate?: () => Date } | string | undefined | null
+): string | undefined => {
+  if (!value) return undefined;
+  if (typeof value === "string") return value;
+  return value.toDate?.().toISOString();
+};
+
+const app = new Hono()
+  .get(
+    "/",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({
+        workspaceId: z.string(),
+        projectId: z.string(),
+      })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const versionsSnapshot = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("versions")
+        .get();
+
+      const documents: Version[] = versionsSnapshot.docs.map((doc: any) => {
+        const data = doc.data();
+        return {
+          ...data,
+          $id: doc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data.startDate),
+          releaseDate: normalizeTimestampField(data.releaseDate),
+        } as Version;
+      });
+
+      // Sort newest-first in memory — no composite index needed
+      documents.sort(
+        (a, b) =>
+          new Date(b.$createdAt).getTime() - new Date(a.$createdAt).getTime()
+      );
+
+      return c.json({ data: { documents, total: documents.length } });
+    }
+  )
+  .post(
+    "/",
+    sessionMiddleware,
+    zValidator("json", createVersionSchema),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { name, workspaceId, projectId, description, startDate, releaseDate } =
+        c.req.valid("json");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const versionRef = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("versions")
+        .add({
+          name,
+          workspaceId,
+          projectId,
+          status: VersionStatus.UNRELEASED,
+          $createdAt: new Date().toISOString(),
+          ...(description !== undefined ? { description } : {}),
+          ...(startDate !== undefined ? { startDate: startDate.toISOString() } : {}),
+          ...(releaseDate !== undefined ? { releaseDate: releaseDate.toISOString() } : {}),
+        });
+
+      const doc = await versionRef.get();
+      const data = doc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: doc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          releaseDate: normalizeTimestampField(data?.releaseDate),
+        } as Version,
+      });
+    }
+  )
+  .patch(
+    "/:versionId",
+    sessionMiddleware,
+    zValidator("json", updateVersionSchema.extend({
+      workspaceId: z.string().trim().min(1, "Required"),
+      projectId: z.string().trim().min(1, "Required"),
+    })),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { versionId } = c.req.param();
+      const { workspaceId, projectId, name, description, startDate, releaseDate, status } =
+        c.req.valid("json");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const versionRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("versions")
+        .doc(versionId);
+
+      const versionDoc = await versionRef.get();
+      if (!versionDoc.exists) {
+        return c.json({ error: "Version not found" }, 404);
+      }
+
+      await versionRef.update({
+        ...(name !== undefined ? { name } : {}),
+        ...(description !== undefined ? { description } : {}),
+        ...(startDate !== undefined ? { startDate: startDate.toISOString() } : {}),
+        ...(releaseDate !== undefined ? { releaseDate: releaseDate.toISOString() } : {}),
+        ...(status !== undefined ? { status } : {}),
+      });
+
+      const updatedDoc = await versionRef.get();
+      const data = updatedDoc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: updatedDoc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          releaseDate: normalizeTimestampField(data?.releaseDate),
+        } as Version,
+      });
+    }
+  )
+  .delete(
+    "/:versionId",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({ workspaceId: z.string(), projectId: z.string() })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { versionId } = c.req.param();
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const versionRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("versions")
+        .doc(versionId);
+
+      const versionDoc = await versionRef.get();
+      if (!versionDoc.exists) {
+        return c.json({ error: "Version not found" }, 404);
+      }
+
+      // Clear fixVersionId on all tasks referencing this version
+      // NOTE: This loads ALL project tasks into memory and filters in JS, which can be
+      // very slow or timeout for projects with thousands of tasks. Consider:
+      // - Paged reads with cursor-based pagination
+      // - A background job triggered by a lightweight status update
+      // - A Firestore composite index on (projectId, fixVersionId) for server-side queries
+      const tasksSnapshot = await databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("tasks")
+        .get();
+
+      const tasksWithVersion = tasksSnapshot.docs.filter(
+        (doc: any) => doc.data().fixVersionId === versionId
+      );
+
+      if (tasksWithVersion.length > 0) {
+        const batch = databases.batch();
+        tasksWithVersion.forEach((doc: any) => {
+          batch.update(doc.ref, { fixVersionId: null });
+        });
+        await batch.commit();
+      }
+
+      await versionRef.delete();
+      return c.json({ data: { versionId } });
+    }
+  )
+  .post(
+    "/:versionId/release",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({ workspaceId: z.string(), projectId: z.string() })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { versionId } = c.req.param();
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const versionRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("versions")
+        .doc(versionId);
+
+      const versionDoc = await versionRef.get();
+      if (!versionDoc.exists) {
+        return c.json({ error: "Version not found" }, 404);
+      }
+
+      const existingData = versionDoc.data();
+      const releaseDate = existingData?.releaseDate ?? new Date().toISOString();
+
+      await versionRef.update({
+        status: VersionStatus.RELEASED,
+        releaseDate,
+      });
+
+      const updatedDoc = await versionRef.get();
+      const data = updatedDoc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: updatedDoc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          releaseDate: normalizeTimestampField(data?.releaseDate),
+        } as Version,
+      });
+    }
+  )
+  .post(
+    "/:versionId/archive",
+    sessionMiddleware,
+    zValidator(
+      "query",
+      z.object({ workspaceId: z.string(), projectId: z.string() })
+    ),
+    async (c) => {
+      const user = c.get("user");
+      const databases = c.get("databases");
+      const { versionId } = c.req.param();
+      const { workspaceId, projectId } = c.req.valid("query");
+
+      const member = await getMember({ databases, workspaceId, userId: user.$id });
+      if (!member) {
+        return c.json({ error: "Unauthorized" }, 401);
+      }
+
+      const versionRef = databases
+        .collection("workspaces")
+        .doc(workspaceId)
+        .collection("projects")
+        .doc(projectId)
+        .collection("versions")
+        .doc(versionId);
+
+      const versionDoc = await versionRef.get();
+      if (!versionDoc.exists) {
+        return c.json({ error: "Version not found" }, 404);
+      }
+
+      await versionRef.update({ status: VersionStatus.ARCHIVED });
+
+      const updatedDoc = await versionRef.get();
+      const data = updatedDoc.data();
+      return c.json({
+        data: {
+          ...data,
+          $id: updatedDoc.id,
+          $createdAt: normalizeDate(data) ?? new Date().toISOString(),
+          startDate: normalizeTimestampField(data?.startDate),
+          releaseDate: normalizeTimestampField(data?.releaseDate),
+        } as Version,
+      });
+    }
+  );
+
+export default app;

--- a/src/features/versions/types.ts
+++ b/src/features/versions/types.ts
@@ -1,0 +1,17 @@
+export enum VersionStatus {
+  UNRELEASED = "UNRELEASED",
+  RELEASED = "RELEASED",
+  ARCHIVED = "ARCHIVED",
+}
+
+export type Version = {
+  $id: string;
+  $createdAt: string;
+  workspaceId: string;
+  projectId: string;
+  name: string;
+  description?: string;
+  startDate?: string;
+  releaseDate?: string;
+  status: VersionStatus;
+};


### PR DESCRIPTION
## Summary
- **Real file upload** — Firebase Storage replaces URL-only attachments; file type icons, size display, 10 MB limit enforced client + server
- **Versions / Releases** — project-level version lifecycle (Unreleased → Released → Archived); tasks assignable to a version; versions page per project
- **Time tracking** — work logs per task, original/remaining estimates, progress bar, log-work modal

## Changes

### Real File Upload
- `POST /:taskId/attachments` now accepts `multipart/form-data` (file + workspaceId + projectId)
- Upload to Firebase Storage at `attachments/{workspaceId}/{taskId}/{timestamp}-{filename}`; signed URL stored in Firestore
- `DELETE /:taskId/attachments/:attachmentId` also removes file from Storage via stored `storagePath`
- `TaskAttachment` type gains `fileType`, `fileSize`, `storagePath`
- Frontend: hidden file input triggered by button, type/size preview before upload, file-type icons (image/pdf/generic)

### Versions / Releases
- Firestore: `workspaces/{wId}/projects/{pId}/versions/{vId}` — no composite indexes
- Endpoints: `GET / POST / PATCH /:id / DELETE /:id / POST /:id/release / POST /:id/archive`
- DELETE cascades: clears `fixVersionId` on all tasks in the project via batch update
- Tasks gain `fixVersionId?` field; create/edit forms include optional version selector
- Versions page at `/workspaces/[workspaceId]/projects/[projectId]/versions`
- Task overview shows assigned version as a badge

### Time Tracking
- Firestore subcollection: `tasks/{tId}/worklogs/{wlId}`
- `Task` gains `originalEstimate?`, `remainingEstimate?` (minutes), `timeSpent?` (display)
- New `WorkLog` type and `logWorkSchema`
- Endpoints: `GET / POST / DELETE /:worklogId` on `/:taskId/worklogs`
- Activity entries: `WORK_LOGGED` / `WORKLOG_DELETED`
- `TaskTimeTracking` component: progress bar, inline estimate edit (hours → minutes), worklog list with per-creator delete, Log Work modal
- Added to task detail page

## Reviewer notes
- No Firestore composite indexes used anywhere — all sorting/filtering in-memory
- `FIREBASE_STORAGE_BUCKET` env var must be set for file upload to work
- File upload uses raw `fetch(FormData)` — Hono RPC client doesn't support multipart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project versioning system to organize and track version releases
  * Introduced time tracking for tasks with work logging and history
  * Tasks can now be assigned to specific project versions
  * Upgraded task attachments to support direct file uploads
  * Added task estimation fields for tracking time estimates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->