### PR TITLE
feat: project-level membership

### DIFF
--- a/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/client.tsx
+++ b/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/client.tsx
@@ -34,32 +34,30 @@ export const ProjectIdSettingsClient = () => {
 	const isAdmin = wsRole === MemberRole.ADMIN || pmRole === "ADMIN";
 
 	return (
-		<div className="w-full lg:max-w-2xl">
-			<Tabs defaultValue="general">
-				<TabsList className="mb-4">
-					<TabsTrigger value="general">General</TabsTrigger>
-					<TabsTrigger value="members">Members</TabsTrigger>
-				</TabsList>
+		<Tabs defaultValue="general">
+			<TabsList className="mb-4">
+				<TabsTrigger value="general">General</TabsTrigger>
+				<TabsTrigger value="members">Members</TabsTrigger>
+			</TabsList>
 
-				<TabsContent value="general">
-					<EditProjectForm initialValues={initialValues} />
-				</TabsContent>
+			<TabsContent value="general">
+				<EditProjectForm initialValues={initialValues} />
+			</TabsContent>
 
-				<TabsContent value="members">
-					<div className="border rounded-lg p-6 bg-card">
-						<h2 className="text-lg font-semibold mb-1">Project Members</h2>
-						<p className="text-sm text-muted-foreground mb-4">
-							Manage who has access to this project.
-						</p>
-						<DottedSeperator className="mb-4" />
-						<ProjectMembersList
-							workspaceId={workspaceId}
-							projectId={projectId}
-							isAdmin={isAdmin}
-						/>
-					</div>
-				</TabsContent>
-			</Tabs>
-		</div>
+			<TabsContent value="members">
+				<div className="border rounded-lg p-6 bg-card">
+					<h2 className="text-lg font-semibold mb-1">Project Members</h2>
+					<p className="text-sm text-muted-foreground mb-4">
+						Manage who has access to this project.
+					</p>
+					<DottedSeperator className="mb-4" />
+					<ProjectMembersList
+						workspaceId={workspaceId}
+						projectId={projectId}
+						isAdmin={isAdmin}
+					/>
+				</div>
+			</TabsContent>
+		</Tabs>
 	);
 };

--- a/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/client.tsx
+++ b/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/client.tsx
@@ -11,6 +11,7 @@ import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetProjectMembers } from "@/features/projects/api/use-get-project-members";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { MemberRole } from "@/features/members/types";
+import { ProjectMemberRole } from "@/features/projects/types";
 import { DottedSeperator } from "@/components/dotted-seperator";
 import { useCurrent } from "@/features/auth/api/use-current";
 
@@ -31,7 +32,7 @@ export const ProjectIdSettingsClient = () => {
 	const pmRole = projectMembers?.documents.find(
 		(m) => m.userId === currentUser?.$id
 	)?.role;
-	const isAdmin = wsRole === MemberRole.ADMIN || pmRole === "ADMIN";
+	const isAdmin = wsRole === MemberRole.ADMIN || pmRole === ProjectMemberRole.ADMIN;
 
 	return (
 		<Tabs defaultValue="general">

--- a/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/client.tsx
+++ b/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/client.tsx
@@ -2,18 +2,64 @@
 
 import { PageError } from "@/components/page-error";
 import { PageLoader } from "@/components/page-loader";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useGetProject } from "@/features/projects/api/use-get-project";
 import { EditProjectForm } from "@/features/projects/components/edit-project-form";
+import { ProjectMembersList } from "@/features/projects/components/project-members-list";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useGetMembers } from "@/features/members/api/use-get-members";
+import { useGetProjectMembers } from "@/features/projects/api/use-get-project-members";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { MemberRole } from "@/features/members/types";
+import { DottedSeperator } from "@/components/dotted-seperator";
+import { useCurrent } from "@/features/auth/api/use-current";
 
 export const ProjectIdSettingsClient = () => {
 	const projectId = useProjectId();
+	const workspaceId = useWorkspaceId();
+	const { data: currentUser } = useCurrent();
 	const { data: initialValues, isLoading } = useGetProject({ projectId });
+	const { data: workspaceMembers } = useGetMembers({ workspaceId });
+	const { data: projectMembers } = useGetProjectMembers({ workspaceId, projectId });
+
 	if (isLoading) return <PageLoader />;
 	if (!initialValues) return <PageError message="Project not found" />;
+
+	const wsRole = workspaceMembers?.documents.find(
+		(m) => m.userId === currentUser?.$id
+	)?.role;
+	const pmRole = projectMembers?.documents.find(
+		(m) => m.userId === currentUser?.$id
+	)?.role;
+	const isAdmin = wsRole === MemberRole.ADMIN || pmRole === "ADMIN";
+
 	return (
-		<div className="w-full lg:max-w-xl">
-			<EditProjectForm initialValues={initialValues} />
+		<div className="w-full lg:max-w-2xl">
+			<Tabs defaultValue="general">
+				<TabsList className="mb-4">
+					<TabsTrigger value="general">General</TabsTrigger>
+					<TabsTrigger value="members">Members</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="general">
+					<EditProjectForm initialValues={initialValues} />
+				</TabsContent>
+
+				<TabsContent value="members">
+					<div className="border rounded-lg p-6 bg-card">
+						<h2 className="text-lg font-semibold mb-1">Project Members</h2>
+						<p className="text-sm text-muted-foreground mb-4">
+							Manage who has access to this project.
+						</p>
+						<DottedSeperator className="mb-4" />
+						<ProjectMembersList
+							workspaceId={workspaceId}
+							projectId={projectId}
+							isAdmin={isAdmin}
+						/>
+					</div>
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 };

--- a/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/page.tsx
+++ b/src/app/(standalone)/workspaces/[workspaceId]/projects/[projectId]/settings/page.tsx
@@ -7,7 +7,7 @@ const projectIdSettingsPage = async () => {
 	const user = await getCurrent();
 	if (!user) redirect("/sing-in");
 	return (
-		<div className="w-full lg:max-w-xl">
+		<div className="w-full lg:max-w-2xl">
 			<ProjectIdSettingsClient />
 		</div>
 	);

--- a/src/features/members/server/route.ts
+++ b/src/features/members/server/route.ts
@@ -116,7 +116,7 @@ const app = new Hono()
 			.doc(memberToDelete.workspaceId)
 			.collection("projects")
 			.get();
-		await Promise.all(
+		const cascadeResults = await Promise.allSettled(
 			projectsSnap.docs.map((pDoc: any) =>
 				databases
 					.collection("workspaces")
@@ -126,9 +126,11 @@ const app = new Hono()
 					.collection("members")
 					.doc(memberToDelete.userId)
 					.delete()
-					.catch(() => {}) // ignore if not a member of this project
 			)
 		);
+		if (cascadeResults.some((r) => r.status === "rejected")) {
+			return c.json({ error: "Failed to remove member from all projects" }, 500);
+		}
 
 		return c.json({ data: { $id: memberId } });
 	})

--- a/src/features/members/server/route.ts
+++ b/src/features/members/server/route.ts
@@ -109,6 +109,27 @@ const app = new Hono()
 			);
 		}
 		await databases.collection("members").doc(memberId).delete();
+
+		// Cascade: remove user from all project member sub-collections in this workspace
+		const projectsSnap = await databases
+			.collection("workspaces")
+			.doc(memberToDelete.workspaceId)
+			.collection("projects")
+			.get();
+		await Promise.all(
+			projectsSnap.docs.map((pDoc: any) =>
+				databases
+					.collection("workspaces")
+					.doc(memberToDelete.workspaceId)
+					.collection("projects")
+					.doc(pDoc.id)
+					.collection("members")
+					.doc(memberToDelete.userId)
+					.delete()
+					.catch(() => {}) // ignore if not a member of this project
+			)
+		);
+
 		return c.json({ data: { $id: memberId } });
 	})
 	.patch(

--- a/src/features/members/server/route.ts
+++ b/src/features/members/server/route.ts
@@ -108,9 +108,7 @@ const app = new Hono()
 				400
 			);
 		}
-		await databases.collection("members").doc(memberId).delete();
-
-		// Cascade: remove user from all project member sub-collections in this workspace
+		// Cascade first: remove user from all project member sub-collections
 		const projectsSnap = await databases
 			.collection("workspaces")
 			.doc(memberToDelete.workspaceId)
@@ -132,6 +130,7 @@ const app = new Hono()
 			return c.json({ error: "Failed to remove member from all projects" }, 500);
 		}
 
+		await databases.collection("members").doc(memberId).delete();
 		return c.json({ data: { $id: memberId } });
 	})
 	.patch(

--- a/src/features/projects/api/use-add-project-member.ts
+++ b/src/features/projects/api/use-add-project-member.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export const useAddProjectMember = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({
+			projectId,
+			userId,
+			role,
+		}: {
+			projectId: string;
+			userId: string;
+			role: "ADMIN" | "MEMBER";
+		}) => {
+			const response = await client.api.projects[":projectId"].members.$post({
+				param: { projectId },
+				json: { userId, role },
+			});
+			if (!response.ok) {
+				const err = await response.json();
+				throw new Error((err as any).error ?? "Failed to add member");
+			}
+			return response.json();
+		},
+		onSuccess: (_data, { projectId }) => {
+			toast.success("Member added to project");
+			queryClient.invalidateQueries({ queryKey: ["project-members"] });
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+};

--- a/src/features/projects/api/use-add-project-member.ts
+++ b/src/features/projects/api/use-add-project-member.ts
@@ -24,7 +24,7 @@ export const useAddProjectMember = () => {
 			}
 			return response.json();
 		},
-		onSuccess: (_data, { projectId }) => {
+		onSuccess: () => {
 			toast.success("Member added to project");
 			queryClient.invalidateQueries({ queryKey: ["project-members"] });
 		},

--- a/src/features/projects/api/use-add-project-member.ts
+++ b/src/features/projects/api/use-add-project-member.ts
@@ -1,6 +1,9 @@
 import { client } from "@/lib/rpc";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { ProjectMemberRole } from "../types";
+
+type ErrorResponse = { error?: string };
 
 export const useAddProjectMember = () => {
 	const queryClient = useQueryClient();
@@ -12,15 +15,15 @@ export const useAddProjectMember = () => {
 		}: {
 			projectId: string;
 			userId: string;
-			role: "ADMIN" | "MEMBER";
+			role: ProjectMemberRole;
 		}) => {
 			const response = await client.api.projects[":projectId"].members.$post({
 				param: { projectId },
 				json: { userId, role },
 			});
 			if (!response.ok) {
-				const err = await response.json();
-				throw new Error((err as any).error ?? "Failed to add member");
+				const err = await response.json() as ErrorResponse;
+				throw new Error(err.error ?? "Failed to add member");
 			}
 			return response.json();
 		},

--- a/src/features/projects/api/use-get-project-members.ts
+++ b/src/features/projects/api/use-get-project-members.ts
@@ -1,0 +1,27 @@
+import { client } from "@/lib/rpc";
+import { useQuery } from "@tanstack/react-query";
+
+interface UseGetProjectMembersProps {
+	workspaceId: string;
+	projectId: string;
+	enabled?: boolean;
+}
+
+export const useGetProjectMembers = ({
+	workspaceId,
+	projectId,
+	enabled = true,
+}: UseGetProjectMembersProps) => {
+	return useQuery({
+		enabled: enabled && !!projectId,
+		queryKey: ["project-members", workspaceId, projectId],
+		queryFn: async () => {
+			const response = await client.api.projects[":projectId"].members.$get({
+				param: { projectId },
+			});
+			if (!response.ok) throw new Error("Failed to fetch project members");
+			const { data } = await response.json();
+			return data;
+		},
+	});
+};

--- a/src/features/projects/api/use-remove-project-member.ts
+++ b/src/features/projects/api/use-remove-project-member.ts
@@ -1,0 +1,33 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export const useRemoveProjectMember = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({
+			projectId,
+			userId,
+		}: {
+			projectId: string;
+			userId: string;
+		}) => {
+			const response = await client.api.projects[":projectId"].members[":userId"].$delete({
+				param: { projectId, userId },
+			});
+			if (!response.ok) {
+				const err = await response.json();
+				throw new Error((err as any).error ?? "Failed to remove member");
+			}
+			return response.json();
+		},
+		onSuccess: () => {
+			toast.success("Member removed from project");
+			queryClient.invalidateQueries({ queryKey: ["project-members"] });
+			queryClient.invalidateQueries({ queryKey: ["projects"] });
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+};

--- a/src/features/projects/api/use-remove-project-member.ts
+++ b/src/features/projects/api/use-remove-project-member.ts
@@ -2,6 +2,8 @@ import { client } from "@/lib/rpc";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
+type ErrorResponse = { error?: string };
+
 export const useRemoveProjectMember = () => {
 	const queryClient = useQueryClient();
 	return useMutation({
@@ -16,8 +18,8 @@ export const useRemoveProjectMember = () => {
 				param: { projectId, userId },
 			});
 			if (!response.ok) {
-				const err = await response.json();
-				throw new Error((err as any).error ?? "Failed to remove member");
+				const err = await response.json() as ErrorResponse;
+				throw new Error(err.error ?? "Failed to remove member");
 			}
 			return response.json();
 		},

--- a/src/features/projects/api/use-update-project-member.ts
+++ b/src/features/projects/api/use-update-project-member.ts
@@ -1,0 +1,35 @@
+import { client } from "@/lib/rpc";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export const useUpdateProjectMember = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: async ({
+			projectId,
+			userId,
+			role,
+		}: {
+			projectId: string;
+			userId: string;
+			role: "ADMIN" | "MEMBER";
+		}) => {
+			const response = await client.api.projects[":projectId"].members[":userId"].$patch({
+				param: { projectId, userId },
+				json: { role },
+			});
+			if (!response.ok) {
+				const err = await response.json();
+				throw new Error((err as any).error ?? "Failed to update member");
+			}
+			return response.json();
+		},
+		onSuccess: () => {
+			toast.success("Member role updated");
+			queryClient.invalidateQueries({ queryKey: ["project-members"] });
+		},
+		onError: (err) => {
+			toast.error(err.message);
+		},
+	});
+};

--- a/src/features/projects/api/use-update-project-member.ts
+++ b/src/features/projects/api/use-update-project-member.ts
@@ -1,6 +1,9 @@
 import { client } from "@/lib/rpc";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { ProjectMemberRole } from "../types";
+
+type ErrorResponse = { error?: string };
 
 export const useUpdateProjectMember = () => {
 	const queryClient = useQueryClient();
@@ -12,15 +15,15 @@ export const useUpdateProjectMember = () => {
 		}: {
 			projectId: string;
 			userId: string;
-			role: "ADMIN" | "MEMBER";
+			role: ProjectMemberRole;
 		}) => {
 			const response = await client.api.projects[":projectId"].members[":userId"].$patch({
 				param: { projectId, userId },
 				json: { role },
 			});
 			if (!response.ok) {
-				const err = await response.json();
-				throw new Error((err as any).error ?? "Failed to update member");
+				const err = await response.json() as ErrorResponse;
+				throw new Error(err.error ?? "Failed to update member");
 			}
 			return response.json();
 		},

--- a/src/features/projects/components/project-members-list.tsx
+++ b/src/features/projects/components/project-members-list.tsx
@@ -25,6 +25,7 @@ import { useUpdateProjectMember } from "../api/use-update-project-member";
 import { useRemoveProjectMember } from "../api/use-remove-project-member";
 import { useConfirm } from "@/hooks/use-confirm";
 import { Loader, MoreVerticalIcon, UserPlusIcon } from "lucide-react";
+import { ProjectMemberRole } from "../types";
 
 interface ProjectMembersListProps {
 	workspaceId: string;
@@ -38,7 +39,7 @@ export const ProjectMembersList = ({
 	isAdmin,
 }: ProjectMembersListProps) => {
 	const [selectedUserId, setSelectedUserId] = useState<string>("");
-	const [selectedRole, setSelectedRole] = useState<"ADMIN" | "MEMBER">("MEMBER");
+	const [selectedRole, setSelectedRole] = useState<ProjectMemberRole>(ProjectMemberRole.MEMBER);
 
 	const [ConfirmDialog, confirm] = useConfirm(
 		"Remove member",
@@ -70,7 +71,12 @@ export const ProjectMembersList = ({
 		);
 	};
 
+	const admins = projectMembers.filter((m) => m.role === ProjectMemberRole.ADMIN);
+	const isLastAdmin = (userId: string) =>
+		admins.length === 1 && admins[0].userId === userId;
+
 	const handleRemove = async (userId: string) => {
+		if (isLastAdmin(userId)) return;
 		const ok = await confirm();
 		if (!ok) return;
 		removeMember({ projectId, userId });
@@ -97,13 +103,13 @@ export const ProjectMembersList = ({
 								<MemberAvatar
 									className="size-10"
 									fallbackClassName="text-lg"
-									name={member.name}
+									name={member.name ?? member.email ?? "Unknown"}
 								/>
 								<div className="flex flex-col">
 									<p className="text-sm font-medium">{member.name}</p>
 									<p className="text-xs text-muted-foreground">{member.email}</p>
 								</div>
-								{member.role === "ADMIN" && (
+								{member.role === ProjectMemberRole.ADMIN && (
 									<div className="text-xs ml-auto text-white px-2 py-1 rounded-md bg-blue-500">
 										Admin
 									</div>
@@ -112,7 +118,7 @@ export const ProjectMembersList = ({
 									<DropdownMenu>
 										<DropdownMenuTrigger asChild>
 											<Button
-												className={member.role !== "ADMIN" ? "ml-auto" : ""}
+												className={member.role !== ProjectMemberRole.ADMIN ? "ml-auto" : ""}
 												variant="secondary"
 												size="icon"
 											>
@@ -123,27 +129,27 @@ export const ProjectMembersList = ({
 											<DropdownMenuItem
 												className="font-medium"
 												onClick={() =>
-													updateMember({ projectId, userId: member.userId, role: "ADMIN" })
+													updateMember({ projectId, userId: member.userId, role: ProjectMemberRole.ADMIN })
 												}
-												disabled={isUpdating || member.role === "ADMIN"}
+												disabled={isUpdating || member.role === ProjectMemberRole.ADMIN}
 											>
 												Set as Administrator
 											</DropdownMenuItem>
 											<DropdownMenuItem
 												className="font-medium"
 												onClick={() =>
-													updateMember({ projectId, userId: member.userId, role: "MEMBER" })
+													updateMember({ projectId, userId: member.userId, role: ProjectMemberRole.MEMBER })
 												}
-												disabled={isUpdating || member.role === "MEMBER"}
+												disabled={isUpdating || member.role === ProjectMemberRole.MEMBER}
 											>
 												Set as Member
 											</DropdownMenuItem>
 											<DropdownMenuItem
 												className="font-medium text-amber-700"
 												onClick={() => handleRemove(member.userId)}
-												disabled={isRemoving}
+												disabled={isRemoving || isLastAdmin(member.userId)}
 											>
-												Remove {member.name}
+												Remove {member.name ?? member.email ?? "Unknown"}
 											</DropdownMenuItem>
 										</DropdownMenuContent>
 									</DropdownMenu>
@@ -175,13 +181,13 @@ export const ProjectMembersList = ({
 							</div>
 							<div>
 								<p className="text-sm font-medium mb-1">Role</p>
-								<Select value={selectedRole} onValueChange={(v) => setSelectedRole(v as "ADMIN" | "MEMBER")}>
+								<Select value={selectedRole} onValueChange={(v) => setSelectedRole(v as ProjectMemberRole)}>
 									<SelectTrigger className="w-28">
 										<SelectValue />
 									</SelectTrigger>
 									<SelectContent>
-										<SelectItem value="MEMBER">Member</SelectItem>
-										<SelectItem value="ADMIN">Admin</SelectItem>
+										<SelectItem value={ProjectMemberRole.MEMBER}>Member</SelectItem>
+										<SelectItem value={ProjectMemberRole.ADMIN}>Admin</SelectItem>
 									</SelectContent>
 								</Select>
 							</div>

--- a/src/features/projects/components/project-members-list.tsx
+++ b/src/features/projects/components/project-members-list.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Fragment, useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { DottedSeperator } from "@/components/dotted-seperator";
 import { Separator } from "@/components/ui/separator";

--- a/src/features/projects/components/project-members-list.tsx
+++ b/src/features/projects/components/project-members-list.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DottedSeperator } from "@/components/dotted-seperator";
+import { Separator } from "@/components/ui/separator";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { MemberAvatar } from "@/features/members/components/member-avatar";
+import { useGetMembers } from "@/features/members/api/use-get-members";
+import { useGetProjectMembers } from "../api/use-get-project-members";
+import { useAddProjectMember } from "../api/use-add-project-member";
+import { useUpdateProjectMember } from "../api/use-update-project-member";
+import { useRemoveProjectMember } from "../api/use-remove-project-member";
+import { useConfirm } from "@/hooks/use-confirm";
+import { Loader, MoreVerticalIcon, UserPlusIcon } from "lucide-react";
+
+interface ProjectMembersListProps {
+	workspaceId: string;
+	projectId: string;
+	isAdmin: boolean;
+}
+
+export const ProjectMembersList = ({
+	workspaceId,
+	projectId,
+	isAdmin,
+}: ProjectMembersListProps) => {
+	const [selectedUserId, setSelectedUserId] = useState<string>("");
+	const [selectedRole, setSelectedRole] = useState<"ADMIN" | "MEMBER">("MEMBER");
+
+	const [ConfirmDialog, confirm] = useConfirm(
+		"Remove member",
+		"Are you sure you want to remove this member from the project?",
+		"destructive"
+	);
+
+	const { data: projectMembersData, isLoading: isLoadingPm } = useGetProjectMembers({
+		workspaceId,
+		projectId,
+	});
+	const { data: workspaceMembersData, isLoading: isLoadingWm } = useGetMembers({ workspaceId });
+
+	const { mutate: addMember, isPending: isAdding } = useAddProjectMember();
+	const { mutate: updateMember, isPending: isUpdating } = useUpdateProjectMember();
+	const { mutate: removeMember, isPending: isRemoving } = useRemoveProjectMember();
+
+	const projectMembers = projectMembersData?.documents ?? [];
+	const workspaceMembers = workspaceMembersData?.documents ?? [];
+
+	const projectMemberIds = new Set(projectMembers.map((m) => m.userId));
+	const addableMembers = workspaceMembers.filter((m) => !projectMemberIds.has(m.userId ?? m.$id));
+
+	const handleAdd = () => {
+		if (!selectedUserId) return;
+		addMember(
+			{ projectId, userId: selectedUserId, role: selectedRole },
+			{ onSuccess: () => setSelectedUserId("") }
+		);
+	};
+
+	const handleRemove = async (userId: string) => {
+		const ok = await confirm();
+		if (!ok) return;
+		removeMember({ projectId, userId });
+	};
+
+	if (isLoadingPm || isLoadingWm) {
+		return (
+			<div className="flex items-center justify-center h-32">
+				<Loader className="size-5 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<ConfirmDialog />
+			<div className="flex flex-col gap-y-4">
+				{projectMembers.length === 0 ? (
+					<p className="text-sm text-muted-foreground">No members yet.</p>
+				) : (
+					projectMembers.map((member, index) => (
+						<Fragment key={member.$id}>
+							<div className="flex items-center gap-2">
+								<MemberAvatar
+									className="size-10"
+									fallbackClassName="text-lg"
+									name={member.name}
+								/>
+								<div className="flex flex-col">
+									<p className="text-sm font-medium">{member.name}</p>
+									<p className="text-xs text-muted-foreground">{member.email}</p>
+								</div>
+								{member.role === "ADMIN" && (
+									<div className="text-xs ml-auto text-white px-2 py-1 rounded-md bg-blue-500">
+										Admin
+									</div>
+								)}
+								{isAdmin && (
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button
+												className={member.role !== "ADMIN" ? "ml-auto" : ""}
+												variant="secondary"
+												size="icon"
+											>
+												<MoreVerticalIcon className="size-4 text-muted-foreground" />
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent side="bottom" align="end">
+											<DropdownMenuItem
+												className="font-medium"
+												onClick={() =>
+													updateMember({ projectId, userId: member.userId, role: "ADMIN" })
+												}
+												disabled={isUpdating || member.role === "ADMIN"}
+											>
+												Set as Administrator
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												className="font-medium"
+												onClick={() =>
+													updateMember({ projectId, userId: member.userId, role: "MEMBER" })
+												}
+												disabled={isUpdating || member.role === "MEMBER"}
+											>
+												Set as Member
+											</DropdownMenuItem>
+											<DropdownMenuItem
+												className="font-medium text-amber-700"
+												onClick={() => handleRemove(member.userId)}
+												disabled={isRemoving}
+											>
+												Remove {member.name}
+											</DropdownMenuItem>
+										</DropdownMenuContent>
+									</DropdownMenu>
+								)}
+							</div>
+							{index < projectMembers.length - 1 && <Separator className="my-1" />}
+						</Fragment>
+					))
+				)}
+
+				{isAdmin && addableMembers.length > 0 && (
+					<>
+						<DottedSeperator className="py-2" />
+						<div className="flex items-end gap-2">
+							<div className="flex-1">
+								<p className="text-sm font-medium mb-1">Add member</p>
+								<Select value={selectedUserId} onValueChange={setSelectedUserId}>
+									<SelectTrigger>
+										<SelectValue placeholder="Select a workspace member" />
+									</SelectTrigger>
+									<SelectContent>
+										{addableMembers.map((m) => (
+											<SelectItem key={m.$id} value={m.userId ?? m.$id}>
+												{m.name ?? m.email}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div>
+								<p className="text-sm font-medium mb-1">Role</p>
+								<Select value={selectedRole} onValueChange={(v) => setSelectedRole(v as "ADMIN" | "MEMBER")}>
+									<SelectTrigger className="w-28">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="MEMBER">Member</SelectItem>
+										<SelectItem value="ADMIN">Admin</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<Button
+								onClick={handleAdd}
+								disabled={!selectedUserId || isAdding}
+								size="default"
+							>
+								<UserPlusIcon className="size-4 mr-2" />
+								Add
+							</Button>
+						</div>
+					</>
+				)}
+			</div>
+		</>
+	);
+};

--- a/src/features/projects/components/project-members-list.tsx
+++ b/src/features/projects/components/project-members-list.tsx
@@ -118,6 +118,7 @@ export const ProjectMembersList = ({
 									<DropdownMenu>
 										<DropdownMenuTrigger asChild>
 											<Button
+												aria-label={`Manage ${member.name ?? member.email ?? "member"}`}
 												className={member.role !== ProjectMemberRole.ADMIN ? "ml-auto" : ""}
 												variant="secondary"
 												size="icon"
@@ -173,7 +174,7 @@ export const ProjectMembersList = ({
 									<SelectContent>
 										{addableMembers.map((m) => (
 											<SelectItem key={m.$id} value={m.userId ?? m.$id}>
-												{m.name ?? m.email}
+												{m.name ?? m.email ?? "Unknown"}
 											</SelectItem>
 										))}
 									</SelectContent>

--- a/src/features/projects/server/route.ts
+++ b/src/features/projects/server/route.ts
@@ -21,8 +21,6 @@ const normalizeDate = (data: Record<string, unknown> | undefined) => {
 	return candidate.toDate?.().toISOString();
 };
 
-// Bootstrap all workspace members into a project's members sub-collection.
-// Called once per project the first time it is accessed after this feature ships.
 const bootstrapProjectMembers = async (
 	databases: any,
 	workspaceId: string,
@@ -56,6 +54,18 @@ const bootstrapProjectMembers = async (
 	}
 	batch.update(projectRef, { membersBootstrapped: true });
 	await batch.commit();
+};
+
+// Ensure the project's member sub-collection is bootstrapped before any membership lookup.
+const ensureProjectBootstrapped = async (
+	databases: any,
+	workspaceId: string,
+	projectId: string,
+	projectDoc: any
+) => {
+	if (!projectDoc.data()?.membersBootstrapped) {
+		await bootstrapProjectMembers(databases, workspaceId, projectId, projectDoc.ref);
+	}
 };
 
 const app = new Hono()
@@ -192,7 +202,7 @@ const app = new Hono()
 			});
 		}
 	)
-	// ── Project member management ──────────────────────────────────────────────
+	// ── Project member management ────────────────────────────────────────────
 	.get("/:projectId/members", sessionMiddleware, async (c) => {
 		const databases = c.get("databases");
 		const user = c.get("user");
@@ -220,6 +230,7 @@ const app = new Hono()
 			}
 		}
 		if (!projectDoc) return c.json({ error: "Not found" }, 404);
+		await ensureProjectBootstrapped(databases, workspaceId, projectId, projectDoc);
 
 		const member = await getMember({ databases, workspaceId, userId: user.$id });
 		if (!member) return c.json({ error: "Unauthorized" }, 401);
@@ -285,6 +296,7 @@ const app = new Hono()
 				if (pDoc.exists) { projectDoc = pDoc; workspaceId = wId; break; }
 			}
 			if (!projectDoc) return c.json({ error: "Not found" }, 404);
+			await ensureProjectBootstrapped(databases, workspaceId, projectId, projectDoc);
 
 			const member = await getMember({ databases, workspaceId, userId: user.$id });
 			if (!member) return c.json({ error: "Unauthorized" }, 401);
@@ -296,14 +308,18 @@ const app = new Hono()
 			const targetMember = await getMember({ databases, workspaceId, userId: targetUserId });
 			if (!targetMember) return c.json({ error: "User is not a workspace member" }, 400);
 
-			await databases
+			const memberRef = databases
 				.collection("workspaces")
 				.doc(workspaceId)
 				.collection("projects")
 				.doc(projectId)
 				.collection("members")
-				.doc(targetUserId)
-				.set({ userId: targetUserId, role, $createdAt: new Date().toISOString() }, { merge: true });
+				.doc(targetUserId);
+			const existingSnap = await memberRef.get();
+			if (existingSnap.exists) {
+				return c.json({ error: "Project member already exists" }, 409);
+			}
+			await memberRef.set({ userId: targetUserId, role, $createdAt: new Date().toISOString() });
 
 			return c.json({ data: { $id: targetUserId } });
 		}
@@ -324,6 +340,7 @@ const app = new Hono()
 				.get();
 			const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId);
 
+			let projectDoc: any = null;
 			let workspaceId = "";
 			for (const wId of workspaceIds) {
 				const pDoc = await databases
@@ -332,9 +349,10 @@ const app = new Hono()
 					.collection("projects")
 					.doc(projectId)
 					.get();
-				if (pDoc.exists) { workspaceId = wId; break; }
+				if (pDoc.exists) { projectDoc = pDoc; workspaceId = wId; break; }
 			}
 			if (!workspaceId) return c.json({ error: "Not found" }, 404);
+			await ensureProjectBootstrapped(databases, workspaceId, projectId, projectDoc);
 
 			const member = await getMember({ databases, workspaceId, userId: user.$id });
 			if (!member) return c.json({ error: "Unauthorized" }, 401);
@@ -342,6 +360,18 @@ const app = new Hono()
 			const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
 			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === ProjectMemberRole.ADMIN;
 			if (!isAdmin) return c.json({ error: "Unauthorized" }, 401);
+
+			const targetMemberRef = databases
+				.collection("workspaces")
+				.doc(workspaceId)
+				.collection("projects")
+				.doc(projectId)
+				.collection("members")
+				.doc(targetUserId);
+			const targetMemberSnap = await targetMemberRef.get();
+			if (!targetMemberSnap.exists) {
+				return c.json({ error: "Project member not found" }, 404);
+			}
 
 			if (role === "MEMBER") {
 				const adminsSnap = await databases
@@ -358,14 +388,7 @@ const app = new Hono()
 				}
 			}
 
-			await databases
-				.collection("workspaces")
-				.doc(workspaceId)
-				.collection("projects")
-				.doc(projectId)
-				.collection("members")
-				.doc(targetUserId)
-				.update({ role });
+			await targetMemberRef.update({ role });
 
 			return c.json({ data: { $id: targetUserId } });
 		}
@@ -381,6 +404,7 @@ const app = new Hono()
 			.get();
 		const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId);
 
+		let deleteProjectDoc: any = null;
 		let workspaceId = "";
 		for (const wId of workspaceIds) {
 			const pDoc = await databases
@@ -389,9 +413,10 @@ const app = new Hono()
 				.collection("projects")
 				.doc(projectId)
 				.get();
-			if (pDoc.exists) { workspaceId = wId; break; }
+			if (pDoc.exists) { deleteProjectDoc = pDoc; workspaceId = wId; break; }
 		}
 		if (!workspaceId) return c.json({ error: "Not found" }, 404);
+		await ensureProjectBootstrapped(databases, workspaceId, projectId, deleteProjectDoc);
 
 		const member = await getMember({ databases, workspaceId, userId: user.$id });
 		if (!member) return c.json({ error: "Unauthorized" }, 401);
@@ -426,7 +451,7 @@ const app = new Hono()
 
 		return c.json({ data: { $id: targetUserId } });
 	})
-	// ── Analytics + single project GET/PATCH/DELETE (unchanged) ───────────────
+	// ── Analytics + single project GET/PATCH/DELETE ─────────────────────────────
 	.get("/:projectId/analytics", sessionMiddleware, async (c) => {
 		const databases = c.get("databases");
 		const user = c.get("user");
@@ -443,9 +468,15 @@ const app = new Hono()
 		if (!projectDoc) return c.json({ error: "Not found" }, 404);
 		const pData = projectDoc.data();
 		const project = { ...pData, $id: projectDoc.id, $createdAt: normalizeDate(pData) } as Project;
+		await ensureProjectBootstrapped(databases, project.workspaceId, projectId, projectDoc);
 
 		const member = await getMember({ databases, workspaceId: project.workspaceId, userId: user.$id });
 		if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+		if (member.role !== MemberRole.ADMIN) {
+			const pm = await getProjectMember({ databases, workspaceId: project.workspaceId, projectId, userId: user.$id });
+			if (!pm) return c.json({ error: "Unauthorized" }, 401);
+		}
 
 		const now = new Date();
 		const thisMonthStart = startOfMonth(now).toISOString();
@@ -519,6 +550,7 @@ const app = new Hono()
 		if (!projectDoc) return c.json({ error: "Not found" }, 404);
 		const pData = projectDoc.data();
 		const project = { ...pData, $id: projectDoc.id, $createdAt: normalizeDate(pData) } as Project;
+		await ensureProjectBootstrapped(databases, project.workspaceId, projectId, projectDoc);
 
 		const member = await getMember({ databases, workspaceId: project.workspaceId, userId: user.$id });
 		if (!member) return c.json({ error: "Unauthorized" }, 401);
@@ -552,6 +584,7 @@ const app = new Hono()
 
 			if (!projectDoc) return c.json({ error: "Not found" }, 404);
 			const existingProject = projectDoc.data() as Project;
+			await ensureProjectBootstrapped(databases, existingProject.workspaceId, projectId, projectDoc);
 
 			const member = await getMember({ databases, workspaceId: existingProject.workspaceId, userId: user.$id });
 			if (!member) return c.json({ error: "Unauthorized" }, 401);

--- a/src/features/projects/server/route.ts
+++ b/src/features/projects/server/route.ts
@@ -1,13 +1,15 @@
 import { getMember } from "@/features/members/utils";
+import { MemberRole } from "@/features/members/types";
 import { sessionMiddleware } from "@/lib/session-middleware";
+import { adminAuth } from "@/lib/firebase-admin";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
 import { createProjectSchema, updateProjectSchema } from "../schemas";
-import { Project } from "../types";
+import { Project, ProjectMember, ProjectMemberRole } from "../types";
+import { getProjectMember } from "../utils";
 import { endOfMonth, startOfMonth, subMonths } from "date-fns";
 import { TaskStatus } from "@/features/tasks/types";
-import { MemberRole } from "@/features/members/types";
 
 const normalizeDate = (data: Record<string, unknown> | undefined) => {
 	const candidate = (data?.$createdAt ?? data?.createdAt) as
@@ -17,6 +19,43 @@ const normalizeDate = (data: Record<string, unknown> | undefined) => {
 	if (!candidate) return undefined;
 	if (typeof candidate === "string") return candidate;
 	return candidate.toDate?.().toISOString();
+};
+
+// Bootstrap all workspace members into a project's members sub-collection.
+// Called once per project the first time it is accessed after this feature ships.
+const bootstrapProjectMembers = async (
+	databases: any,
+	workspaceId: string,
+	projectId: string,
+	projectRef: FirebaseFirestore.DocumentReference
+) => {
+	const workspaceMembersSnap = await databases
+		.collection("members")
+		.where("workspaceId", "==", workspaceId)
+		.get();
+
+	const batch = databases.batch();
+	for (const doc of workspaceMembersSnap.docs) {
+		const data = doc.data();
+		const memberRef = databases
+			.collection("workspaces")
+			.doc(workspaceId)
+			.collection("projects")
+			.doc(projectId)
+			.collection("members")
+			.doc(data.userId);
+		batch.set(
+			memberRef,
+			{
+				userId: data.userId,
+				role: data.role === MemberRole.ADMIN ? "ADMIN" : "MEMBER",
+				$createdAt: new Date().toISOString(),
+			},
+			{ merge: true }
+		);
+	}
+	batch.update(projectRef, { membersBootstrapped: true });
+	await batch.commit();
 };
 
 const app = new Hono()
@@ -44,15 +83,49 @@ const app = new Hono()
 				.collection("projects")
 				.orderBy("$createdAt", "desc")
 				.get();
-			const projects = projectsSnapshot.docs.map((doc: any) => {
+			const allProjects = projectsSnapshot.docs.map((doc: any) => {
 				const data = doc.data();
 				return {
 					...data,
 					$id: doc.id,
 					$createdAt: normalizeDate(data),
+					_ref: doc.ref,
 				};
-			}) as Project[];
-			return c.json({ data: { documents: projects, total: projects.length } });
+			});
+
+			// Workspace ADMINs see all projects
+			if (member.role === MemberRole.ADMIN) {
+				const projects = allProjects.map(({ _ref, ...p }: any) => p) as Project[];
+				return c.json({ data: { documents: projects, total: projects.length } });
+			}
+
+			// For regular members: filter by project membership; bootstrap legacy projects
+			const visibleProjects: Project[] = [];
+			await Promise.all(
+				allProjects.map(async (project: any) => {
+					const { _ref, membersBootstrapped, ...projectData } = project;
+					if (!membersBootstrapped) {
+						await bootstrapProjectMembers(databases, workspaceId, projectData.$id, _ref);
+						visibleProjects.push(projectData as Project);
+						return;
+					}
+					const pm = await getProjectMember({
+						databases,
+						workspaceId,
+						projectId: projectData.$id,
+						userId: user.$id,
+					});
+					if (pm) visibleProjects.push(projectData as Project);
+				})
+			);
+
+			// Restore ordering after parallel resolution
+			const orderedIds = allProjects.map((p: any) => p.$id);
+			visibleProjects.sort(
+				(a, b) => orderedIds.indexOf(a.$id) - orderedIds.indexOf(b.$id)
+			);
+
+			return c.json({ data: { documents: visibleProjects, total: visibleProjects.length } });
 		}
 	)
 	.post(
@@ -91,57 +164,289 @@ const app = new Hono()
 					imageUrl: uploadImageUrl || null,
 					workspaceId,
 					$createdAt: new Date().toISOString(),
+					membersBootstrapped: true,
 				});
+
+			// Auto-add creator as project ADMIN
+			await databases
+				.collection("workspaces")
+				.doc(workspaceId)
+				.collection("projects")
+				.doc(docRef.id)
+				.collection("members")
+				.doc(user.$id)
+				.set({
+					userId: user.$id,
+					role: "ADMIN" as ProjectMemberRole,
+					$createdAt: new Date().toISOString(),
+				});
+
 			const projectDoc = await docRef.get();
 			const pData = projectDoc.data();
-			return c.json({ 
-				data: { 
+			return c.json({
+				data: {
 					...pData,
-					$id: projectDoc.id, 
+					$id: projectDoc.id,
 					$createdAt: normalizeDate(pData),
-				} 
+				},
 			});
 		}
 	)
+	// ── Project member management ──────────────────────────────────────────────
+	.get("/:projectId/members", sessionMiddleware, async (c) => {
+		const databases = c.get("databases");
+		const user = c.get("user");
+		const { projectId } = c.req.param();
+
+		const membersSnap = await databases
+			.collection("members")
+			.where("userId", "==", user.$id)
+			.get();
+		const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId);
+
+		let projectDoc: any = null;
+		let workspaceId = "";
+		for (const wId of workspaceIds) {
+			const pDoc = await databases
+				.collection("workspaces")
+				.doc(wId)
+				.collection("projects")
+				.doc(projectId)
+				.get();
+			if (pDoc.exists) {
+				projectDoc = pDoc;
+				workspaceId = wId;
+				break;
+			}
+		}
+		if (!projectDoc) return c.json({ error: "Not found" }, 404);
+
+		const member = await getMember({ databases, workspaceId, userId: user.$id });
+		if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+		const pmSnap = await databases
+			.collection("workspaces")
+			.doc(workspaceId)
+			.collection("projects")
+			.doc(projectId)
+			.collection("members")
+			.orderBy("$createdAt", "asc")
+			.get();
+
+		const projectMembers = pmSnap.docs.map((doc: any) => ({
+			...doc.data(),
+			$id: doc.id,
+		})) as ProjectMember[];
+
+		const userRecords = await adminAuth.getUsers(
+			projectMembers.map((m) => ({ uid: m.userId }))
+		);
+		const userMap = new Map<string, any>();
+		userRecords.users.forEach((u) => userMap.set(u.uid, u));
+
+		const populated = projectMembers.map((pm) => {
+			const u = userMap.get(pm.userId) ?? { displayName: "Unknown", email: "" };
+			return { ...pm, name: u.displayName || u.email, email: u.email };
+		});
+
+		return c.json({ data: { documents: populated, total: populated.length } });
+	})
+	.post(
+		"/:projectId/members",
+		sessionMiddleware,
+		zValidator("json", z.object({ userId: z.string(), role: z.enum(["ADMIN", "MEMBER"]) })),
+		async (c) => {
+			const databases = c.get("databases");
+			const user = c.get("user");
+			const { projectId } = c.req.param();
+			const { userId: targetUserId, role } = c.req.valid("json");
+
+			const membersSnap = await databases
+				.collection("members")
+				.where("userId", "==", user.$id)
+				.get();
+			const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId);
+
+			let projectDoc: any = null;
+			let workspaceId = "";
+			for (const wId of workspaceIds) {
+				const pDoc = await databases
+					.collection("workspaces")
+					.doc(wId)
+					.collection("projects")
+					.doc(projectId)
+					.get();
+				if (pDoc.exists) { projectDoc = pDoc; workspaceId = wId; break; }
+			}
+			if (!projectDoc) return c.json({ error: "Not found" }, 404);
+
+			const member = await getMember({ databases, workspaceId, userId: user.$id });
+			if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+			const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
+			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === "ADMIN";
+			if (!isAdmin) return c.json({ error: "Unauthorized" }, 401);
+
+			const targetMember = await getMember({ databases, workspaceId, userId: targetUserId });
+			if (!targetMember) return c.json({ error: "User is not a workspace member" }, 400);
+
+			await databases
+				.collection("workspaces")
+				.doc(workspaceId)
+				.collection("projects")
+				.doc(projectId)
+				.collection("members")
+				.doc(targetUserId)
+				.set({ userId: targetUserId, role, $createdAt: new Date().toISOString() }, { merge: true });
+
+			return c.json({ data: { $id: targetUserId } });
+		}
+	)
+	.patch(
+		"/:projectId/members/:userId",
+		sessionMiddleware,
+		zValidator("json", z.object({ role: z.enum(["ADMIN", "MEMBER"]) })),
+		async (c) => {
+			const databases = c.get("databases");
+			const user = c.get("user");
+			const { projectId, userId: targetUserId } = c.req.param();
+			const { role } = c.req.valid("json");
+
+			const membersSnap = await databases
+				.collection("members")
+				.where("userId", "==", user.$id)
+				.get();
+			const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId);
+
+			let workspaceId = "";
+			for (const wId of workspaceIds) {
+				const pDoc = await databases
+					.collection("workspaces")
+					.doc(wId)
+					.collection("projects")
+					.doc(projectId)
+					.get();
+				if (pDoc.exists) { workspaceId = wId; break; }
+			}
+			if (!workspaceId) return c.json({ error: "Not found" }, 404);
+
+			const member = await getMember({ databases, workspaceId, userId: user.$id });
+			if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+			const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
+			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === "ADMIN";
+			if (!isAdmin) return c.json({ error: "Unauthorized" }, 401);
+
+			if (role === "MEMBER") {
+				const adminsSnap = await databases
+					.collection("workspaces")
+					.doc(workspaceId)
+					.collection("projects")
+					.doc(projectId)
+					.collection("members")
+					.where("role", "==", "ADMIN")
+					.get();
+				const otherAdmins = adminsSnap.docs.filter((d: any) => d.id !== targetUserId);
+				if (otherAdmins.length === 0) {
+					return c.json({ error: "Cannot remove the last project admin" }, 400);
+				}
+			}
+
+			await databases
+				.collection("workspaces")
+				.doc(workspaceId)
+				.collection("projects")
+				.doc(projectId)
+				.collection("members")
+				.doc(targetUserId)
+				.update({ role });
+
+			return c.json({ data: { $id: targetUserId } });
+		}
+	)
+	.delete("/:projectId/members/:userId", sessionMiddleware, async (c) => {
+		const databases = c.get("databases");
+		const user = c.get("user");
+		const { projectId, userId: targetUserId } = c.req.param();
+
+		const membersSnap = await databases
+			.collection("members")
+			.where("userId", "==", user.$id)
+			.get();
+		const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId);
+
+		let workspaceId = "";
+		for (const wId of workspaceIds) {
+			const pDoc = await databases
+				.collection("workspaces")
+				.doc(wId)
+				.collection("projects")
+				.doc(projectId)
+				.get();
+			if (pDoc.exists) { workspaceId = wId; break; }
+		}
+		if (!workspaceId) return c.json({ error: "Not found" }, 404);
+
+		const member = await getMember({ databases, workspaceId, userId: user.$id });
+		if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+		const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
+		const isSelf = user.$id === targetUserId;
+		const isAdmin = member.role === MemberRole.ADMIN || pm?.role === "ADMIN";
+		if (!isSelf && !isAdmin) return c.json({ error: "Unauthorized" }, 401);
+
+		const adminsSnap = await databases
+			.collection("workspaces")
+			.doc(workspaceId)
+			.collection("projects")
+			.doc(projectId)
+			.collection("members")
+			.where("role", "==", "ADMIN")
+			.get();
+		const targetIsAdmin = adminsSnap.docs.some((d: any) => d.id === targetUserId);
+		const otherAdmins = adminsSnap.docs.filter((d: any) => d.id !== targetUserId);
+		if (targetIsAdmin && otherAdmins.length === 0) {
+			return c.json({ error: "Cannot remove the last project admin" }, 400);
+		}
+
+		await databases
+			.collection("workspaces")
+			.doc(workspaceId)
+			.collection("projects")
+			.doc(projectId)
+			.collection("members")
+			.doc(targetUserId)
+			.delete();
+
+		return c.json({ data: { $id: targetUserId } });
+	})
+	// ── Analytics + single project GET/PATCH/DELETE (unchanged) ───────────────
 	.get("/:projectId/analytics", sessionMiddleware, async (c) => {
 		const databases = c.get("databases");
 		const user = c.get("user");
 		const { projectId } = c.req.param();
-		// Avoid collectionGroup by searching user's workspaces
 		const membersSnapshot = await databases.collection("members").where("userId", "==", user.$id).get();
 		const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
-		
+
 		let projectDoc = null;
 		for (const wId of workspaceIds) {
 			const pDoc = await databases.collection("workspaces").doc(wId).collection("projects").doc(projectId).get();
-			if (pDoc.exists) {
-				projectDoc = pDoc;
-				break;
-			}
+			if (pDoc.exists) { projectDoc = pDoc; break; }
 		}
-		
+
 		if (!projectDoc) return c.json({ error: "Not found" }, 404);
 		const pData = projectDoc.data();
-		const project = { 
-			...pData,
-			$id: projectDoc.id, 
-			$createdAt: normalizeDate(pData),
-		} as Project;
-		
-		const member = await getMember({
-			databases,
-			workspaceId: project.workspaceId,
-			userId: user.$id,
-		});
-		if (!member) {
-			return c.json({ error: "Unauthorized" }, 401);
-		}
+		const project = { ...pData, $id: projectDoc.id, $createdAt: normalizeDate(pData) } as Project;
+
+		const member = await getMember({ databases, workspaceId: project.workspaceId, userId: user.$id });
+		if (!member) return c.json({ error: "Unauthorized" }, 401);
+
 		const now = new Date();
 		const thisMonthStart = startOfMonth(now).toISOString();
 		const thisMonthEnd = endOfMonth(now).toISOString();
 		const lastMonthStart = startOfMonth(subMonths(now, 1)).toISOString();
 		const lastMonthEnd = endOfMonth(subMonths(now, 1)).toISOString();
-		
+
 		const tasksSnapshot = await databases
 			.collection("workspaces")
 			.doc(project.workspaceId)
@@ -149,55 +454,35 @@ const app = new Hono()
 			.doc(projectId)
 			.collection("tasks")
 			.get();
-		
-		const allTasks = tasksSnapshot.docs.map(doc => doc.data());
+
+		const allTasks = tasksSnapshot.docs.map((doc: any) => doc.data());
 
 		const getTaskCount = (start: string, end: string, filters: any = {}) => {
 			let docs = allTasks.filter((data: any) => {
 				const createdAt = normalizeDate(data) ?? "";
 				return createdAt >= start && createdAt <= end;
 			});
-
 			if (filters.assigneeId) docs = docs.filter((data: any) => data.assigneeId === filters.assigneeId);
 			if (filters.status) docs = docs.filter((data: any) => data.status === filters.status);
-			if (filters.notStatus) {
-				docs = docs.filter((data: any) => data.status !== filters.notStatus);
-			}
+			if (filters.notStatus) docs = docs.filter((data: any) => data.status !== filters.notStatus);
 			if (filters.overdue) {
-				docs = docs.filter((data: any) => {
-					return data.status !== TaskStatus.DONE && (data.dueDate || "") < now.toISOString();
-				});
+				docs = docs.filter((data: any) => data.status !== TaskStatus.DONE && (data.dueDate || "") < now.toISOString());
 			}
 			return docs.length;
 		};
 
-		const thisMonthTasksCount = getTaskCount(thisMonthStart, thisMonthEnd);
-		const lastMonthTasksCount = getTaskCount(lastMonthStart, lastMonthEnd);
-		
-		const thisMonthAssignedCount = getTaskCount(thisMonthStart, thisMonthEnd, { assigneeId: member.$id });
-		const lastMonthAssignedCount = getTaskCount(lastMonthStart, lastMonthEnd, { assigneeId: member.$id });
-		
-		const thisMonthIncompleteCount = getTaskCount(thisMonthStart, thisMonthEnd, { notStatus: TaskStatus.DONE });
-		const lastMonthIncompleteCount = getTaskCount(lastMonthStart, lastMonthEnd, { notStatus: TaskStatus.DONE });
-		
-		const thisMonthCompletedCount = getTaskCount(thisMonthStart, thisMonthEnd, { status: TaskStatus.DONE });
-		const lastMonthCompletedCount = getTaskCount(lastMonthStart, lastMonthEnd, { status: TaskStatus.DONE });
-		
-		const thisMonthOverdueCount = getTaskCount(thisMonthStart, thisMonthEnd, { overdue: true });
-		const lastMonthOverdueCount = getTaskCount(lastMonthStart, lastMonthEnd, { overdue: true });
-
 		return c.json({
 			data: {
-				taskCount: thisMonthTasksCount,
-				taskDifference: thisMonthTasksCount - lastMonthTasksCount,
-				assignedTaskCount: thisMonthAssignedCount,
-				assignedTaskDifference: thisMonthAssignedCount - lastMonthAssignedCount,
-				incompleteTaskCount: thisMonthIncompleteCount,
-				incompleteTaskDifference: thisMonthIncompleteCount - lastMonthIncompleteCount,
-				completedTaskCount: thisMonthCompletedCount,
-				completedTaskDifference: thisMonthCompletedCount - lastMonthCompletedCount,
-				overdueTaskCount: thisMonthOverdueCount,
-				overdueTaskDifference: thisMonthOverdueCount - lastMonthOverdueCount,
+				taskCount: getTaskCount(thisMonthStart, thisMonthEnd),
+				taskDifference: getTaskCount(thisMonthStart, thisMonthEnd) - getTaskCount(lastMonthStart, lastMonthEnd),
+				assignedTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { assigneeId: member.$id }),
+				assignedTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { assigneeId: member.$id }) - getTaskCount(lastMonthStart, lastMonthEnd, { assigneeId: member.$id }),
+				incompleteTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { notStatus: TaskStatus.DONE }),
+				incompleteTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { notStatus: TaskStatus.DONE }) - getTaskCount(lastMonthStart, lastMonthEnd, { notStatus: TaskStatus.DONE }),
+				completedTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { status: TaskStatus.DONE }),
+				completedTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { status: TaskStatus.DONE }) - getTaskCount(lastMonthStart, lastMonthEnd, { status: TaskStatus.DONE }),
+				overdueTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { overdue: true }),
+				overdueTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { overdue: true }) - getTaskCount(lastMonthStart, lastMonthEnd, { overdue: true }),
 			},
 		});
 	})
@@ -207,32 +492,19 @@ const app = new Hono()
 		const { projectId } = c.req.param();
 		const membersSnapshot = await databases.collection("members").where("userId", "==", user.$id).get();
 		const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
-		
+
 		let projectDoc = null;
 		for (const wId of workspaceIds) {
 			const pDoc = await databases.collection("workspaces").doc(wId).collection("projects").doc(projectId).get();
-			if (pDoc.exists) {
-				projectDoc = pDoc;
-				break;
-			}
+			if (pDoc.exists) { projectDoc = pDoc; break; }
 		}
-		
+
 		if (!projectDoc) return c.json({ error: "Not found" }, 404);
 		const pData = projectDoc.data();
-		const project = { 
-			...pData,
-			$id: projectDoc.id, 
-			$createdAt: normalizeDate(pData),
-		} as Project;
-		
-		const member = await getMember({
-			databases,
-			workspaceId: project.workspaceId,
-			userId: user.$id,
-		});
-		if (!member) {
-			return c.json({ error: "Unauthorized" }, 401);
-		}
+		const project = { ...pData, $id: projectDoc.id, $createdAt: normalizeDate(pData) } as Project;
+
+		const member = await getMember({ databases, workspaceId: project.workspaceId, userId: user.$id });
+		if (!member) return c.json({ error: "Unauthorized" }, 401);
 		return c.json({ data: project });
 	})
 	.patch(
@@ -245,30 +517,22 @@ const app = new Hono()
 			const user = c.get("user");
 			const { name, imageUrl } = c.req.valid("form");
 			const { projectId } = c.req.param();
-			
+
 			const membersSnapshot = await databases.collection("members").where("userId", "==", user.$id).get();
 			const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
-			
+
 			let projectDoc = null;
 			for (const wId of workspaceIds) {
 				const pDoc = await databases.collection("workspaces").doc(wId).collection("projects").doc(projectId).get();
-				if (pDoc.exists) {
-					projectDoc = pDoc;
-					break;
-				}
+				if (pDoc.exists) { projectDoc = pDoc; break; }
 			}
-			
+
 			if (!projectDoc) return c.json({ error: "Not found" }, 404);
 			const existingProject = projectDoc.data() as Project;
-			
-			const member = await getMember({
-				databases,
-				workspaceId: existingProject.workspaceId,
-				userId: user.$id,
-			});
-			if (!member) {
-				return c.json({ error: "Unauthorized" }, 401);
-			}
+
+			const member = await getMember({ databases, workspaceId: existingProject.workspaceId, userId: user.$id });
+			if (!member) return c.json({ error: "Unauthorized" }, 401);
+
 			let uploadImageUrl: string | undefined;
 			if (imageUrl instanceof File) {
 				const buffer = Buffer.from(await imageUrl.arrayBuffer());
@@ -287,12 +551,8 @@ const app = new Hono()
 			});
 			const updatedDoc = await projectDoc.ref.get();
 			const pData = updatedDoc.data();
-			return c.json({ 
-				data: { 
-					...pData,
-					$id: updatedDoc.id, 
-					$createdAt: normalizeDate(pData),
-				} 
+			return c.json({
+				data: { ...pData, $id: updatedDoc.id, $createdAt: normalizeDate(pData) },
 			});
 		}
 	)
@@ -304,37 +564,27 @@ const app = new Hono()
 		try {
 			const membersSnapshot = await databases.collection("members").where("userId", "==", user.$id).get();
 			const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
-			
+
 			let projectDoc = null;
 			for (const wId of workspaceIds) {
 				const pDoc = await databases.collection("workspaces").doc(wId).collection("projects").doc(projectId).get();
-				if (pDoc.exists) {
-					projectDoc = pDoc;
-					break;
-				}
+				if (pDoc.exists) { projectDoc = pDoc; break; }
 			}
-			
+
 			if (!projectDoc) return c.json({ error: "Not found" }, 404);
 			const workspaceId = projectDoc.data()?.workspaceId;
 
-			const member = await getMember({
-				databases,
-				workspaceId,
-				userId: user.$id,
-			});
-
+			const member = await getMember({ databases, workspaceId, userId: user.$id });
 			if (!member || member.role !== MemberRole.ADMIN) {
 				return c.json({ error: "Unauthorized" }, 401);
 			}
 
-			// Recursively delete project and all subcollections (tasks)
 			await databases.recursiveDelete(projectDoc.ref);
 			return c.json({ data: { $id: projectId } });
 		} catch (error) {
 			console.error(`[PROJECT_DELETE_ERROR] Project ID: ${projectId}`, error);
 			return c.json({ error: "Internal Server Error" }, 500);
 		}
-		}
-	);
+	});
 
 export default app;

--- a/src/features/projects/server/route.ts
+++ b/src/features/projects/server/route.ts
@@ -471,18 +471,29 @@ const app = new Hono()
 			return docs.length;
 		};
 
+		const thisTotal = getTaskCount(thisMonthStart, thisMonthEnd);
+		const lastTotal = getTaskCount(lastMonthStart, lastMonthEnd);
+		const thisAssigned = getTaskCount(thisMonthStart, thisMonthEnd, { assigneeId: member.$id });
+		const lastAssigned = getTaskCount(lastMonthStart, lastMonthEnd, { assigneeId: member.$id });
+		const thisIncomplete = getTaskCount(thisMonthStart, thisMonthEnd, { notStatus: TaskStatus.DONE });
+		const lastIncomplete = getTaskCount(lastMonthStart, lastMonthEnd, { notStatus: TaskStatus.DONE });
+		const thisCompleted = getTaskCount(thisMonthStart, thisMonthEnd, { status: TaskStatus.DONE });
+		const lastCompleted = getTaskCount(lastMonthStart, lastMonthEnd, { status: TaskStatus.DONE });
+		const thisOverdue = getTaskCount(thisMonthStart, thisMonthEnd, { overdue: true });
+		const lastOverdue = getTaskCount(lastMonthStart, lastMonthEnd, { overdue: true });
+
 		return c.json({
 			data: {
-				taskCount: getTaskCount(thisMonthStart, thisMonthEnd),
-				taskDifference: getTaskCount(thisMonthStart, thisMonthEnd) - getTaskCount(lastMonthStart, lastMonthEnd),
-				assignedTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { assigneeId: member.$id }),
-				assignedTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { assigneeId: member.$id }) - getTaskCount(lastMonthStart, lastMonthEnd, { assigneeId: member.$id }),
-				incompleteTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { notStatus: TaskStatus.DONE }),
-				incompleteTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { notStatus: TaskStatus.DONE }) - getTaskCount(lastMonthStart, lastMonthEnd, { notStatus: TaskStatus.DONE }),
-				completedTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { status: TaskStatus.DONE }),
-				completedTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { status: TaskStatus.DONE }) - getTaskCount(lastMonthStart, lastMonthEnd, { status: TaskStatus.DONE }),
-				overdueTaskCount: getTaskCount(thisMonthStart, thisMonthEnd, { overdue: true }),
-				overdueTaskDifference: getTaskCount(thisMonthStart, thisMonthEnd, { overdue: true }) - getTaskCount(lastMonthStart, lastMonthEnd, { overdue: true }),
+				taskCount: thisTotal,
+				taskDifference: thisTotal - lastTotal,
+				assignedTaskCount: thisAssigned,
+				assignedTaskDifference: thisAssigned - lastAssigned,
+				incompleteTaskCount: thisIncomplete,
+				incompleteTaskDifference: thisIncomplete - lastIncomplete,
+				completedTaskCount: thisCompleted,
+				completedTaskDifference: thisCompleted - lastCompleted,
+				overdueTaskCount: thisOverdue,
+				overdueTaskDifference: thisOverdue - lastOverdue,
 			},
 		});
 	})

--- a/src/features/projects/server/route.ts
+++ b/src/features/projects/server/route.ts
@@ -48,7 +48,7 @@ const bootstrapProjectMembers = async (
 			memberRef,
 			{
 				userId: data.userId,
-				role: data.role === MemberRole.ADMIN ? "ADMIN" : "MEMBER",
+				role: data.role === MemberRole.ADMIN ? ProjectMemberRole.ADMIN : ProjectMemberRole.MEMBER,
 				$createdAt: new Date().toISOString(),
 			},
 			{ merge: true }
@@ -177,7 +177,7 @@ const app = new Hono()
 				.doc(user.$id)
 				.set({
 					userId: user.$id,
-					role: "ADMIN" as ProjectMemberRole,
+					role: ProjectMemberRole.ADMIN,
 					$createdAt: new Date().toISOString(),
 				});
 
@@ -224,6 +224,11 @@ const app = new Hono()
 		const member = await getMember({ databases, workspaceId, userId: user.$id });
 		if (!member) return c.json({ error: "Unauthorized" }, 401);
 
+		if (member.role !== MemberRole.ADMIN) {
+			const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
+			if (!pm) return c.json({ error: "Unauthorized" }, 401);
+		}
+
 		const pmSnap = await databases
 			.collection("workspaces")
 			.doc(workspaceId)
@@ -238,11 +243,12 @@ const app = new Hono()
 			$id: doc.id,
 		})) as ProjectMember[];
 
-		const userRecords = await adminAuth.getUsers(
-			projectMembers.map((m) => ({ uid: m.userId }))
-		);
 		const userMap = new Map<string, any>();
-		userRecords.users.forEach((u) => userMap.set(u.uid, u));
+		for (let i = 0; i < projectMembers.length; i += 100) {
+			const chunk = projectMembers.slice(i, i + 100);
+			const userRecords = await adminAuth.getUsers(chunk.map((m) => ({ uid: m.userId })));
+			userRecords.users.forEach((u) => userMap.set(u.uid, u));
+		}
 
 		const populated = projectMembers.map((pm) => {
 			const u = userMap.get(pm.userId) ?? { displayName: "Unknown", email: "" };
@@ -284,7 +290,7 @@ const app = new Hono()
 			if (!member) return c.json({ error: "Unauthorized" }, 401);
 
 			const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
-			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === "ADMIN";
+			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === ProjectMemberRole.ADMIN;
 			if (!isAdmin) return c.json({ error: "Unauthorized" }, 401);
 
 			const targetMember = await getMember({ databases, workspaceId, userId: targetUserId });
@@ -334,7 +340,7 @@ const app = new Hono()
 			if (!member) return c.json({ error: "Unauthorized" }, 401);
 
 			const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
-			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === "ADMIN";
+			const isAdmin = member.role === MemberRole.ADMIN || pm?.role === ProjectMemberRole.ADMIN;
 			if (!isAdmin) return c.json({ error: "Unauthorized" }, 401);
 
 			if (role === "MEMBER") {
@@ -392,7 +398,7 @@ const app = new Hono()
 
 		const pm = await getProjectMember({ databases, workspaceId, projectId, userId: user.$id });
 		const isSelf = user.$id === targetUserId;
-		const isAdmin = member.role === MemberRole.ADMIN || pm?.role === "ADMIN";
+		const isAdmin = member.role === MemberRole.ADMIN || pm?.role === ProjectMemberRole.ADMIN;
 		if (!isSelf && !isAdmin) return c.json({ error: "Unauthorized" }, 401);
 
 		const adminsSnap = await databases
@@ -516,6 +522,12 @@ const app = new Hono()
 
 		const member = await getMember({ databases, workspaceId: project.workspaceId, userId: user.$id });
 		if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+		if (member.role !== MemberRole.ADMIN) {
+			const pm = await getProjectMember({ databases, workspaceId: project.workspaceId, projectId, userId: user.$id });
+			if (!pm) return c.json({ error: "Unauthorized" }, 401);
+		}
+
 		return c.json({ data: project });
 	})
 	.patch(
@@ -543,6 +555,10 @@ const app = new Hono()
 
 			const member = await getMember({ databases, workspaceId: existingProject.workspaceId, userId: user.$id });
 			if (!member) return c.json({ error: "Unauthorized" }, 401);
+
+			const pmForPatch = await getProjectMember({ databases, workspaceId: existingProject.workspaceId, projectId, userId: user.$id });
+			const isProjectAdmin = member.role === MemberRole.ADMIN || pmForPatch?.role === ProjectMemberRole.ADMIN;
+			if (!isProjectAdmin) return c.json({ error: "Unauthorized" }, 401);
 
 			let uploadImageUrl: string | undefined;
 			if (imageUrl instanceof File) {

--- a/src/features/projects/types.ts
+++ b/src/features/projects/types.ts
@@ -7,7 +7,10 @@ export type Project = {
 	membersBootstrapped?: boolean;
 };
 
-export type ProjectMemberRole = "ADMIN" | "MEMBER";
+export enum ProjectMemberRole {
+	ADMIN = "ADMIN",
+	MEMBER = "MEMBER",
+}
 
 export type ProjectMember = {
 	$id: string;

--- a/src/features/projects/types.ts
+++ b/src/features/projects/types.ts
@@ -4,4 +4,16 @@ export type Project = {
 	name: string;
 	imageUrl: string;
 	workspaceId: string;
+	membersBootstrapped?: boolean;
+};
+
+export type ProjectMemberRole = "ADMIN" | "MEMBER";
+
+export type ProjectMember = {
+	$id: string;
+	$createdAt?: string;
+	userId: string;
+	role: ProjectMemberRole;
+	name?: string;
+	email?: string;
 };

--- a/src/features/projects/utils.ts
+++ b/src/features/projects/utils.ts
@@ -1,0 +1,34 @@
+import { adminDb } from "@/lib/firebase-admin";
+import { ProjectMember } from "./types";
+
+interface GetProjectMemberProps {
+	databases: typeof adminDb;
+	workspaceId: string;
+	projectId: string;
+	userId: string;
+}
+
+export const getProjectMember = async ({
+	databases,
+	workspaceId,
+	projectId,
+	userId,
+}: GetProjectMemberProps): Promise<ProjectMember | null> => {
+	const doc = await databases
+		.collection("workspaces")
+		.doc(workspaceId)
+		.collection("projects")
+		.doc(projectId)
+		.collection("members")
+		.doc(userId)
+		.get();
+
+	if (!doc.exists) return null;
+	const data = doc.data()!;
+	return {
+		$id: doc.id,
+		userId: data.userId,
+		role: data.role,
+		$createdAt: data.$createdAt,
+	} as ProjectMember;
+};

--- a/src/features/tasks/components/create-task-form-wrapper.tsx
+++ b/src/features/tasks/components/create-task-form-wrapper.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetProjects } from "@/features/projects/api/use-get-projects";
+import { useGetProjectMembers } from "@/features/projects/api/use-get-project-members";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
 import { useGetSprints } from "@/features/sprints/api/use-get-sprints";
 import { SprintStatus } from "@/features/sprints/types";
@@ -8,7 +8,9 @@ import { useGetVersions } from "@/features/versions/api/use-get-versions";
 import { VersionStatus } from "@/features/versions/types";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { Loader } from "lucide-react";
+import { useState } from "react";
 import { CreateTaskForm } from "./create-task-form";
+import { usePrefill } from "@/contexts/sidebar-context";
 
 interface CreateTaskFormWrapperProps {
 	onCancel: () => void;
@@ -19,38 +21,55 @@ export const CreateTaskFormWrapper = ({
 }: CreateTaskFormWrapperProps) => {
 	const workspaceId = useWorkspaceId();
 	const projectId = useProjectId();
+	const { prefill } = usePrefill();
+
+	const [selectedProjectId, setSelectedProjectId] = useState<string>(
+		prefill.projectId ?? projectId ?? ""
+	);
+
 	const { data: projects, isLoading: isLoadingProjects } = useGetProjects({
 		workspaceId,
 	});
-	const { data: members, isLoading: isLoadingMembers } = useGetMembers({
+	const { data: projectMembersData, isLoading: isLoadingMembers } = useGetProjectMembers({
 		workspaceId,
+		projectId: selectedProjectId,
+		enabled: !!selectedProjectId,
 	});
 	const { data: sprints, isLoading: isLoadingSprints } = useGetSprints({
 		workspaceId,
-		projectId: projectId ?? "",
-		enabled: !!projectId,
+		projectId: selectedProjectId ?? "",
+		enabled: !!selectedProjectId,
 	});
 	const { data: versions, isLoading: isLoadingVersions } = useGetVersions({
 		workspaceId,
-		projectId: projectId ?? "",
-		enabled: !!projectId,
+		projectId: selectedProjectId ?? "",
+		enabled: !!selectedProjectId,
 	});
+
 	const projectOptions = projects?.documents.map((project) => ({
 		id: project.$id,
 		name: project.name,
 		imageUrl: project.imageUrl,
 	}));
-	const memeberOptions = members?.documents.map((member) => ({
+
+	const memberOptions = (projectMembersData?.documents ?? []).map((member) => ({
 		id: member.$id,
-		name: member.name,
+		name: member.name ?? member.email ?? "Unknown",
 	}));
+
 	const sprintOptions = (sprints?.documents ?? [])
 		.filter((s) => s.status === SprintStatus.PLANNED || s.status === SprintStatus.ACTIVE)
 		.map((s) => ({ id: s.$id, name: s.name }));
+
 	const versionOptions = (versions?.documents ?? [])
 		.filter((v) => v.status === VersionStatus.UNRELEASED)
 		.map((v) => ({ id: v.$id, name: v.name }));
-	const isLoading = isLoadingProjects || isLoadingMembers || (!!projectId && (isLoadingSprints || isLoadingVersions));
+
+	const isLoading =
+		isLoadingProjects ||
+		(!!selectedProjectId && isLoadingMembers) ||
+		(!!selectedProjectId && (isLoadingSprints || isLoadingVersions));
+
 	if (isLoading) {
 		return (
 			<Card className="w-full h-[714px] border-none shadow-none">
@@ -60,13 +79,15 @@ export const CreateTaskFormWrapper = ({
 			</Card>
 		);
 	}
+
 	return (
 		<CreateTaskForm
 			onCancel={onCancel}
 			projectOptions={projectOptions ?? []}
-			memberOptions={memeberOptions ?? []}
+			memberOptions={memberOptions}
 			sprintOptions={sprintOptions}
 			versionOptions={versionOptions}
+			onProjectChange={setSelectedProjectId}
 		/>
 	);
 };

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -304,6 +304,9 @@ export const CreateTaskForm = ({
 												defaultValue={field.value}
 												onValueChange={(value) => {
 													field.onChange(value);
+													form.setValue("assigneeId", undefined);
+													form.setValue("sprintId", undefined);
+													form.setValue("fixVersionId", undefined);
 													onProjectChange?.(value);
 												}}
 											>

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -45,6 +45,7 @@ interface CreateTaskFormProps {
 	memberOptions: { id: string; name: string }[];
 	sprintOptions?: { id: string; name: string }[];
 	versionOptions?: { id: string; name: string }[];
+	onProjectChange?: (projectId: string) => void;
 }
 
 export const CreateTaskForm = ({
@@ -53,6 +54,7 @@ export const CreateTaskForm = ({
 	memberOptions,
 	sprintOptions = [],
 	versionOptions = [],
+	onProjectChange,
 }: CreateTaskFormProps) => {
 	const workspaceId = useWorkspaceId();
 	const { mutate, isPending } = useCreateTask();
@@ -300,7 +302,10 @@ export const CreateTaskForm = ({
 											<FormLabel>Project</FormLabel>
 											<Select
 												defaultValue={field.value}
-												onValueChange={field.onChange}
+												onValueChange={(value) => {
+													field.onChange(value);
+													onProjectChange?.(value);
+												}}
 											>
 												<FormControl>
 													<SelectTrigger>
@@ -376,7 +381,7 @@ export const CreateTaskForm = ({
 																? undefined
 																: Number(e.target.value);
 														field.onChange(
-															isNaN(val as number) ? field.value : val
+															Number.isNaN(val as number) ? field.value : val
 														);
 													}}
 												/>

--- a/src/features/tasks/components/create-task-form.tsx
+++ b/src/features/tasks/components/create-task-form.tsx
@@ -184,7 +184,7 @@ export const CreateTaskForm = ({
 										<FormItem>
 											<FormLabel>Assignee</FormLabel>
 											<Select
-												defaultValue={field.value}
+												value={field.value ?? undefined}
 												onValueChange={field.onChange}
 											>
 												<FormControl>
@@ -304,9 +304,9 @@ export const CreateTaskForm = ({
 												defaultValue={field.value}
 												onValueChange={(value) => {
 													field.onChange(value);
-													form.setValue("assigneeId", undefined);
-													form.setValue("sprintId", undefined);
-													form.setValue("fixVersionId", undefined);
+													form.resetField("assigneeId");
+													form.resetField("sprintId");
+													form.resetField("fixVersionId");
 													onProjectChange?.(value);
 												}}
 											>
@@ -345,7 +345,7 @@ export const CreateTaskForm = ({
 											<FormItem>
 												<FormLabel>Sprint (optional)</FormLabel>
 												<Select
-													defaultValue={field.value ?? undefined}
+													value={field.value ?? undefined}
 													onValueChange={field.onChange}
 												>
 													<FormControl>
@@ -401,7 +401,7 @@ export const CreateTaskForm = ({
 											<FormItem>
 												<FormLabel>Version (optional)</FormLabel>
 												<Select
-													defaultValue={field.value ?? undefined}
+													value={field.value ?? undefined}
 													onValueChange={(value) =>
 														field.onChange(
 															value === "none" ? undefined : value

--- a/src/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/src/features/tasks/components/edit-task-form-wrapper.tsx
@@ -53,7 +53,7 @@ export const EditTaskFormWrapper = ({
 		if (!initialValues?.assigneeId) return rawMemberOptions;
 		const already = rawMemberOptions.some((m) => m.id === initialValues.assigneeId);
 		if (already) return rawMemberOptions;
-		return [...rawMemberOptions, { id: initialValues.assigneeId, name: "Former member", userId: initialValues.assigneeId }];
+		return [...rawMemberOptions, { id: initialValues.assigneeId, name: "Former member", userId: "" }];
 	})();
 
 	const versionOptions = (versions?.documents ?? [])

--- a/src/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/src/features/tasks/components/edit-task-form-wrapper.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetProjects } from "@/features/projects/api/use-get-projects";
+import { useGetProjectMembers } from "@/features/projects/api/use-get-project-members";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { Loader } from "lucide-react";
 import { useGetTask } from "../api/use-get-task";
@@ -24,28 +24,47 @@ export const EditTaskFormWrapper = ({
 	const { data: projects, isLoading: isLoadingProjects } = useGetProjects({
 		workspaceId,
 	});
-	const { data: members, isLoading: isLoadingMembers } = useGetMembers({
-		workspaceId,
-	});
 	const projectId = initialValues?.projectId ?? "";
+	const { data: projectMembersData, isLoading: isLoadingMembers } = useGetProjectMembers({
+		workspaceId,
+		projectId,
+		enabled: !!projectId,
+	});
 	const { data: versions, isLoading: isLoadingVersions } = useGetVersions({
 		workspaceId,
 		projectId,
 		enabled: !!projectId,
 	});
+
 	const projectOptions = projects?.documents.map((project) => ({
 		id: project.$id,
 		name: project.name,
 		imageUrl: project.imageUrl,
 	}));
-	const memeberOptions = members?.documents.map((member) => ({
+
+	const rawMemberOptions = (projectMembersData?.documents ?? []).map((member) => ({
 		id: member.$id,
-		name: member.name,
+		name: member.name ?? member.email ?? "Unknown",
+		userId: member.userId,
 	}));
+
+	// Always include current assignee even if they've been removed from the project
+	const memberOptions = (() => {
+		if (!initialValues?.assigneeId) return rawMemberOptions;
+		const already = rawMemberOptions.some((m) => m.id === initialValues.assigneeId);
+		if (already) return rawMemberOptions;
+		return [...rawMemberOptions, { id: initialValues.assigneeId, name: "Former member", userId: initialValues.assigneeId }];
+	})();
+
 	const versionOptions = (versions?.documents ?? [])
 		.filter((v) => v.status === VersionStatus.UNRELEASED || v.$id === initialValues?.fixVersionId)
 		.map((v) => ({ id: v.$id, name: v.name }));
-	const isLoading = isLoadingProjects || isLoadingMembers || isLoadingTask || (!!projectId && isLoadingVersions);
+
+	const isLoading =
+		isLoadingProjects ||
+		isLoadingTask ||
+		(!!projectId && (isLoadingMembers || isLoadingVersions));
+
 	if (isLoading) {
 		return (
 			<Card className="w-full h-[714px] border-none shadow-none">
@@ -63,7 +82,7 @@ export const EditTaskFormWrapper = ({
 			initalValues={initialValues}
 			onCancel={onCancel}
 			projectOptions={projectOptions ?? []}
-			memberOptions={memeberOptions ?? []}
+			memberOptions={memberOptions}
 			versionOptions={versionOptions}
 		/>
 	);


### PR DESCRIPTION
## Summary

- Each project now has its own member list stored at `workspaces/{wid}/projects/{pid}/members/{userId}`
- Workspace ADMINs bypass filtering and see all projects; regular members only see projects they belong to
- Legacy projects are lazy-bootstrapped on first access (all workspace members added as project MEMBERs, `membersBootstrapped` flag set)
- New projects auto-add the creator as project ADMIN at creation time
- Create task and edit task modals now show only members of the selected project as assignees
- Project settings page gains a **Members** tab for managing project membership (add, remove, change role)
- Removing a workspace member cascades to all project member sub-collections

## New API routes (`/api/projects`)

| Method | Path | Description |
|--------|------|-------------|
| GET | `/:projectId/members` | List project members with name/email |
| POST | `/:projectId/members` | Add workspace member to project |
| PATCH | `/:projectId/members/:userId` | Update member role |
| DELETE | `/:projectId/members/:userId` | Remove member (guards last-admin) |

## Test plan

- [ ] Workspace ADMIN sees all projects in sidebar
- [ ] Workspace MEMBER only sees projects they are a member of
- [ ] Legacy projects (no `membersBootstrapped`) get all workspace members added on first load
- [ ] Creating a new project adds creator as project ADMIN
- [ ] Project settings → Members tab lists members, shows Add section for admins
- [ ] Adding/removing/changing role of a project member works
- [ ] Cannot remove or downgrade the last project admin
- [ ] Create task modal assignee list updates when project is changed
- [ ] Edit task modal shows correct assignees; former assignee still appears if removed from project
- [ ] Removing a workspace member removes them from all project member sub-collections

---
_Generated by [Claude Code](https://claude.ai/code/session_019PzpoPqCaBHbN9KK8CzC65)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now include a “Members” tab with full member management (add/update/remove), admin badges, loaders and success/error toasts.
  * Legacy projects are auto-populated with members; project membership is used everywhere (task create/edit prefill, member-scoped lists).
  * Settings page layout is wider on large screens; task form clears dependent fields when project changes.

* **Bug Fixes**
  * Prevents removing the last project admin and surfaces member-operation failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/51)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->