### PR TITLE
UX polish and bug fixes

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -6,7 +6,7 @@ import { EditTaskModal } from "@/features/tasks/components/edit-task-model";
 import { CreateWorkspaceModal } from "@/features/workspaces/components/create-workspace-modal";
 import { SidebarProvider } from "@/contexts/sidebar-context";
 import { CreateSprintModal } from "@/features/sprints/components/create-sprint-modal";
-
+import { CreateVersionModal } from "@/features/versions/components/create-version-modal";
 
 interface DashBoardLayoutProps {
 	children?: React.ReactNode;
@@ -20,6 +20,7 @@ const DashBoardLayout = ({ children }: DashBoardLayoutProps) => {
 			<CreateTaskModal />
 			<EditTaskModal />
 			<CreateSprintModal />
+			<CreateVersionModal />
 			<div className="flex w-full h-full">
 				<div className="fixed left-0 top-0 hidden lg:block lg:w-[264px] h-full overflow-y-auto">
 					<Sidebar />

--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/releases/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/releases/client.tsx
@@ -2,14 +2,36 @@
 
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useGetProject } from "@/features/projects/api/use-get-project";
+import { useCreateVersionModal } from "@/features/versions/hooks/use-create-version-modal";
 import { VersionsList } from "@/features/versions/components/versions-list";
+import { Button } from "@/components/ui/button";
+import { ProjectAvatar } from "@/features/projects/components/project-avatar";
+import { PageError } from "@/components/page-error";
+import { PageLoader } from "@/components/page-loader";
+import { PlusIcon } from "lucide-react";
 
 export const VersionsPageClient = () => {
   const workspaceId = useWorkspaceId();
   const projectId = useProjectId();
+  const { data: project, isLoading } = useGetProject({ projectId });
+  const { open: openCreateVersion } = useCreateVersionModal();
+
+  if (isLoading) return <PageLoader />;
+  if (!project) return <PageError message="Project not found" />;
 
   return (
-    <div className="flex flex-col gap-y-4 max-w-2xl mx-auto py-6">
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          <ProjectAvatar name={project.name} imageUrl={project.imageUrl} className="size-8" />
+          <p className="text-lg font-semibold">{project.name} - Releases</p>
+        </div>
+        <Button size="sm" onClick={() => openCreateVersion({ projectId })}>
+          <PlusIcon className="size-4 mr-2" />
+          Create Release
+        </Button>
+      </div>
       <VersionsList workspaceId={workspaceId} projectId={projectId} />
     </div>
   );

--- a/src/app/(dashboard)/workspace/[workspaceId]/tasks/[taskId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/tasks/[taskId]/client.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { DottedSeperator } from "@/components/dotted-seperator";
 import { PageError } from "@/components/page-error";
 import { PageLoader } from "@/components/page-loader";
 import { useGetTask } from "@/features/tasks/api/use-get-task";
@@ -15,6 +14,7 @@ import { TaskTimeTracking } from "@/features/tasks/components/task-time-tracking
 import { useTaskId } from "@/features/tasks/hooks/use-task-id";
 import { TaskRca } from "@/features/tasks/components/task-description";
 import { IssueType } from "@/features/tasks/types";
+import { DottedSeperator } from "@/components/dotted-seperator";
 
 export const TaskIdClient = () => {
 	const taskId = useTaskId();
@@ -22,35 +22,36 @@ export const TaskIdClient = () => {
 	if (isLoading) return <PageLoader />;
 	if (!data) return <PageError message="Task not found" />;
 	return (
-		<div className="flex flex-col">
+		<div className="flex flex-col gap-y-4">
 			<TaskBreadcrumbs project={data.project} task={data} />
-			<DottedSeperator className="my-6" />
-			<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-				<TaskOverview task={data} />
-				<TaskDescription task={data} />
+			<DottedSeperator />
+			<div className="grid grid-cols-1 xl:grid-cols-[280px_1fr_280px] gap-6">
+				{/* LEFT — Overview + Time Tracking */}
+				<div className="flex flex-col gap-y-4">
+					<TaskOverview task={data} />
+					<TaskTimeTracking
+						taskId={data.$id}
+						workspaceId={data.workspaceId}
+						projectId={data.projectId}
+						task={data}
+					/>
+				</div>
+
+				{/* CENTER — Title, Description, RCA (bug only), Comments */}
+				<div className="flex flex-col gap-y-4">
+					<h1 className="text-2xl font-semibold break-words">{data.name}</h1>
+					<TaskDescription task={data} />
+					{data.issueType === IssueType.BUG && <TaskRca task={data} />}
+					<TaskComments taskId={data.$id} />
+				</div>
+
+				{/* RIGHT — Links, Attachments, Activity */}
+				<div className="flex flex-col gap-y-4">
+					<TaskLinks taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
+					<TaskAttachments taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
+					<TaskActivity taskId={data.$id} />
+				</div>
 			</div>
-			<DottedSeperator className="my-6" />
-			<TaskComments taskId={data.$id} />
-			{data.issueType === IssueType.BUG && (
-				<>
-					<DottedSeperator className="my-6" />
-					<TaskRca task={data} />
-					<DottedSeperator className="my-6" />
-				</>
-			)}
-			<div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-				<TaskLinks taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
-				<TaskAttachments taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
-			</div>
-			<DottedSeperator className="my-6" />
-			<TaskTimeTracking
-				taskId={data.$id}
-				workspaceId={data.workspaceId}
-				projectId={data.projectId}
-				task={data}
-			/>
-			<DottedSeperator className="my-6" />
-			<TaskActivity taskId={data.$id} />
 		</div>
 	);
 };

--- a/src/app/api/mcp/[[...mcp]]/route.ts
+++ b/src/app/api/mcp/[[...mcp]]/route.ts
@@ -8,6 +8,7 @@ import { taskConditionalRefine } from "@/features/tasks/schemas";
 import { SprintStatus } from "@/features/sprints/types";
 import { VersionStatus } from "@/features/versions/types";
 import { generateInviteCode } from "@/lib/utils";
+import { generatePrefixedId, ID_PREFIX } from "@/lib/ids";
 import { adminDb, adminStorage } from "@/lib/firebase-admin";
 import { fileTypeFromBuffer } from "file-type";
 import { MemberRole } from "@/features/members/types";
@@ -225,6 +226,173 @@ const updateTicketSchema = z.object({
   rca: z.string().optional().describe("Root Cause Analysis"),
 }).superRefine(taskConditionalRefine);
 
+async function findProjectAcrossWorkspaces(projectId: string, userId: string) {
+  const membersSnap = await adminDb.collection("members").where("userId", "==", userId).get();
+  const workspaceIds = membersSnap.docs.map((d: any) => d.data().workspaceId as string);
+  for (const wId of workspaceIds) {
+    const pDoc = await projRef(wId, projectId).get();
+    if (pDoc.exists) return { projectDoc: pDoc, workspaceId: wId };
+  }
+  throw new Error("Project not found");
+}
+
+async function getCallerWorkspaceRole(workspaceId: string, userId: string): Promise<string | null> {
+  const snap = await adminDb.collection("members")
+    .where("workspaceId", "==", workspaceId)
+    .where("userId", "==", userId)
+    .limit(1)
+    .get();
+  return snap.empty ? null : (snap.docs[0].data().role as string);
+}
+
+async function verifyProjectAdminAccess(workspaceId: string, projectRef: any, callerId: string, action: string) {
+  const workspaceRole = await getCallerWorkspaceRole(workspaceId, callerId);
+  if (workspaceRole === MemberRole.ADMIN) return;
+  const pm = await projectRef.collection("members").doc(callerId).get();
+  if (!pm.exists || pm.data()!.role !== MemberRole.ADMIN) {
+    throw new Error(`Only workspace admins or project admins can ${action}`);
+  }
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
+}
+function docJson(doc: any) { return { $id: doc.id, ...doc.data() }; }
+
+async function setDocStatus(ref: any, status: string, entityName: string) {
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error(`${entityName} not found`);
+  await ref.update({ status });
+  const updated = await ref.get();
+  return textResult(docJson(updated));
+}
+
+async function resolveProjectRef(workspaceId: string, projectId: string) {
+  const ref = projRef(workspaceId, projectId);
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error("Project not found");
+  return ref;
+}
+
+async function updateDocFields(ref: any, updates: Record<string, unknown>, entityName: string) {
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error(`${entityName} not found`);
+  await ref.update(updates);
+  const updated = await ref.get();
+  return textResult(docJson(updated));
+}
+
+async function listByProject(workspaceId: string, projectId: string | undefined, subColFn: (wId: string, pId: string) => any) {
+  const projectsSnap = await adminDb.collection("workspaces").doc(workspaceId).collection("projects").get();
+  const items: any[] = [];
+  for (const pDoc of projectsSnap.docs) {
+    if (projectId && pDoc.id !== projectId) continue;
+    const snap = await subColFn(workspaceId, pDoc.id).get();
+    items.push(...snap.docs.map((doc: any) => docJson(doc)));
+  }
+  return textResult(items);
+}
+
+async function applyWithResolvedImage(ref: any, updates: Record<string, unknown>, imageUrl: string | undefined, userId: string) {
+  const resolvedUrl = await resolveImageUrl(imageUrl, userId);
+  const finalUpdates = resolvedUrl ? { ...updates, imageUrl: resolvedUrl } : updates;
+  await ref.update(finalUpdates);
+  return textResult(docJson(await ref.get()));
+}
+
+async function resolveCommentRef(args: any, userId: string, action: string) {
+  const ref = taskDocRef(args.workspaceId, args.projectId, args.taskId)
+    .collection("comments").doc(args.commentId);
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error("Comment not found");
+  if (doc.data()!.authorId !== userId) throw new Error(`Only the comment author can ${action}`);
+  return ref;
+}
+
+async function resolveWorkspaceMember(workspaceId: string, memberId: string) {
+  const ref = adminDb.collection("members").doc(memberId);
+  const doc = await ref.get();
+  if (!doc.exists || doc.data()!.workspaceId !== workspaceId) {
+    throw new Error("Member not found in this workspace");
+  }
+  return { memberRef: ref, memberDoc: doc };
+}
+
+async function batchClearFieldAndDelete(entityRef: any, tasksQuery: any, fieldName: string) {
+  const affectedTasks = await tasksQuery.get();
+  const batch = adminDb.batch();
+  affectedTasks.docs.forEach((doc: any) => { batch.update(doc.ref, { [fieldName]: null }); });
+  batch.delete(entityRef);
+  await batch.commit();
+}
+
+async function resolveSprintRef(args: any) {
+  const ref = sprintsCol(args.workspaceId, args.projectId).doc(args.sprintId);
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error("Sprint not found");
+  return { sprintRef: ref, sprintDoc: doc };
+}
+
+async function resolveTaskRef(args: any) {
+  const ref = taskDocRef(args.workspaceId, args.projectId, args.taskId);
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error("Task not found");
+  return { taskRef: ref, taskDoc: doc };
+}
+
+async function resolveWorklogRef(args: any) {
+  const taskRef = taskDocRef(args.workspaceId, args.projectId, args.taskId);
+  const ref = taskRef.collection("worklogs").doc(args.worklogId);
+  const doc = await ref.get();
+  if (!doc.exists) throw new Error("Worklog not found");
+  return { taskRef, worklogRef: ref, worklogDoc: doc };
+}
+
+async function getTaskSubcollection(args: any, colName: string, ascending: boolean) {
+  const snap = await taskDocRef(args.workspaceId, args.projectId, args.taskId).collection(colName).get();
+  const items = snap.docs.map((doc: any) => docJson(doc))
+    .sort((a: any, b: any) => {
+      const diff = new Date(a.$createdAt).getTime() - new Date(b.$createdAt).getTime();
+      return ascending ? diff : -diff;
+    });
+  return textResult(items);
+}
+
+function projRef(wId: string, pId: string) {
+  return adminDb.collection("workspaces").doc(wId).collection("projects").doc(pId);
+}
+function tasksCol(wId: string, pId: string) { return projRef(wId, pId).collection("tasks"); }
+function taskDocRef(wId: string, pId: string, taskId: string) { return tasksCol(wId, pId).doc(taskId); }
+function sprintsCol(wId: string, pId: string) { return projRef(wId, pId).collection("sprints"); }
+function versionsCol(wId: string, pId: string) { return projRef(wId, pId).collection("versions"); }
+
+function computeAnalytics(allTasks: any[], userId: string) {
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+  const lastMonthStart = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString();
+
+  const thisTasks = allTasks.filter((t) => t.$createdAt >= thisMonthStart);
+  const lastTasks = allTasks.filter((t) => t.$createdAt >= lastMonthStart && t.$createdAt < thisMonthStart);
+
+  const metrics = (tasks: any[]) => ({
+    taskCount: tasks.length,
+    assignedTaskCount: tasks.filter((t) => t.assigneeId === userId).length,
+    incompleteTaskCount: tasks.filter((t) => t.status !== TaskStatus.DONE).length,
+    completedTaskCount: tasks.filter((t) => t.status === TaskStatus.DONE).length,
+    overdueTaskCount: tasks.filter((t) => t.dueDate && t.dueDate < nowIso && t.status !== TaskStatus.DONE).length,
+  });
+
+  const thisM = metrics(thisTasks);
+  const lastM = metrics(lastTasks);
+  return Object.fromEntries(
+    (Object.keys(thisM) as (keyof typeof thisM)[]).map((key) => [
+      key,
+      { value: thisM[key], difference: thisM[key] - lastM[key] },
+    ])
+  );
+}
+
 const handler = globalForMcp.mcpHandler || createMcpHandler(
   (server) => {
     server.registerTool(
@@ -236,33 +404,34 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const highestPositionSnapshot = await adminDb
-          .collection("workspaces")
-          .doc(args.workspaceId)
-          .collection("projects")
-          .doc(args.projectId)
-          .collection("tasks")
+        const col = tasksCol(args.workspaceId, args.projectId);
+
+        const highestPositionSnapshot = await col
           .orderBy("position", "desc")
           .limit(1)
           .get();
 
         const highestPositionTask = highestPositionSnapshot.docs[0]?.data();
-
         const newPosition = highestPositionTask ? highestPositionTask.position + 1000 : 1000;
 
-        const taskRef = await adminDb
-          .collection("workspaces")
-          .doc(args.workspaceId)
-          .collection("projects")
-          .doc(args.projectId)
-          .collection("tasks")
-          .add({
-            ...args,
-            position: newPosition,
-            $createdAt: new Date().toISOString(),
-          });
+        const idPrefix = (() => {
+          switch (args.issueType) {
+            case IssueType.EPIC: return ID_PREFIX.EPIC;
+            case IssueType.STORY: return ID_PREFIX.STORY;
+            case IssueType.BUG: return ID_PREFIX.BUG;
+            default: return ID_PREFIX.SPIKE;
+          }
+        })();
+        const newTaskId = generatePrefixedId(idPrefix);
+
+        const taskRef = col.doc(newTaskId);
+        await taskRef.set({
+          ...args,
+          position: newPosition,
+          $createdAt: new Date().toISOString(),
+        });
         const taskDoc = await taskRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: taskDoc.id, ...taskDoc.data() }, null, 2) }] };
+        return textResult(docJson(taskDoc));
       }
     );
 
@@ -299,14 +468,8 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
         const allTasks: any[] = [];
         for (const pId of projectIds) {
           if (args.projectId && pId !== args.projectId) continue;
-          const tasksSnapshot = await adminDb
-            .collection("workspaces")
-            .doc(args.workspaceId)
-            .collection("projects")
-            .doc(pId)
-            .collection("tasks")
-            .get();
-          allTasks.push(...tasksSnapshot.docs.map((doc: any) => ({ $id: doc.id, ...doc.data() })));
+          const tasksSnapshot = await tasksCol(args.workspaceId, pId).get();
+          allTasks.push(...tasksSnapshot.docs.map((doc: any) => (docJson(doc))));
         }
 
         let tasks = allTasks;
@@ -332,7 +495,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
           tasks = tasks.filter((task: any) => task.name.toLowerCase().includes(lowerSearch));
         }
 
-        return { content: [{ type: "text" as const, text: JSON.stringify(tasks.slice(0, 100), null, 2) }] };
+        return textResult(tasks.slice(0, 100));
       }
     );
 
@@ -346,14 +509,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       async (args: any) => {
         const { workspaceId, projectId, taskId, ...updates } = args;
         await verifyWorkspaceAccess(workspaceId);
-
-        const taskRef = adminDb.collection("workspaces").doc(workspaceId).collection("projects").doc(projectId).collection("tasks").doc(taskId);
-        const taskDoc = await taskRef.get();
-        if (!taskDoc.exists) throw new Error("Task not found");
-
-        await taskRef.update(updates);
-        const updatedTaskDoc = await taskRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updatedTaskDoc.id, ...updatedTaskDoc.data() }, null, 2) }] };
+        return updateDocFields(taskDocRef(workspaceId, projectId, taskId), updates, "Task");
       }
     );
 
@@ -370,12 +526,9 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const taskRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("tasks").doc(args.taskId);
-        const taskDoc = await taskRef.get();
-        if (!taskDoc.exists) throw new Error("Task not found");
-
+        const { taskRef } = await resolveTaskRef(args);
         await taskRef.delete();
-        return { content: [{ type: "text" as const, text: `Ticket ${args.taskId} deleted successfully` }] };
+        return textResult(`Ticket ${args.taskId} deleted successfully`);
       }
     );
 
@@ -395,9 +548,9 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
         for (const wId of workspaceIds) {
           // Only get the workspace itself
           const wDoc = await adminDb.collection("workspaces").doc(wId).get();
-          if (wDoc.exists) workspaces.push({ $id: wDoc.id, ...wDoc.data() });
+          if (wDoc.exists) workspaces.push(docJson(wDoc));
         }
-        return { content: [{ type: "text" as const, text: JSON.stringify(workspaces, null, 2) }] };
+        return textResult(workspaces);
       }
     );
 
@@ -412,13 +565,9 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const snapshot = await adminDb.collection("workspaces")
-          .doc(args.workspaceId)
-          .collection("projects")
-          .limit(100)
-          .get();
-        const projects = snapshot.docs.map((doc: any) => ({ $id: doc.id, ...doc.data() }));
-        return { content: [{ type: "text" as const, text: JSON.stringify(projects, null, 2) }] };
+        const snapshot = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").limit(100).get();
+        const projects = snapshot.docs.map((doc: any) => (docJson(doc)));
+        return textResult(projects);
       }
     );
 
@@ -437,8 +586,8 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
           .where("workspaceId", "==", args.workspaceId)
           .limit(100)
           .get();
-        const members = snapshot.docs.map((doc: any) => ({ $id: doc.id, ...doc.data() }));
-        return { content: [{ type: "text" as const, text: JSON.stringify(members, null, 2) }] };
+        const members = snapshot.docs.map((doc: any) => (docJson(doc)));
+        return textResult(members);
       }
     );
 
@@ -469,7 +618,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
           $createdAt: new Date().toISOString(),
         });
         const doc = await workspaceRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: doc.id, ...doc.data() }, null, 2) }] };
+        return textResult(docJson(doc));
       }
     );
 
@@ -487,11 +636,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       async (args: any) => {
         const { workspaceId, imageUrl, ...updates } = args;
         await verifyWorkspaceAccess(workspaceId);
-        const resolvedImageUrl = await resolveImageUrl(imageUrl, getMcpUserId());
-        const finalUpdates = resolvedImageUrl ? { ...updates, imageUrl: resolvedImageUrl } : updates;
-        await adminDb.collection("workspaces").doc(workspaceId).update(finalUpdates);
-        const doc = await adminDb.collection("workspaces").doc(workspaceId).get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: doc.id, ...doc.data() }, null, 2) }] };
+        return applyWithResolvedImage(adminDb.collection("workspaces").doc(workspaceId), updates, imageUrl, getMcpUserId());
       }
     );
 
@@ -520,7 +665,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
 
         // 2. Recursively delete the workspace and its projects/tasks
         await adminDb.recursiveDelete(adminDb.collection("workspaces").doc(args.workspaceId));
-        return { content: [{ type: "text" as const, text: `Workspace ${args.workspaceId} deleted successfully` }] };
+        return textResult(`Workspace ${args.workspaceId} deleted successfully`);
       }
     );
 
@@ -539,18 +684,14 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
         await verifyWorkspaceAccess(args.workspaceId);
         const userId = getMcpUserId();
         const imageUrl = await resolveImageUrl(args.imageUrl, userId);
-        const projectRef = await adminDb
-          .collection("workspaces")
-          .doc(args.workspaceId)
-          .collection("projects")
-          .add({
+        const projectRef = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").add({
             name: args.name,
             workspaceId: args.workspaceId,
             imageUrl,
             $createdAt: new Date().toISOString(),
           });
         const doc = await projectRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: doc.id, ...doc.data() }, null, 2) }] };
+        return textResult(docJson(doc));
       }
     );
 
@@ -568,26 +709,9 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       async (args: any) => {
         const { projectId, imageUrl, ...updates } = args;
         const userId = getMcpUserId();
-        const membersSnapshot = await adminDb.collection("members").where("userId", "==", userId).get();
-        const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
-
-        let projectDoc = null;
-        for (const wId of workspaceIds) {
-          const pDoc = await adminDb.collection("workspaces").doc(wId).collection("projects").doc(projectId).get();
-          if (pDoc.exists) {
-            projectDoc = pDoc;
-            break;
-          }
-        }
-
-        if (!projectDoc) throw new Error("Project not found");
-        await verifyWorkspaceAccess(projectDoc.data()!.workspaceId);
-
-        const resolvedImageUrl = await resolveImageUrl(imageUrl, userId);
-        const finalUpdates = resolvedImageUrl ? { ...updates, imageUrl: resolvedImageUrl } : updates;
-        await projectDoc.ref.update(finalUpdates);
-        const updatedDoc = await projectDoc.ref.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updatedDoc.id, ...updatedDoc.data() }, null, 2) }] };
+        const { projectDoc, workspaceId } = await findProjectAcrossWorkspaces(projectId, userId);
+        await verifyWorkspaceAccess(workspaceId);
+        return applyWithResolvedImage(projectDoc.ref, updates, imageUrl, userId);
       }
     );
 
@@ -602,23 +726,10 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         const userId = getMcpUserId();
-        const membersSnapshot = await adminDb.collection("members").where("userId", "==", userId).get();
-        const workspaceIds = membersSnapshot.docs.map((doc: any) => doc.data().workspaceId);
-
-        let projectDoc = null;
-        for (const wId of workspaceIds) {
-          const pDoc = await adminDb.collection("workspaces").doc(wId).collection("projects").doc(args.projectId).get();
-          if (pDoc.exists) {
-            projectDoc = pDoc;
-            break;
-          }
-        }
-
-        if (!projectDoc) throw new Error("Project not found");
-        await verifyWorkspaceAccess(projectDoc.data()!.workspaceId);
-
+        const { projectDoc, workspaceId } = await findProjectAcrossWorkspaces(args.projectId, userId);
+        await verifyWorkspaceAccess(workspaceId);
         await adminDb.recursiveDelete(projectDoc.ref);
-        return { content: [{ type: "text" as const, text: `Project ${args.projectId} deleted successfully` }] };
+        return textResult(`Project ${args.projectId} deleted successfully`);
       }
     );
 
@@ -636,14 +747,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const projectsSnapshot = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").get();
-        const allSprints: any[] = [];
-        for (const pDoc of projectsSnapshot.docs) {
-          if (args.projectId && pDoc.id !== args.projectId) continue;
-          const sprintsSnapshot = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(pDoc.id).collection("sprints").get();
-          allSprints.push(...sprintsSnapshot.docs.map((doc: any) => ({ $id: doc.id, ...doc.data() })));
-        }
-        return { content: [{ type: "text" as const, text: JSON.stringify(allSprints, null, 2) }] };
+        return listByProject(args.workspaceId, args.projectId, sprintsCol);
       }
     );
 
@@ -663,7 +767,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const sprintRef = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("sprints").add({
+        const sprintRef = await sprintsCol(args.workspaceId, args.projectId).add({
           name: args.name,
           goal: args.goal || null,
           startDate: args.startDate || null,
@@ -674,7 +778,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
           $createdAt: new Date().toISOString(),
         });
         const doc = await sprintRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: doc.id, ...doc.data() }, null, 2) }] };
+        return textResult(docJson(doc));
       }
     );
 
@@ -696,12 +800,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       async (args: any) => {
         const { workspaceId, projectId, sprintId, ...updates } = args;
         await verifyWorkspaceAccess(workspaceId);
-        const sprintRef = adminDb.collection("workspaces").doc(workspaceId).collection("projects").doc(projectId).collection("sprints").doc(sprintId);
-        const sprintDoc = await sprintRef.get();
-        if (!sprintDoc.exists) throw new Error("Sprint not found");
-        await sprintRef.update(updates);
-        const updated = await sprintRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updated.id, ...updated.data() }, null, 2) }] };
+        return updateDocFields(sprintsCol(workspaceId, projectId).doc(sprintId), updates, "Sprint");
       }
     );
 
@@ -718,12 +817,16 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const sprintRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("sprints").doc(args.sprintId);
-        const sprintDoc = await sprintRef.get();
-        if (!sprintDoc.exists) throw new Error("Sprint not found");
+        const { sprintRef } = await resolveSprintRef(args);
+        const allSprintsSnap = await sprintsCol(args.workspaceId, args.projectId).get();
+        const alreadyActive = allSprintsSnap.docs.find(
+          (doc) => doc.id !== args.sprintId && doc.data().status === SprintStatus.ACTIVE
+        );
+        if (alreadyActive) throw new Error("Another sprint is already active in this project");
+
         await sprintRef.update({ status: SprintStatus.ACTIVE });
         const updated = await sprintRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updated.id, ...updated.data() }, null, 2) }] };
+        return textResult(docJson(updated));
       }
     );
 
@@ -740,11 +843,8 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const sprintRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("sprints").doc(args.sprintId);
-        const sprintDoc = await sprintRef.get();
-        if (!sprintDoc.exists) throw new Error("Sprint not found");
-
-        const sprintTasks = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("tasks")
+        const { sprintRef } = await resolveSprintRef(args);
+        const sprintTasks = await tasksCol(args.workspaceId, args.projectId)
           .where("sprintId", "==", args.sprintId)
           .get();
 
@@ -758,7 +858,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
         await batch.commit();
 
         const updated = await sprintRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updated.id, ...updated.data() }, null, 2) }] };
+        return textResult(docJson(updated));
       }
     );
 
@@ -775,22 +875,10 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const sprintRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("sprints").doc(args.sprintId);
-        const sprintDoc = await sprintRef.get();
-        if (!sprintDoc.exists) throw new Error("Sprint not found");
+        const { sprintRef, sprintDoc } = await resolveSprintRef(args);
         if (sprintDoc.data()!.status !== SprintStatus.PLANNED) throw new Error("Only PLANNED sprints can be deleted");
-
-        const affectedTasks = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("tasks")
-          .where("sprintId", "==", args.sprintId)
-          .get();
-
-        const batch = adminDb.batch();
-        affectedTasks.docs.forEach((doc: any) => {
-          batch.update(doc.ref, { sprintId: null });
-        });
-        batch.delete(sprintRef);
-        await batch.commit();
-        return { content: [{ type: "text" as const, text: `Sprint ${args.sprintId} deleted successfully` }] };
+        await batchClearFieldAndDelete(sprintRef, tasksCol(args.workspaceId, args.projectId).where("sprintId", "==", args.sprintId), "sprintId");
+        return textResult(`Sprint ${args.sprintId} deleted successfully`);
       }
     );
 
@@ -808,14 +896,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const projectsSnapshot = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").get();
-        const allVersions: any[] = [];
-        for (const pDoc of projectsSnapshot.docs) {
-          if (args.projectId && pDoc.id !== args.projectId) continue;
-          const versionsSnapshot = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(pDoc.id).collection("versions").get();
-          allVersions.push(...versionsSnapshot.docs.map((doc: any) => ({ $id: doc.id, ...doc.data() })));
-        }
-        return { content: [{ type: "text" as const, text: JSON.stringify(allVersions, null, 2) }] };
+        return listByProject(args.workspaceId, args.projectId, versionsCol);
       }
     );
 
@@ -835,7 +916,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const versionRef = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("versions").add({
+        const versionRef = await versionsCol(args.workspaceId, args.projectId).add({
           name: args.name,
           description: args.description || null,
           startDate: args.startDate || null,
@@ -846,7 +927,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
           $createdAt: new Date().toISOString(),
         });
         const doc = await versionRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: doc.id, ...doc.data() }, null, 2) }] };
+        return textResult(docJson(doc));
       }
     );
 
@@ -868,12 +949,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       async (args: any) => {
         const { workspaceId, projectId, versionId, ...updates } = args;
         await verifyWorkspaceAccess(workspaceId);
-        const versionRef = adminDb.collection("workspaces").doc(workspaceId).collection("projects").doc(projectId).collection("versions").doc(versionId);
-        const versionDoc = await versionRef.get();
-        if (!versionDoc.exists) throw new Error("Version not found");
-        await versionRef.update(updates);
-        const updated = await versionRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updated.id, ...updated.data() }, null, 2) }] };
+        return updateDocFields(versionsCol(workspaceId, projectId).doc(versionId), updates, "Version");
       }
     );
 
@@ -890,12 +966,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const versionRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("versions").doc(args.versionId);
-        const versionDoc = await versionRef.get();
-        if (!versionDoc.exists) throw new Error("Version not found");
-        await versionRef.update({ status: VersionStatus.RELEASED });
-        const updated = await versionRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updated.id, ...updated.data() }, null, 2) }] };
+        return setDocStatus(versionsCol(args.workspaceId, args.projectId).doc(args.versionId), VersionStatus.RELEASED, "Version");
       }
     );
 
@@ -912,12 +983,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const versionRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("versions").doc(args.versionId);
-        const versionDoc = await versionRef.get();
-        if (!versionDoc.exists) throw new Error("Version not found");
-        await versionRef.update({ status: VersionStatus.ARCHIVED });
-        const updated = await versionRef.get();
-        return { content: [{ type: "text" as const, text: JSON.stringify({ $id: updated.id, ...updated.data() }, null, 2) }] };
+        return setDocStatus(versionsCol(args.workspaceId, args.projectId).doc(args.versionId), VersionStatus.ARCHIVED, "Version");
       }
     );
 
@@ -934,22 +1000,481 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
       },
       async (args: any) => {
         await verifyWorkspaceAccess(args.workspaceId);
-        const versionRef = adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("versions").doc(args.versionId);
+        const versionRef = versionsCol(args.workspaceId, args.projectId).doc(args.versionId);
         const versionDoc = await versionRef.get();
         if (!versionDoc.exists) throw new Error("Version not found");
+        await batchClearFieldAndDelete(versionRef, tasksCol(args.workspaceId, args.projectId).where("fixVersionId", "==", args.versionId), "fixVersionId");
+        return textResult(`Version ${args.versionId} deleted successfully`);
+      }
+    );
 
-        const affectedTasks = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").doc(args.projectId).collection("tasks")
-          .where("fixVersionId", "==", args.versionId)
-          .get();
+    // ── Worklog / Time Tracking Tools ────────────────────────────────────────
 
-        const batch = adminDb.batch();
-        affectedTasks.docs.forEach((doc: any) => {
-          batch.update(doc.ref, { fixVersionId: null });
+    server.registerTool(
+      "get_worklogs",
+      {
+        title: "Get Worklogs",
+        description: "List work log entries for a task",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        return getTaskSubcollection(args, "worklogs", false);
+      }
+    );
+
+    server.registerTool(
+      "log_work",
+      {
+        title: "Log Work",
+        description: "Log time spent on a task. Updates the task's timeSpent and remainingEstimate automatically.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          timeSpent: z.number().positive().describe("Time spent in minutes"),
+          date: z.string().describe("ISO date string for when work was done"),
+          description: z.string().optional().describe("What was worked on"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const userId = getMcpUserId();
+        const { taskRef, taskDoc } = await resolveTaskRef(args);
+        const worklogRef = await taskRef.collection("worklogs").add({
+          timeSpent: args.timeSpent,
+          date: args.date,
+          description: args.description || null,
+          userId,
+          workspaceId: args.workspaceId,
+          projectId: args.projectId,
+          $createdAt: new Date().toISOString(),
         });
-        batch.delete(versionRef);
-        await batch.commit();
 
-        return { content: [{ type: "text" as const, text: `Version ${args.versionId} deleted successfully` }] };
+        const task = taskDoc.data()!;
+        const currentTimeSpent = task.timeSpent || 0;
+        const currentRemaining = task.remainingEstimate ?? task.originalEstimate ?? null;
+        const updates: Record<string, unknown> = { timeSpent: currentTimeSpent + args.timeSpent };
+        if (currentRemaining !== null) {
+          updates.remainingEstimate = Math.max(0, currentRemaining - args.timeSpent);
+        }
+        await taskRef.update(updates);
+
+        const worklogDoc = await worklogRef.get();
+        return textResult(docJson(worklogDoc));
+      }
+    );
+
+    server.registerTool(
+      "update_worklog",
+      {
+        title: "Update Worklog",
+        description: "Edit an existing work log entry (time spent or description). Adjusts the task's timeSpent accordingly.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          worklogId: z.string(),
+          timeSpent: z.number().positive().optional().describe("Updated time spent in minutes"),
+          description: z.string().optional().describe("Updated description"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const { taskRef, worklogRef, worklogDoc } = await resolveWorklogRef(args);
+        const oldTimeSpent = worklogDoc.data()!.timeSpent || 0;
+        const updates: Record<string, unknown> = {};
+        if (args.description !== undefined) updates.description = args.description;
+
+        if (args.timeSpent !== undefined) {
+          updates.timeSpent = args.timeSpent;
+          const taskDoc = await taskRef.get();
+          if (taskDoc.exists) {
+            const diff = args.timeSpent - oldTimeSpent;
+            await taskRef.update({ timeSpent: Math.max(0, (taskDoc.data()!.timeSpent || 0) + diff) });
+          }
+        }
+
+        await worklogRef.update(updates);
+        return textResult(docJson(await worklogRef.get()));
+      }
+    );
+
+    server.registerTool(
+      "delete_worklog",
+      {
+        title: "Delete Worklog",
+        description: "Delete a work log entry and reverse its time contribution from the task",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          worklogId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const { taskRef, worklogRef, worklogDoc } = await resolveWorklogRef(args);
+        const timeSpent = worklogDoc.data()!.timeSpent || 0;
+        const taskDoc = await taskRef.get();
+        if (taskDoc.exists) {
+          await taskRef.update({ timeSpent: Math.max(0, (taskDoc.data()!.timeSpent || 0) - timeSpent) });
+        }
+        await worklogRef.delete();
+        return textResult(`Worklog ${args.worklogId} deleted successfully`);
+      }
+    );
+
+    // ── Comment Tools ─────────────────────────────────────────────────────────
+
+    server.registerTool(
+      "get_comments",
+      {
+        title: "Get Comments",
+        description: "List comments on a task",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        return getTaskSubcollection(args, "comments", true);
+      }
+    );
+
+    server.registerTool(
+      "add_comment",
+      {
+        title: "Add Comment",
+        description: "Add a comment to a task",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          content: z.string().describe("The comment text"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const userId = getMcpUserId();
+        const { taskRef } = await resolveTaskRef(args);
+        const commentRef = await taskRef.collection("comments").add({
+          content: args.content,
+          authorId: userId,
+          workspaceId: args.workspaceId,
+          projectId: args.projectId,
+          $createdAt: new Date().toISOString(),
+        });
+        const commentDoc = await commentRef.get();
+        return textResult(docJson(commentDoc));
+      }
+    );
+
+    server.registerTool(
+      "update_comment",
+      {
+        title: "Update Comment",
+        description: "Edit the content of an existing comment (only the comment author can edit)",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          commentId: z.string(),
+          content: z.string().describe("The updated comment text"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const commentRef = await resolveCommentRef(args, getMcpUserId(), "edit it");
+        await commentRef.update({ content: args.content, updatedAt: new Date().toISOString() });
+        return textResult(docJson(await commentRef.get()));
+      }
+    );
+
+    server.registerTool(
+      "delete_comment",
+      {
+        title: "Delete Comment",
+        description: "Delete a comment from a task (only the comment author can delete)",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          commentId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const commentRef = await resolveCommentRef(args, getMcpUserId(), "delete it");
+        await commentRef.delete();
+        return textResult(`Comment ${args.commentId} deleted successfully`);
+      }
+    );
+
+    // ── Task Link Tools ───────────────────────────────────────────────────────
+
+    server.registerTool(
+      "get_task_links",
+      {
+        title: "Get Task Links",
+        description: "List links (relationships) for a task",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const snapshot = await taskDocRef(args.workspaceId, args.projectId, args.taskId)
+          .collection("links").get();
+        const links = snapshot.docs.map((doc: any) => (docJson(doc)));
+        return textResult(links);
+      }
+    );
+
+    server.registerTool(
+      "add_task_link",
+      {
+        title: "Add Task Link",
+        description: "Link two tasks together with a relationship type (e.g. 'blocks', 'is blocked by', 'relates to', 'duplicates')",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          targetTaskId: z.string().describe("ID of the task to link to"),
+          type: z.string().describe("Relationship type, e.g. 'blocks', 'is blocked by', 'relates to', 'duplicates'"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        if (args.taskId === args.targetTaskId) throw new Error("Cannot link a task to itself");
+        const userId = getMcpUserId();
+        const { taskRef } = await resolveTaskRef(args);
+        const existingLinks = await taskRef.collection("links").get();
+        const duplicate = existingLinks.docs.find(
+          (doc) => doc.data().targetTaskId === args.targetTaskId && doc.data().type === args.type
+        );
+        if (duplicate) throw new Error("This link already exists");
+
+        const linkRef = await taskRef.collection("links").add({
+          targetTaskId: args.targetTaskId,
+          type: args.type,
+          createdBy: userId,
+          workspaceId: args.workspaceId,
+          projectId: args.projectId,
+          $createdAt: new Date().toISOString(),
+        });
+        const linkDoc = await linkRef.get();
+        return textResult(docJson(linkDoc));
+      }
+    );
+
+    server.registerTool(
+      "delete_task_link",
+      {
+        title: "Delete Task Link",
+        description: "Remove a link between tasks",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          taskId: z.string(),
+          linkId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const linkRef = taskDocRef(args.workspaceId, args.projectId, args.taskId)
+          .collection("links").doc(args.linkId);
+        const linkDoc = await linkRef.get();
+        if (!linkDoc.exists) throw new Error("Link not found");
+        await linkRef.delete();
+        return textResult(`Link ${args.linkId} deleted successfully`);
+      }
+    );
+
+    // ── Analytics Tools ───────────────────────────────────────────────────────
+
+    server.registerTool(
+      "get_workspace_analytics",
+      {
+        title: "Get Workspace Analytics",
+        description: "Get task metrics for a workspace: total, assigned, incomplete, completed, and overdue counts with month-over-month differences",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const userId = getMcpUserId();
+        const projectsSnap = await adminDb.collection("workspaces").doc(args.workspaceId).collection("projects").get();
+        const allTasks: any[] = [];
+        for (const pDoc of projectsSnap.docs) {
+          const tasksSnap = await tasksCol(args.workspaceId, pDoc.id).get();
+          allTasks.push(...tasksSnap.docs.map((d: any) => d.data()));
+        }
+        return textResult(computeAnalytics(allTasks, userId));
+      }
+    );
+
+    server.registerTool(
+      "get_project_analytics",
+      {
+        title: "Get Project Analytics",
+        description: "Get task metrics for a specific project with month-over-month differences",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const userId = getMcpUserId();
+        const tasksSnap = await tasksCol(args.workspaceId, args.projectId).get();
+        const allTasks = tasksSnap.docs.map((d: any) => d.data());
+        return textResult(computeAnalytics(allTasks, userId));
+      }
+    );
+
+    // ── Member Management Tools ───────────────────────────────────────────────
+
+    server.registerTool(
+      "update_member",
+      {
+        title: "Update Member",
+        description: "Update a workspace member's role (ADMIN or MEMBER). Requires admin role.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          memberId: z.string().describe("The member document ID"),
+          role: z.enum([MemberRole.ADMIN, MemberRole.MEMBER]),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const userId = getMcpUserId();
+        const role = await getCallerWorkspaceRole(args.workspaceId, userId);
+        if (role !== MemberRole.ADMIN) throw new Error("Only workspace admins can update member roles");
+        const { memberRef } = await resolveWorkspaceMember(args.workspaceId, args.memberId);
+        await memberRef.update({ role: args.role });
+        return textResult(docJson(await memberRef.get()));
+      }
+    );
+
+    server.registerTool(
+      "remove_member",
+      {
+        title: "Remove Member",
+        description: "Remove a member from a workspace. Admins can remove anyone; members can only remove themselves.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          memberId: z.string().describe("The member document ID to remove"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const userId = getMcpUserId();
+        const { memberRef, memberDoc } = await resolveWorkspaceMember(args.workspaceId, args.memberId);
+        const callerRole = await getCallerWorkspaceRole(args.workspaceId, userId);
+        const isSelf = memberDoc.data()!.userId === userId;
+        if (callerRole !== MemberRole.ADMIN && !isSelf) throw new Error("Only admins can remove other members");
+        const allMembers = await adminDb.collection("members").where("workspaceId", "==", args.workspaceId).get();
+        if (allMembers.size <= 1) throw new Error("Cannot remove the only member of a workspace");
+        await memberRef.delete();
+        return textResult(`Member ${args.memberId} removed from workspace successfully`);
+      }
+    );
+
+    // ── Project Member Tools ──────────────────────────────────────────────────
+
+    server.registerTool(
+      "add_project_member",
+      {
+        title: "Add Project Member",
+        description: "Add a workspace member to a specific project with a given role. The user must already be a member of the workspace. Requires project admin or workspace admin role.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          userId: z.string().describe("The userId of the workspace member to add"),
+          role: z.enum([MemberRole.ADMIN, MemberRole.MEMBER]).describe("Role within the project"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const callerId = getMcpUserId();
+        const projectRef = await resolveProjectRef(args.workspaceId, args.projectId);
+
+        await verifyProjectAdminAccess(args.workspaceId, projectRef, callerId, "add project members");
+
+        const targetRole = await getCallerWorkspaceRole(args.workspaceId, args.userId);
+        if (!targetRole) throw new Error("User is not a member of this workspace");
+
+        const memberRef = projectRef.collection("members").doc(args.userId);
+        if ((await memberRef.get()).exists) throw new Error("User is already a member of this project");
+
+        await memberRef.set({ userId: args.userId, role: args.role, $createdAt: new Date().toISOString() });
+        return textResult({ userId: args.userId, role: args.role });
+      }
+    );
+
+    server.registerTool(
+      "update_project_member",
+      {
+        title: "Update Project Member",
+        description: "Update a project member's role. Requires project admin or workspace admin role.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          userId: z.string().describe("The userId of the project member to update"),
+          role: z.enum([MemberRole.ADMIN, MemberRole.MEMBER]),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const callerId = getMcpUserId();
+        const projectRef = await resolveProjectRef(args.workspaceId, args.projectId);
+
+        await verifyProjectAdminAccess(args.workspaceId, projectRef, callerId, "update project member roles");
+
+        const memberRef = projectRef.collection("members").doc(args.userId);
+        if (!(await memberRef.get()).exists) throw new Error("User is not a member of this project");
+
+        await memberRef.update({ role: args.role });
+        const updated = await memberRef.get();
+        return textResult(docJson(updated));
+      }
+    );
+
+    server.registerTool(
+      "remove_project_member",
+      {
+        title: "Remove Project Member",
+        description: "Remove a member from a project. Workspace admins and project admins can remove anyone; members can remove themselves.",
+        inputSchema: z.object({
+          workspaceId: z.string(),
+          projectId: z.string(),
+          userId: z.string().describe("The userId of the project member to remove"),
+        }) as any,
+      },
+      async (args: any) => {
+        await verifyWorkspaceAccess(args.workspaceId);
+        const callerId = getMcpUserId();
+        const projectRef = await resolveProjectRef(args.workspaceId, args.projectId);
+
+        if (callerId !== args.userId) {
+          await verifyProjectAdminAccess(args.workspaceId, projectRef, callerId, "remove other project members");
+        }
+
+        const memberRef = projectRef.collection("members").doc(args.userId);
+        if (!(await memberRef.get()).exists) throw new Error("User is not a member of this project");
+
+        await memberRef.delete();
+        return textResult(`User ${args.userId} removed from project ${args.projectId} successfully`);
       }
     );
 

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -11,12 +11,13 @@ import { useState } from "react";
 import { ChevronDown, Plus, List, Timer, Rocket, Target, BookOpen, Bug, Zap } from "lucide-react";
 import { useCreateTaskModal } from "@/features/tasks/hooks/use-create-task-modal";
 import { useCreateSprintModal } from "@/features/sprints/hooks/use-create-sprint-modal";
+import { useCreateVersionModal } from "@/features/versions/hooks/use-create-version-modal";
 import { IssueType } from "@/features/tasks/types";
 
 const subItems = [
 	{ label: "Backlog", icon: List, color: "text-blue-600", bg: "bg-blue-50 dark:bg-blue-950", hrefSuffix: "/backlog", issueType: undefined, modalType: "task" as const },
 	{ label: "Sprints", icon: Timer, color: "text-green-600", bg: "bg-green-50 dark:bg-green-950", hrefSuffix: "/sprints", issueType: undefined, modalType: "sprint" as const },
-	{ label: "Releases", icon: Rocket, color: "text-purple-600", bg: "bg-purple-50 dark:bg-purple-950", hrefSuffix: "/releases", issueType: undefined, modalType: "task" as const },
+	{ label: "Releases", icon: Rocket, color: "text-purple-600", bg: "bg-purple-50 dark:bg-purple-950", hrefSuffix: "/releases", issueType: undefined, modalType: "release" as const },
 	{ label: "Epics", icon: Target, color: "text-amber-600", bg: "bg-amber-50 dark:bg-amber-950", hrefSuffix: "/epics", issueType: "EPIC" as IssueType, modalType: "task" as const },
 	{ label: "Stories", icon: BookOpen, color: "text-emerald-600", bg: "bg-emerald-50 dark:bg-emerald-950", hrefSuffix: "/stories", issueType: "STORY" as IssueType, modalType: "task" as const },
 	{ label: "Spikes", icon: Zap, color: "text-yellow-600", bg: "bg-yellow-50 dark:bg-yellow-950", hrefSuffix: "/spikes", issueType: "SPIKE" as IssueType, modalType: "task" as const },
@@ -31,7 +32,7 @@ interface SubItemProps {
 	href: string;
 	projectId: string;
 	issueType?: IssueType;
-	modalType: "task" | "sprint";
+	modalType: "task" | "sprint" | "release";
 }
 
 const SubItem = ({ label, icon: Icon, color, bg, href, projectId, issueType, modalType }: SubItemProps) => {
@@ -39,12 +40,15 @@ const SubItem = ({ label, icon: Icon, color, bg, href, projectId, issueType, mod
 	const isActive = pathname === href;
 	const { open: openTaskModal } = useCreateTaskModal();
 	const { open: openSprintModal } = useCreateSprintModal();
+	const { open: openVersionModal } = useCreateVersionModal();
 
 	const handleCreate = (e: React.MouseEvent) => {
 		e.preventDefault();
 		e.stopPropagation();
 		if (modalType === "sprint") {
 			openSprintModal({ projectId });
+		} else if (modalType === "release") {
+			openVersionModal({ projectId });
 		} else {
 			openTaskModal({ projectId, issueType });
 		}
@@ -54,25 +58,26 @@ const SubItem = ({ label, icon: Icon, color, bg, href, projectId, issueType, mod
 		<div className="relative group">
 			<Link href={href} className="block">
 				<div className={cn(
-					"flex items-center justify-between p-2.5 rounded-xl transition-all",
+					"flex items-center justify-between p-1.5 rounded-lg transition-all",
 					isActive
 						? "bg-background border border-border text-foreground shadow-sm"
 						: "hover:bg-background hover:border-border hover:shadow-sm border border-transparent"
 				)}>
-					<div className="flex items-center gap-x-3">
-						<div className={cn("p-2 rounded-lg", bg)}>
-							<Icon className={cn("size-4", color)} />
+					<div className="flex items-center gap-x-2">
+						<div className={cn("p-1.5 rounded-md", bg)}>
+							<Icon className={cn("size-3.5", color)} />
 						</div>
-						<span className="text-sm font-medium tracking-tight">{label}</span>
+						<span className="text-xs font-medium tracking-tight">{label}</span>
 					</div>
 				</div>
 			</Link>
 			<button
 				type="button"
 				onClick={handleCreate}
-				className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-1 hover:bg-muted rounded-full transition-all"
+				aria-label={`Create ${label}`}
+				className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 p-1 hover:bg-muted rounded-full transition-all"
 			>
-				<Plus className="size-4 text-muted-foreground" />
+				<Plus className="size-3 text-muted-foreground" />
 			</button>
 		</div>
 	);
@@ -93,9 +98,17 @@ export const Projects = () => {
 	const toggleExpand = (e: React.MouseEvent, projectId: string) => {
 		e.preventDefault();
 		e.stopPropagation();
-		const isActive = isProjectActive(projectId);
-		const currentlyExpanded = expanded[projectId] !== undefined ? expanded[projectId] : isActive;
-		setExpanded((prev) => ({ ...prev, [projectId]: !currentlyExpanded }));
+		const isCurrentlyExpanded = expanded[projectId] !== undefined ? expanded[projectId] : isProjectActive(projectId);
+		if (isCurrentlyExpanded) {
+			setExpanded((prev) => ({ ...prev, [projectId]: false }));
+		} else {
+			const next: Record<string, boolean> = {};
+			data?.documents.forEach((p) => {
+				if (p.$id !== projectId && !isProjectActive(p.$id)) next[p.$id] = false;
+			});
+			next[projectId] = true;
+			setExpanded((prev) => ({ ...prev, ...next }));
+		}
 	};
 
 	return (
@@ -117,7 +130,7 @@ export const Projects = () => {
 					const isExpanded = expanded[project.$id] !== undefined ? expanded[project.$id] : isActive;
 
 					return (
-						<div key={project.$id} className="flex flex-col gap-y-1">
+						<div key={project.$id} className="flex flex-col gap-y-0.5">
 							<div className="flex items-center justify-between">
 								<Link href={href} className="flex-1">
 									<div
@@ -146,7 +159,7 @@ export const Projects = () => {
 								</button>
 							</div>
 							{isExpanded && (
-								<div className="flex flex-col gap-y-1.5 ml-2 pl-4 border-l border-border">
+								<div className="flex flex-col gap-y-0.5 ml-1 pl-2 border-l border-border">
 									{subItems.map((item) => (
 										<SubItem
 											key={item.label}

--- a/src/features/tasks/components/create-task-form-wrapper.tsx
+++ b/src/features/tasks/components/create-task-form-wrapper.tsx
@@ -66,7 +66,7 @@ export const CreateTaskFormWrapper = ({
 	}));
 
 	const sprintOptions = (sprints?.documents ?? [])
-		.filter((s) => s.status === SprintStatus.PLANNED || s.status === SprintStatus.ACTIVE)
+		.filter((s) => s.status === SprintStatus.ACTIVE)
 		.map((s) => ({ id: s.$id, name: s.name }));
 
 	const versionOptions = (versions?.documents ?? [])

--- a/src/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/src/features/tasks/components/edit-task-form-wrapper.tsx
@@ -75,7 +75,7 @@ export const EditTaskFormWrapper = ({
 		.map((v) => ({ id: v.$id, name: v.name }));
 
 	const sprintOptions = (sprints?.documents ?? [])
-		.filter((s) => s.status === SprintStatus.PLANNED || s.status === SprintStatus.ACTIVE)
+		.filter((s) => s.status === SprintStatus.ACTIVE)
 		.map((s) => ({ id: s.$id, name: s.name }));
 
 	const epicOptions = (epicsData?.documents ?? []).map((e) => ({

--- a/src/features/tasks/components/log-work-modal.tsx
+++ b/src/features/tasks/components/log-work-modal.tsx
@@ -74,8 +74,8 @@ export const LogWorkModal = ({
             <Input
               id="hours"
               type="number"
-              min={0.1}
-              step={0.25}
+              min={0.01}
+              step="any"
               placeholder="e.g. 1.5"
               value={hours}
               onChange={(e) => setHours(e.target.value)}

--- a/src/features/tasks/components/task-form-fields.tsx
+++ b/src/features/tasks/components/task-form-fields.tsx
@@ -37,6 +37,7 @@ const EPIC_SELECTOR_TYPES = new Set([
 	IssueType.SPIKE,
 	IssueType.BUG,
 ]);
+const EPIC_REQUIRED_TYPES = new Set([IssueType.STORY, IssueType.SPIKE, IssueType.BUG]);
 
 interface TaskFormFieldsProps {
 	form: UseFormReturn<z.infer<typeof createTaskSchema>>;
@@ -321,7 +322,7 @@ export const TaskFormFields = ({
 						render={({ field }) => (
 							<FormItem>
 								<FormLabel>
-									Epic{issueType === IssueType.BUG ? " *" : " (optional)"}
+									Epic{issueType && EPIC_REQUIRED_TYPES.has(issueType as IssueType) ? " *" : " (optional)"}
 								</FormLabel>
 								<Select
 									value={field.value ?? undefined}

--- a/src/features/tasks/schemas.ts
+++ b/src/features/tasks/schemas.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { IssueType, LinkType, TaskPriority, TaskStatus } from "./types";
 
 const ACCEPTANCE_CRITERIA_TYPES = new Set([IssueType.EPIC, IssueType.STORY, IssueType.BUG]);
+const EPIC_REQUIRED_TYPES = new Set([IssueType.STORY, IssueType.SPIKE, IssueType.BUG]);
 
 export const taskConditionalRefine = (data: Record<string, unknown>, ctx: z.RefinementCtx, requireRca = false) => {
 	if (data.issueType && ACCEPTANCE_CRITERIA_TYPES.has(data.issueType as IssueType)) {
@@ -13,19 +14,21 @@ export const taskConditionalRefine = (data: Record<string, unknown>, ctx: z.Refi
 			});
 		}
 	}
+	if (data.issueType && EPIC_REQUIRED_TYPES.has(data.issueType as IssueType)) {
+		if (!data.epicId || (typeof data.epicId === "string" && data.epicId.trim() === "")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Epic is required for Stories, Spikes, and Bugs",
+				path: ["epicId"],
+			});
+		}
+	}
 	if (data.issueType === IssueType.BUG) {
 		if (requireRca && (!data.rca || (typeof data.rca === "string" && data.rca.trim() === ""))) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
 				message: "Root Cause Analysis is required for Bugs",
 				path: ["rca"],
-			});
-		}
-		if (!data.epicId || (typeof data.epicId === "string" && data.epicId.trim() === "")) {
-			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
-				message: "Epic is required for Bugs",
-				path: ["epicId"],
 			});
 		}
 	}

--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -171,16 +171,16 @@ const app = new Hono()
 			
 			const assignees = await Promise.all(
 				members.map(async (m) => {
-					let u;
+					let u: { displayName?: string | null; email?: string } = {};
 					try {
 						u = await adminAuth.getUser(m.userId);
 					} catch (e) {
-						u = { displayName: "Unknown User", email: "" };
+						console.error("getUser failed for", m.userId, e);
 					}
 					return {
 						...m,
-						name: u.displayName || u.email,
-						email: u.email,
+						name: u.displayName || u.email || m.userId,
+						email: u.email ?? "",
 					};
 				})
 			);
@@ -253,16 +253,16 @@ const app = new Hono()
 		
 		let assignee = null;
 		if (memberData) {
-			let u;
+			let u: { displayName?: string | null; email?: string } = {};
 			try {
 				u = await adminAuth.getUser(memberData.userId);
 			} catch (e) {
-				u = { displayName: "Unknown", email: "" };
+				console.error("getUser failed for", memberData.userId, e);
 			}
 			assignee = {
 				...memberData,
-				name: u.displayName || u.email,
-				email: u.email,
+				name: u.displayName || u.email || memberData.userId,
+				email: u.email ?? "",
 			};
 		}
 		
@@ -686,9 +686,9 @@ workspaceId,
 
 		const authors = await Promise.all(
 			memberDocs.map(async (m) => {
-				let u;
-				try { u = await adminAuth.getUser(m.userId); } catch { u = { displayName: "Unknown", email: "" }; }
-				return { $id: m.$id, name: u.displayName || u.email, email: u.email };
+				let u: { displayName?: string | null; email?: string } = {};
+				try { u = await adminAuth.getUser(m.userId); } catch (e) { console.error("getUser failed for", m.userId, e); }
+				return { $id: m.$id, name: u.displayName || u.email || m.userId, email: u.email ?? "" };
 			})
 		);
 
@@ -739,15 +739,15 @@ workspaceId,
 			const commentDoc = await commentRef.get();
 			const data = commentDoc.data();
 
-			let u;
-			try { u = await adminAuth.getUser(currentUser.$id); } catch { u = { displayName: "Unknown", email: "" }; }
+			let u: { displayName?: string | null; email?: string } = {};
+			try { u = await adminAuth.getUser(currentUser.$id); } catch (e) { console.error("getUser failed for", currentUser.$id, e); }
 
 			return c.json({
 				data: {
 					...data,
 					$id: commentDoc.id,
 					$createdAt: normalizeDate(data),
-					author: { name: u.displayName || u.email, email: u.email },
+					author: { name: u.displayName || u.email || currentUser.$id, email: u.email ?? "" },
 				} as TaskComment,
 			});
 		}

--- a/src/features/versions/components/create-version-modal.tsx
+++ b/src/features/versions/components/create-version-modal.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ResponsiveModal } from "@/components/responsive-modal";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useCreateVersionModal } from "../hooks/use-create-version-modal";
+import { CreateVersionForm } from "./create-version-form";
+import { usePrefill } from "@/contexts/sidebar-context";
+
+export const CreateVersionModal = () => {
+  const { isOpen, close } = useCreateVersionModal();
+  const workspaceId = useWorkspaceId();
+  const urlProjectId = useProjectId();
+  const { prefill } = usePrefill();
+
+  const projectId = prefill.projectId || urlProjectId;
+
+  return (
+    <ResponsiveModal open={!!isOpen} onOpenChange={close}>
+      <div className="p-4">
+        <h2 className="text-lg font-semibold mb-4">Create Release</h2>
+        <CreateVersionForm
+          workspaceId={workspaceId}
+          projectId={projectId}
+          onCancel={close}
+          onSuccess={close}
+        />
+      </div>
+    </ResponsiveModal>
+  );
+};

--- a/src/features/versions/components/versions-list.tsx
+++ b/src/features/versions/components/versions-list.tsx
@@ -4,34 +4,29 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { DottedSeperator } from "@/components/dotted-seperator";
 import {
-  PlusIcon,
   TrashIcon,
   RocketIcon,
   ArchiveIcon,
   PencilIcon,
   CheckIcon,
   XIcon,
+  CalendarIcon,
 } from "lucide-react";
+import { format } from "date-fns";
 import { useGetVersions } from "../api/use-get-versions";
-import { useCreateVersion } from "../api/use-create-version";
 import { useUpdateVersion } from "../api/use-update-version";
 import { useDeleteVersion } from "../api/use-delete-version";
 import { useReleaseVersion } from "../api/use-release-version";
 import { useArchiveVersion } from "../api/use-archive-version";
 import { Version, VersionStatus } from "../types";
-import { CreateVersionForm } from "./create-version-form";
 
 interface VersionsListProps {
   workspaceId: string;
   projectId: string;
 }
 
-const statusVariant: Record<
-  VersionStatus,
-  "default" | "secondary" | "outline" | "destructive"
-> = {
+const statusVariant: Record<VersionStatus, "default" | "secondary" | "outline" | "destructive"> = {
   [VersionStatus.UNRELEASED]: "default",
   [VersionStatus.RELEASED]: "secondary",
   [VersionStatus.ARCHIVED]: "outline",
@@ -43,8 +38,13 @@ const statusLabel: Record<VersionStatus, string> = {
   [VersionStatus.ARCHIVED]: "Archived",
 };
 
+function formatDate(val: string | null | undefined): string | null {
+  if (!val) return null;
+  const d = new Date(val);
+  return isNaN(d.getTime()) ? null : format(d, "MMM d, yyyy");
+}
+
 export const VersionsList = ({ workspaceId, projectId }: VersionsListProps) => {
-  const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState("");
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -63,179 +63,119 @@ export const VersionsList = ({ workspaceId, projectId }: VersionsListProps) => {
   const saveEdit = (version: Version) => {
     if (!editName.trim()) return;
     updateVersion(
-      {
-        param: { versionId: version.$id },
-        json: { name: editName.trim(), workspaceId, projectId },
-      },
-      {
-        onSuccess: () => {
-          setEditingId(null);
-          setEditName("");
-        },
-      }
+      { param: { versionId: version.$id }, json: { name: editName.trim(), workspaceId, projectId } },
+      { onSuccess: () => { setEditingId(null); setEditName(""); } }
     );
   };
 
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground py-8 text-center">Loading releases...</p>;
+  }
+
+  const versions = (data?.documents as Version[] | undefined) ?? [];
+
+  if (versions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-8 text-center">
+        No releases yet. Create your first release to get started.
+      </p>
+    );
+  }
+
   return (
-    <div className="p-4 border rounded-lg">
-      <div className="flex items-center justify-between">
-        <p className="text-lg font-semibold">Versions / Releases</p>
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={() => setShowCreateForm((v) => !v)}
-        >
-          <PlusIcon className="size-4 mr-1" />
-          Create Version
-        </Button>
-      </div>
-      <DottedSeperator className="my-4" />
+    <div className="flex flex-col gap-y-4">
+      {versions.map((version) => {
+        const startFmt = formatDate(version.startDate);
+        const releaseFmt = formatDate(version.releaseDate);
 
-      {showCreateForm && (
-        <>
-          <CreateVersionForm
-            workspaceId={workspaceId}
-            projectId={projectId}
-            onCancel={() => setShowCreateForm(false)}
-            onSuccess={() => setShowCreateForm(false)}
-          />
-          <DottedSeperator className="my-4" />
-        </>
-      )}
+        return (
+          <div key={version.$id} className="flex flex-col gap-y-2 p-4 border rounded-lg bg-muted/30">
+            <div className="flex items-start justify-between gap-x-4">
+              <div className="flex-1 min-w-0">
+                {editingId === version.$id ? (
+                  <div className="flex items-center gap-x-1">
+                    <Input
+                      className="h-7 text-sm"
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") saveEdit(version);
+                        if (e.key === "Escape") setEditingId(null);
+                      }}
+                      autoFocus
+                    />
+                    <Button size="sm" variant="ghost" className="size-7 p-0" aria-label="Save release name" onClick={() => saveEdit(version)}>
+                      <CheckIcon className="size-3" />
+                    </Button>
+                    <Button size="sm" variant="ghost" className="size-7 p-0" aria-label="Cancel editing release name" onClick={() => setEditingId(null)}>
+                      <XIcon className="size-3" />
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-x-2 flex-wrap">
+                    <h3 className="font-semibold text-base">{version.name}</h3>
+                    <Badge variant={statusVariant[version.status]}>{statusLabel[version.status]}</Badge>
+                  </div>
+                )}
+                {version.description && editingId !== version.$id && (
+                  <p className="text-sm text-muted-foreground mt-1">{version.description}</p>
+                )}
+              </div>
 
-      {isLoading && (
-        <p className="text-sm text-muted-foreground">Loading versions...</p>
-      )}
-      {!isLoading && (!data?.documents || data.documents.length === 0) && (
-        <p className="text-sm text-muted-foreground">No versions yet.</p>
-      )}
-
-      <div className="flex flex-col gap-y-2">
-        {(data?.documents as Version[] | undefined)?.map((version) => (
-          <div
-            key={version.$id}
-            className="flex items-start gap-x-2 p-3 rounded-md border bg-muted/20"
-          >
-            <div className="flex-1 min-w-0">
-              {editingId === version.$id ? (
-                <div className="flex items-center gap-x-1">
-                  <Input
-                    className="h-7 text-sm"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") saveEdit(version);
-                      if (e.key === "Escape") setEditingId(null);
-                    }}
-                    autoFocus
-                  />
+              <div className="flex items-center gap-x-1 shrink-0">
+                {version.status === VersionStatus.UNRELEASED && (
                   <Button
-                    size="sm"
-                    variant="ghost"
-                    className="size-7 p-0"
-                    onClick={() => saveEdit(version)}
+                    size="sm" variant="primary"
+                    onClick={() => releaseVersion({ param: { versionId: version.$id }, query: { workspaceId, projectId } })}
+                    title="Mark as Released"
                   >
-                    <CheckIcon className="size-3" />
+                    <RocketIcon className="size-3.5 mr-1" />
+                    Release
                   </Button>
+                )}
+                {version.status === VersionStatus.RELEASED && (
                   <Button
-                    size="sm"
-                    variant="ghost"
-                    className="size-7 p-0"
-                    onClick={() => setEditingId(null)}
+                    size="sm" variant="secondary"
+                    onClick={() => archiveVersion({ param: { versionId: version.$id }, query: { workspaceId, projectId } })}
+                    title="Archive"
                   >
-                    <XIcon className="size-3" />
+                    <ArchiveIcon className="size-3.5 mr-1" />
+                    Archive
                   </Button>
-                </div>
-              ) : (
-                <div className="flex items-center gap-x-2 flex-wrap">
-                  <span className="text-sm font-medium">{version.name}</span>
-                  <Badge variant={statusVariant[version.status]}>
-                    {statusLabel[version.status]}
-                  </Badge>
-                </div>
-              )}
-              {version.description && editingId !== version.$id && (
-                <p className="text-xs text-muted-foreground mt-0.5 truncate">
-                  {version.description}
-                </p>
-              )}
-              {version.releaseDate && editingId !== version.$id && (
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  Release: {new Date(version.releaseDate).toLocaleDateString()}
-                </p>
-              )}
+                )}
+                {editingId !== version.$id && (
+                  <Button size="sm" variant="ghost" className="size-8 p-0 text-muted-foreground" title="Edit" aria-label="Edit release" onClick={() => startEdit(version)}>
+                    <PencilIcon className="size-3.5" />
+                  </Button>
+                )}
+                <Button
+                  size="sm" variant="ghost"
+                  className="size-8 p-0 text-muted-foreground hover:text-destructive"
+                  title="Delete"
+                  aria-label="Delete release"
+                  disabled={deletingId === version.$id}
+                  onClick={() => {
+                    setDeletingId(version.$id);
+                    deleteVersion(
+                      { param: { versionId: version.$id }, query: { workspaceId, projectId } },
+                      { onSuccess: () => setDeletingId(null), onError: () => setDeletingId(null) }
+                    );
+                  }}
+                >
+                  <TrashIcon className="size-3.5" />
+                </Button>
+              </div>
             </div>
 
-            <div className="flex items-center gap-x-1 shrink-0">
-              {version.status === VersionStatus.UNRELEASED && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="size-7 p-0 text-muted-foreground hover:text-green-600"
-                  title="Release"
-                  onClick={() =>
-                    releaseVersion({
-                      param: { versionId: version.$id },
-                      query: { workspaceId, projectId },
-                    })
-                  }
-                >
-                  <RocketIcon className="size-3" />
-                </Button>
-              )}
-              {version.status === VersionStatus.RELEASED && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="size-7 p-0 text-muted-foreground hover:text-yellow-600"
-                  title="Archive"
-                  onClick={() =>
-                    archiveVersion({
-                      param: { versionId: version.$id },
-                      query: { workspaceId, projectId },
-                    })
-                  }
-                >
-                  <ArchiveIcon className="size-3" />
-                </Button>
-              )}
-              {editingId !== version.$id && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="size-7 p-0 text-muted-foreground"
-                  title="Edit"
-                  onClick={() => startEdit(version)}
-                >
-                  <PencilIcon className="size-3" />
-                </Button>
-              )}
-              <Button
-                size="sm"
-                variant="ghost"
-                className="size-7 p-0 text-muted-foreground hover:text-destructive"
-                title="Delete"
-                disabled={deletingId === version.$id}
-                onClick={() => {
-                  setDeletingId(version.$id);
-                  deleteVersion(
-                    {
-                      param: { versionId: version.$id },
-                      query: { workspaceId, projectId },
-                    },
-                    {
-                      onSuccess: () => setDeletingId(null),
-                      onError: () => setDeletingId(null),
-                    }
-                  );
-                }}
-              >
-                <TrashIcon className="size-3" />
-              </Button>
-            </div>
+            {(startFmt || releaseFmt) && (
+              <p className="text-sm text-muted-foreground flex items-center gap-x-1">
+                <CalendarIcon className="size-3.5" />
+                {startFmt ?? "—"} → {releaseFmt ?? "—"}
+              </p>
+            )}
           </div>
-        ))}
-      </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/features/versions/hooks/use-create-version-modal.ts
+++ b/src/features/versions/hooks/use-create-version-modal.ts
@@ -1,0 +1,28 @@
+import { useQueryState, parseAsBoolean } from "nuqs";
+import { usePrefill } from "@/contexts/sidebar-context";
+
+export interface VersionModalPrefill {
+	projectId?: string;
+}
+
+export const useCreateVersionModal = () => {
+	const [isOpen, setIsOpen] = useQueryState(
+		"create-version",
+		parseAsBoolean.withDefault(false).withOptions({ clearOnDefault: true })
+	);
+	const { setPrefill, clearPrefill } = usePrefill();
+
+	const open = (prefill?: VersionModalPrefill) => {
+		if (prefill) {
+			setPrefill({ projectId: prefill.projectId });
+		}
+		setIsOpen(true);
+	};
+
+	const close = () => {
+		setIsOpen(false);
+		clearPrefill();
+	};
+
+	return { isOpen, open, close };
+};

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from "crypto";
 
-const CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const CHARS = "0123456789";
 
-export function generatePrefixedId(prefix: string, length = 6): string {
+export function generatePrefixedId(prefix: string, length = 8): string {
 	const CHARS_LEN = CHARS.length;
 	const MAX_VALID = 256 - (256 % CHARS_LEN);
 	let suffix = "";


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Numeric-only IDs** — suffixes now use digits only (length 8), e.g. `EPIC-12345678`
- **Epic required for STORY and SPIKE** — schema validation and form label updated (previously only BUG required an epic)
- **Sprint dropdown** — shows only ACTIVE sprints in create/edit task forms
- **Releases page** — card-based design matching the sprints page; "Create Release" opens a modal instead of an inline form
- **Create Release modal** — new hook + modal component wired to the sidebar "+" button and releases page; mounted in dashboard layout
- **Sidebar** — compact sub-items (smaller padding/icons), reduced left indent, accordion behaviour (expanding one project collapses others; active project always stays expanded)
- **Task detail** — 3-column layout: left (Overview + Time Tracking), centre (Title + Description + Acceptance Criteria + RCA + Comments), right (Links + Attachments + Activity)
- **Assignee "Unknown"** — falls back through `displayName → email → userId` instead of hard-coding "Unknown"; fixed at all three server call sites
- **Time tracking** — `step="any"` and `min=0` on the hours input so values like `1.5` are accepted without browser validation errors

## Test plan

- [ ] Create an Epic → ID shows as `EPIC-XXXXXXXX` (8 digits, no letters)
- [ ] Create a Story/Spike without selecting an Epic → form shows validation error
- [ ] Open create/edit task modal → Sprint dropdown lists only ACTIVE sprints
- [ ] Releases page → cards match sprint page style; "Create Release" opens modal
- [ ] Click "+" next to Releases in sidebar → create-release modal opens with project pre-filled
- [ ] Expand two projects in sidebar → second one collapses the first; active project stays open
- [ ] Open any task detail page → 3-column layout renders correctly at wide viewport
- [ ] Task assigned to current user → Assignee shows real name, not "Unknown"
- [ ] Log Work → enter `1.5` hours → submits successfully as 90 minutes

https://claude.ai/code/session_01G2mjMVJBLvWiQ71vXHcK9A
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2mjMVJBLvWiQ71vXHcK9A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Create releases directly from projects or the dedicated releases page.

* **Enhancements**
  * Active sprints only appear in task sprint selection.
  * Time tracking now accepts zero hours and any decimal value.
  * Epic field now required for Stories, Spikes, and Bugs.
  * Improved error handling for user profile lookups.

* **Style**
  * Redesigned task detail page with optimized 3-column layout.
  * Enhanced releases page with project header and controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->