### PR TITLE
feat: task detail & settings UX polish

### DIFF
--- a/src/app/(dashboard)/workspace/[workspaceId]/tasks/[taskId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/tasks/[taskId]/client.tsx
@@ -23,6 +23,7 @@ export const TaskIdClient = () => {
 	if (!data) return <PageError message="Task not found" />;
 	return (
 		<div className="flex flex-col gap-y-4">
+			<h1 className="text-2xl font-semibold break-words">{data.name}</h1>
 			<TaskBreadcrumbs project={data.project} task={data} />
 			<DottedSeperator />
 			<div className="grid grid-cols-1 xl:grid-cols-[280px_1fr_280px] gap-6">
@@ -37,9 +38,8 @@ export const TaskIdClient = () => {
 					/>
 				</div>
 
-				{/* CENTER — Title, Description, RCA (bug only), Comments */}
+				{/* CENTER — Description, RCA (bug only), Comments */}
 				<div className="flex flex-col gap-y-4">
-					<h1 className="text-2xl font-semibold break-words">{data.name}</h1>
 					<TaskDescription task={data} />
 					{data.issueType === IssueType.BUG && <TaskRca task={data} />}
 					<TaskComments taskId={data.$id} />

--- a/src/app/(standalone)/settings/client.tsx
+++ b/src/app/(standalone)/settings/client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { DottedSeperator } from "@/components/dotted-seperator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,14 +9,24 @@ import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Switch } from "@/components/ui/switch";
-import { Trash2, Plus, Key, AlertCircle, Bell, User, Palette, Shield } from "lucide-react";
+import {
+	Trash2,
+	Plus,
+	Key,
+	AlertCircle,
+	Bell,
+	User,
+	Palette,
+	Shield,
+	ArrowLeft,
+} from "lucide-react";
 import { useGenerateToken } from "@/features/tokens/api/use-generate-token";
 import { useGetUserTokens, Token } from "@/features/tokens/api/use-user-tokens";
 import { useRevokeToken } from "@/features/tokens/api/use-user-tokens";
 import { useTheme } from "next-themes";
 import { formatDistanceToNow } from "date-fns";
-import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { useRouter } from "next/navigation";
 
 interface SettingsClientProps {
 	user: {
@@ -28,9 +38,9 @@ interface SettingsClientProps {
 }
 
 export const SettingsClient = ({ user }: SettingsClientProps) => {
+	const router = useRouter();
 	const { theme, resolvedTheme, setTheme } = useTheme();
 	const [displayName, setDisplayName] = useState(user.name || "");
-	const [isUpdatingProfile, setIsUpdatingProfile] = useState(false);
 
 	const { data: tokens, isLoading: tokensLoading, isError: tokensError, error: tokensErrorObj } = useGetUserTokens();
 	const { mutate: generateToken, isPending: isGenerating } = useGenerateToken();
@@ -39,157 +49,139 @@ export const SettingsClient = ({ user }: SettingsClientProps) => {
 	const avatarFallback =
 		(user.name?.charAt(0) || user.email?.charAt(0) || "U").toUpperCase();
 
-	const handleSaveProfile = async () => {
-		setIsUpdatingProfile(true);
-		try {
-			toast.success("Profile updated");
-		} catch {
-			toast.error("Failed to update profile");
-		} finally {
-			setIsUpdatingProfile(false);
-		}
-	};
-
 	return (
-		<div className="w-full max-w-2xl">
-			<div className="mb-6">
-				<h1 className="text-2xl font-bold">Settings</h1>
-				<p className="text-muted-foreground text-sm mt-1">
-					Manage your account preferences
-				</p>
-			</div>
+		<div className="w-full lg:max-w-xl">
+			<Card className="w-full h-full border-none shadow-none">
+				<CardHeader className="flex flex-row items-center gap-x-4 p-7 space-y-0">
+					<Button
+						size="sm"
+						variant="secondary"
+						onClick={() => router.back()}
+					>
+						<ArrowLeft className="size-4 mr-2" />
+						Back
+					</Button>
+					<div>
+						<CardTitle className="text-xl font-bold">Settings</CardTitle>
+						<p className="text-sm text-muted-foreground mt-0.5">
+							Manage your account preferences
+						</p>
+					</div>
+				</CardHeader>
 
-			<Tabs defaultValue="profile" className="w-full">
-				<TabsList className="grid w-full grid-cols-4 mb-6">
-					<TabsTrigger value="profile" className="gap-1">
-						<User className="size-3.5" />
-						Profile
-					</TabsTrigger>
-					<TabsTrigger value="appearance" className="gap-1">
-						<Palette className="size-3.5" />
-						Appearance
-					</TabsTrigger>
-					<TabsTrigger value="security" className="gap-1">
-						<Shield className="size-3.5" />
-						Security
-					</TabsTrigger>
-					<TabsTrigger value="notifications" className="gap-1">
-						<Bell className="size-3.5" />
-						Notifications
-					</TabsTrigger>
-				</TabsList>
+				<DottedSeperator />
 
-				<TabsContent value="profile">
-					<Card>
-						<CardHeader>
-							<CardTitle>Profile</CardTitle>
-							<CardDescription>
-								Update your personal information
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							<div className="flex items-center gap-4">
-								<Avatar className="size-16">
-									<AvatarImage src={user.photoUrl} alt={user.name || user.email} />
-									<AvatarFallback className="text-xl">
-										{avatarFallback}
-									</AvatarFallback>
-								</Avatar>
-								<div>
-									<p className="font-medium text-sm">{user.name || "User"}</p>
-									<p className="text-xs text-muted-foreground">{user.email}</p>
+				<CardContent className="p-7">
+					<Tabs defaultValue="profile" className="w-full">
+						<TabsList className="w-full mb-4">
+							<TabsTrigger value="profile" className="flex-1 gap-1.5">
+								<User className="size-3.5" />
+								Profile
+							</TabsTrigger>
+							<TabsTrigger value="appearance" className="flex-1 gap-1.5">
+								<Palette className="size-3.5" />
+								Appearance
+							</TabsTrigger>
+							<TabsTrigger value="security" className="flex-1 gap-1.5">
+								<Shield className="size-3.5" />
+								Security
+							</TabsTrigger>
+							<TabsTrigger value="notifications" className="flex-1 gap-1.5">
+								<Bell className="size-3.5" />
+								Notifications
+							</TabsTrigger>
+						</TabsList>
+
+						{/* ── Profile ──────────────────────────────────────────── */}
+						<TabsContent value="profile" className="mt-0">
+							<div className="space-y-4 pt-2">
+								<div className="flex items-center gap-4">
+									<Avatar className="size-14">
+										<AvatarImage src={user.photoUrl} alt={user.name || user.email} />
+										<AvatarFallback className="text-lg font-semibold">
+											{avatarFallback}
+										</AvatarFallback>
+									</Avatar>
+									<div>
+										<p className="font-semibold text-sm">{user.name || "User"}</p>
+										<p className="text-xs text-muted-foreground">{user.email}</p>
+									</div>
 								</div>
-							</div>
-							<DottedSeperator />
-							<div className="space-y-3">
-								<div>
-									<Label htmlFor="displayName">Display Name</Label>
-									<Input
-										id="displayName"
-										value={displayName}
-										onChange={(e) => setDisplayName(e.target.value)}
-										placeholder="Your display name"
-										className="mt-1.5"
-									/>
+								<DottedSeperator />
+								<div className="space-y-3">
+									<div className="space-y-1.5">
+										<Label htmlFor="displayName">Display Name</Label>
+										<Input
+											id="displayName"
+											value={displayName}
+											onChange={(e) => setDisplayName(e.target.value)}
+											placeholder="Your display name"
+										/>
+									</div>
+									<div className="space-y-1.5">
+										<Label>Email</Label>
+										<Input value={user.email} disabled />
+										<p className="text-xs text-muted-foreground">
+											Email cannot be changed
+										</p>
+									</div>
 								</div>
-								<div>
-									<Label>Email</Label>
-									<Input
-										value={user.email}
+								<DottedSeperator />
+								<div className="space-y-1">
+									<Button
 										disabled
-										className="mt-1.5"
+										variant="primary"
+										size="sm"
+									>
+										Save Changes
+									</Button>
+									<p className="text-xs text-muted-foreground">Profile editing coming soon</p>
+								</div>
+							</div>
+						</TabsContent>
+
+						{/* ── Appearance ───────────────────────────────────────── */}
+						<TabsContent value="appearance" className="mt-0">
+							<div className="space-y-4 pt-2">
+								<div className="flex items-center justify-between">
+									<div>
+										<p className="font-medium text-sm">Dark Mode</p>
+										<p className="text-xs text-muted-foreground">
+											Switch between light and dark themes
+										</p>
+									</div>
+									<Switch
+										checked={resolvedTheme === "dark"}
+										onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
 									/>
-									<p className="text-xs text-muted-foreground mt-1">
-										Email cannot be changed
-									</p>
+								</div>
+								<DottedSeperator />
+								<div className="space-y-2">
+									<p className="font-medium text-sm">Theme</p>
+									<div className="flex gap-2">
+										{["light", "dark", "system"].map((t) => (
+											<Button
+												key={t}
+												variant={theme === t ? "secondary" : "outline"}
+												size="sm"
+												onClick={() => setTheme(t)}
+											>
+												{t.charAt(0).toUpperCase() + t.slice(1)}
+											</Button>
+										))}
+									</div>
 								</div>
 							</div>
-							<Button
-								onClick={handleSaveProfile}
-								disabled={isUpdatingProfile || displayName === (user.name || "")}
-							>
-								{isUpdatingProfile ? "Saving..." : "Save Changes"}
-							</Button>
-						</CardContent>
-					</Card>
-				</TabsContent>
+						</TabsContent>
 
-				<TabsContent value="appearance">
-					<Card>
-						<CardHeader>
-							<CardTitle>Appearance</CardTitle>
-							<CardDescription>
-								Customize how FlowBoard looks
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							<div className="flex items-center justify-between">
-								<div>
-									<p className="font-medium text-sm">Dark Mode</p>
-									<p className="text-xs text-muted-foreground">
-										Switch between light and dark themes
-									</p>
-								</div>
-								<Switch
-									checked={resolvedTheme === "dark"}
-									onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
-								/>
-							</div>
-							<DottedSeperator />
-							<div className="space-y-2">
-								<p className="font-medium text-sm">Theme</p>
-								<div className="flex gap-3">
-									{["light", "dark", "system"].map((t) => (
-										<Button
-											key={t}
-											variant={theme === t ? "secondary" : "outline"}
-											size="sm"
-											onClick={() => setTheme(t)}
-										>
-											{t.charAt(0).toUpperCase() + t.slice(1)}
-										</Button>
-									))}
-								</div>
-							</div>
-						</CardContent>
-					</Card>
-				</TabsContent>
-
-				<TabsContent value="security">
-					<Card>
-						<CardHeader>
-							<CardTitle>Security</CardTitle>
-							<CardDescription>
-								Manage your personal access tokens and security settings
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							<div>
-								<div className="flex items-center justify-between mb-4">
+						{/* ── Security ─────────────────────────────────────────── */}
+						<TabsContent value="security" className="mt-0">
+							<div className="space-y-4 pt-2">
+								<div className="flex items-center justify-between">
 									<div>
 										<p className="font-medium text-sm">Personal Access Tokens</p>
 										<p className="text-xs text-muted-foreground">
-											Tokens are used for API access. Max 5 active tokens.
+											Used for API access. Max 5 active tokens.
 										</p>
 									</div>
 									<Button
@@ -199,10 +191,10 @@ export const SettingsClient = ({ user }: SettingsClientProps) => {
 										disabled={isGenerating || !!((tokens?.filter((t: Token) => !t.isExpired) ?? []).length >= 5)}
 									>
 										<Plus className="size-3.5 mr-1" />
-										Generate Token
+										Generate
 									</Button>
 								</div>
-
+								<DottedSeperator />
 								{tokensLoading ? (
 									<p className="text-sm text-muted-foreground">Loading...</p>
 								) : tokensError ? (
@@ -242,11 +234,12 @@ export const SettingsClient = ({ user }: SettingsClientProps) => {
 												className="flex items-center justify-between p-3 border rounded-lg"
 											>
 												<div className="flex items-center gap-3">
-													<Key className="size-4 text-muted-foreground" />
+													<Key className="size-4 text-muted-foreground shrink-0" />
 													<div>
 														<p className="text-sm font-medium">{token.name}</p>
 														<p className="text-xs text-muted-foreground">
-															Created {token.$createdAt
+															Created{" "}
+															{token.$createdAt
 																? formatDistanceToNow(new Date(token.$createdAt), { addSuffix: true })
 																: "recently"}
 															{token.expiresAt && (
@@ -277,62 +270,55 @@ export const SettingsClient = ({ user }: SettingsClientProps) => {
 									</div>
 								)}
 							</div>
-						</CardContent>
-					</Card>
-				</TabsContent>
+						</TabsContent>
 
-				<TabsContent value="notifications">
-					<Card>
-						<CardHeader>
-							<CardTitle>Notifications</CardTitle>
-							<CardDescription>
-								Configure how you receive notifications
-							</CardDescription>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							<div className="flex items-center justify-between">
-								<div>
-									<p className="font-medium text-sm">Email Notifications</p>
+						{/* ── Notifications ─────────────────────────────────────── */}
+						<TabsContent value="notifications" className="mt-0">
+							<div className="space-y-4 pt-2">
+								<div className="flex items-center justify-between">
+									<div>
+										<p className="font-medium text-sm">Email Notifications</p>
+										<p className="text-xs text-muted-foreground">
+											Receive email updates about task assignments
+										</p>
+									</div>
+									<Switch defaultChecked disabled />
+								</div>
+								<DottedSeperator />
+								<div className="flex items-center justify-between">
+									<div>
+										<p className="font-medium text-sm">Mention Alerts</p>
+										<p className="text-xs text-muted-foreground">
+											Get notified when someone mentions you in a comment
+										</p>
+									</div>
+									<Switch defaultChecked disabled />
+								</div>
+								<DottedSeperator />
+								<div className="flex items-center justify-between">
+									<div>
+										<p className="font-medium text-sm">Sprint Updates</p>
+										<p className="text-xs text-muted-foreground">
+											Notifications for sprint start, end, and summary
+										</p>
+									</div>
+									<Switch defaultChecked disabled />
+								</div>
+								<DottedSeperator />
+								<div className="rounded-lg border border-dashed p-4">
+									<div className="flex items-center gap-2 mb-1">
+										<AlertCircle className="size-4 text-muted-foreground" />
+										<p className="text-sm font-medium">More options coming soon</p>
+									</div>
 									<p className="text-xs text-muted-foreground">
-										Receive email updates about task assignments
+										Per-project notification preferences and digest settings will be available in a future update.
 									</p>
 								</div>
-								<Switch defaultChecked />
 							</div>
-							<DottedSeperator />
-							<div className="flex items-center justify-between">
-								<div>
-									<p className="font-medium text-sm">Mention Alerts</p>
-									<p className="text-xs text-muted-foreground">
-										Get notified when someone mentions you in a comment
-									</p>
-								</div>
-								<Switch defaultChecked />
-							</div>
-							<DottedSeperator />
-							<div className="flex items-center justify-between">
-								<div>
-									<p className="font-medium text-sm">Sprint Updates</p>
-									<p className="text-xs text-muted-foreground">
-										Notifications for sprint start, end, and summary
-									</p>
-								</div>
-								<Switch defaultChecked />
-							</div>
-							<DottedSeperator />
-							<div className="rounded-lg border border-dashed p-4">
-								<div className="flex items-center gap-2 mb-1">
-									<AlertCircle className="size-4 text-muted-foreground" />
-									<p className="text-sm font-medium">More options coming soon</p>
-								</div>
-								<p className="text-xs text-muted-foreground">
-									Per-project notification preferences and digest settings will be available in a future update.
-								</p>
-							</div>
-						</CardContent>
-					</Card>
-				</TabsContent>
-			</Tabs>
+						</TabsContent>
+					</Tabs>
+				</CardContent>
+			</Card>
 		</div>
 	);
 };

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -66,6 +66,8 @@ export const Navbar = () => {
 		});
 	}
 
+	const isTaskDetailPage = new Set(["epic", "story", "spike", "bug"]).has(pageSegment ?? "");
+
 	const pageLabel = pageSegment
 		? PAGE_LABEL[pageSegment] ?? (pageSegment.charAt(0).toUpperCase() + pageSegment.slice(1))
 		: null;
@@ -78,6 +80,7 @@ export const Navbar = () => {
 
 	return (
 		<nav className="pt-4 px-6 flex items-center justify-between">
+			{!isTaskDetailPage && (
 			<div className="flex-col hidden lg:flex gap-y-1">
 				<h1 className="text-2xl font-semibold">{title}</h1>
 				{crumbs.length > 0 && (
@@ -103,6 +106,7 @@ export const Navbar = () => {
 					</div>
 				)}
 			</div>
+			)}
 			<MobileSidebar />
 			<UserButton />
 		</nav>

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -159,7 +159,7 @@ export const Projects = () => {
 								</button>
 							</div>
 							{isExpanded && (
-								<div className="flex flex-col gap-y-0.5 ml-1 pl-2 border-l border-border">
+								<div className="flex flex-col gap-y-0.5 ml-1 pl-2 border-l border-border dark:border-muted-foreground/30">
 									{subItems.map((item) => (
 										<SubItem
 											key={item.label}

--- a/src/features/sprints/components/backlog-view.tsx
+++ b/src/features/sprints/components/backlog-view.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { DottedSeperator } from "@/components/dotted-seperator";
+import { snakeCaseToTitleCase } from "@/lib/utils";
 import { MemberAvatar } from "@/features/members/components/member-avatar";
 import { Task, TaskStatus } from "@/features/tasks/types";
 import { useUpdateTask } from "@/features/tasks/api/use-update-task";
@@ -65,8 +66,8 @@ const TaskRow = ({ task, sprints }: TaskRowProps) => {
     <div className="flex items-center gap-x-3 px-4 py-2 hover:bg-muted/50 rounded-md group">
       <div className="flex-1 flex items-center gap-x-2 min-w-0">
         {task.issueType && (
-          <Badge variant="outline" className="text-xs shrink-0">
-            {task.issueType}
+          <Badge variant="outline" className="text-xs shrink-0 w-14 justify-center">
+            {snakeCaseToTitleCase(task.issueType)}
           </Badge>
         )}
         <span className="text-sm truncate">{task.name}</span>

--- a/src/features/tasks/api/use-create-comment.ts
+++ b/src/features/tasks/api/use-create-comment.ts
@@ -25,6 +25,7 @@ export const useCreateComment = () => {
 		onSuccess: (_data, { param }) => {
 			toast.success("Comment added");
 			queryClient.invalidateQueries({ queryKey: ["comments", param.taskId] });
+			queryClient.invalidateQueries({ queryKey: ["activity", param.taskId] });
 		},
 		onError: () => {
 			toast.error("Failed to add comment");

--- a/src/features/tasks/api/use-get-activity.ts
+++ b/src/features/tasks/api/use-get-activity.ts
@@ -16,5 +16,7 @@ export const useGetActivity = ({ taskId }: UseGetActivityProps) => {
 			const { data } = await response.json();
 			return data;
 		},
+		refetchInterval: 5000,
+		refetchOnWindowFocus: true,
 	});
 };

--- a/src/features/tasks/api/use-get-comments.ts
+++ b/src/features/tasks/api/use-get-comments.ts
@@ -16,5 +16,7 @@ export const useGetComments = ({ taskId }: UseGetCommentsProps) => {
 			const { data } = await response.json();
 			return data;
 		},
+		refetchInterval: 5000,
+		refetchOnWindowFocus: true,
 	});
 };

--- a/src/features/tasks/api/use-update-task.ts
+++ b/src/features/tasks/api/use-update-task.ts
@@ -30,6 +30,7 @@ export const useUpdateTask = () => {
 			queryClient.invalidateQueries({ queryKey: ["workspace-analytics"] });
 			queryClient.invalidateQueries({ queryKey: ["tasks"] });
 			queryClient.invalidateQueries({ queryKey: ["task", data.$id] });
+			queryClient.invalidateQueries({ queryKey: ["activity", data.$id] });
 		},
 		onError: () => {
 			toast.error("Failed to update task");

--- a/src/features/tasks/components/columns.tsx
+++ b/src/features/tasks/components/columns.tsx
@@ -10,7 +10,7 @@ import { TaskDate } from "./task-date";
 import { Badge } from "@/components/ui/badge";
 import { snakeCaseToTitleCase } from "@/lib/utils";
 import { TaskActions } from "./task-actions";
-import { TaskPriority } from "../types";
+import { TaskPriority, IssueType } from "../types";
 
 export const columns: ColumnDef<Task>[] = [
 	{
@@ -32,6 +32,19 @@ export const columns: ColumnDef<Task>[] = [
 		cell: ({ row }) => {
 			const name = row.original.name;
 			return <p className="line-clamp-1">{name}</p>;
+		},
+	},
+	{
+		header: "Type",
+		accessorKey: "issueType",
+		cell: ({ row }) => {
+			const issueType = row.original.issueType as IssueType | undefined;
+			if (!issueType) return <span className="text-muted-foreground text-xs">—</span>;
+			return (
+				<Badge variant="outline" className="w-14 justify-center">
+					{snakeCaseToTitleCase(issueType)}
+				</Badge>
+			);
 		},
 	},
 	{
@@ -164,10 +177,8 @@ export const columns: ColumnDef<Task>[] = [
 		id: "actions",
 		cell: ({ row }) => {
 			const id = row.original.$id;
-			const projectId = row.original.projectId;
-			const issueType = row.original.issueType;
 			return (
-				<TaskActions id={id} projectId={projectId} issueType={issueType}>
+				<TaskActions id={id}>
 					<Button variant="ghost" className="size-8 p-0">
 						<MoreVertical className="size-4" />
 					</Button>

--- a/src/features/tasks/components/data-table.tsx
+++ b/src/features/tasks/components/data-table.tsx
@@ -26,11 +26,13 @@ import {
 interface DataTableProps<TData, TValue> {
 	columns: ColumnDef<TData, TValue>[];
 	data: TData[];
+	onRowClick?: (row: TData) => void;
 }
 
 export function DataTable<TData, TValue>({
 	columns,
 	data,
+	onRowClick,
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = React.useState<SortingState>([]);
 	const table = useReactTable({
@@ -76,6 +78,11 @@ export function DataTable<TData, TValue>({
 									data-state={
 										row.getIsSelected() && "selected"
 									}
+									onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+									onKeyDown={onRowClick ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onRowClick(row.original); } } : undefined}
+									tabIndex={onRowClick ? 0 : undefined}
+									role={onRowClick ? "button" : undefined}
+									className={onRowClick ? "cursor-pointer" : ""}
 								>
 									{row.getVisibleCells().map((cell) => (
 										<TableCell key={cell.id}>

--- a/src/features/tasks/components/issue-type-list.tsx
+++ b/src/features/tasks/components/issue-type-list.tsx
@@ -13,7 +13,9 @@ import { useGetTasks } from "@/features/tasks/api/use-get-tasks";
 import { DataTable } from "@/features/tasks/components/data-table";
 import { columns } from "@/features/tasks/components/columns";
 import { useCreateTaskModal } from "@/features/tasks/hooks/use-create-task-modal";
-import { IssueType } from "@/features/tasks/types";
+import { IssueType, Task } from "@/features/tasks/types";
+import { useRouter } from "next/navigation";
+import { getTaskRoute } from "@/lib/task-routes";
 
 const singularMap: Record<string, string> = {
 	Epics: "Epic",
@@ -34,6 +36,7 @@ interface IssueTypeListProps {
 export const IssueTypeList = ({ issueType, pageTitle }: IssueTypeListProps) => {
 	const projectId = useProjectId();
 	const workspaceId = useWorkspaceId();
+	const router = useRouter();
 	const { open } = useCreateTaskModal();
 
 	const { data: project, isLoading: isLoadingProject } = useGetProject({ projectId });
@@ -89,7 +92,11 @@ export const IssueTypeList = ({ issueType, pageTitle }: IssueTypeListProps) => {
 					<Loader className="size-5 animate-spin text-muted-foreground" />
 				</div>
 			) : (
-				<DataTable columns={columns} data={tasks} />
+				<DataTable
+					columns={columns}
+					data={tasks}
+					onRowClick={(task) => router.push(getTaskRoute(workspaceId, (task as Task).projectId, task as Task))}
+				/>
 			)}
 		</div>
 	);

--- a/src/features/tasks/components/kanban-card.tsx
+++ b/src/features/tasks/components/kanban-card.tsx
@@ -17,7 +17,7 @@ export const KanbanCard = ({ task }: KanbanCardProps) => {
 		<div className="bg-card p-2.5 mb-1.5 rounded shadow-sm space-y-3">
 			<div className="flex items-start justify-between gap-x-2">
 				<p className="text-sm line-clamp-2">{task.name}</p>
-				<TaskActions id={task.$id} projectId={task.projectId} issueType={task.issueType}>
+				<TaskActions id={task.$id}>
 					<MoreHorizontalIcon className="size-[18px] stroke-1 shrink-0 text-muted-foreground hover:opacity-75 transition" />
 				</TaskActions>
 			</div>

--- a/src/features/tasks/components/task-actions.tsx
+++ b/src/features/tasks/components/task-actions.tsx
@@ -5,24 +5,16 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useConfirm } from "@/hooks/use-confirm";
-import { ExternalLinkIcon, PencilIcon, TrashIcon } from "lucide-react";
+import { PencilIcon, TrashIcon } from "lucide-react";
 import { useDeleteTask } from "../api/use-delete-task";
-import { useRouter } from "next/navigation";
-import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useEditTaskModal } from "../hooks/use-edit-task-modal";
-import { getTaskRoute } from "@/lib/task-routes";
-import { IssueType } from "../types";
 
 interface TaskActionsProps {
 	id: string;
-	projectId: string;
-	issueType?: IssueType;
 	children: React.ReactNode;
 }
 
-export const TaskActions = ({ id, projectId, issueType, children }: TaskActionsProps) => {
-	const router = useRouter();
-	const workspaceId = useWorkspaceId();
+export const TaskActions = ({ id, children }: TaskActionsProps) => {
 	const { open } = useEditTaskModal();
 	const [ConfirmDialog, confirm] = useConfirm(
 		"Delete task",
@@ -36,34 +28,13 @@ export const TaskActions = ({ id, projectId, issueType, children }: TaskActionsP
 		mutate({ param: { taskId: id } });
 	};
 
-	const onOpenTask = () => {
-		router.push(getTaskRoute(workspaceId, projectId, { $id: id, issueType }));
-	};
-	const onOpenProject = () => {
-		router.push(`/workspace/${workspaceId}/project/${projectId}`);
-	};
-
 	return (
-		<div className="flex justify-end">
+		<div className="flex justify-end" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
 			<ConfirmDialog />
-			
+
 			<DropdownMenu modal={false}>
 				<DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
 				<DropdownMenuContent align="end" className="w-48">
-					<DropdownMenuItem
-						onClick={onOpenTask}
-						className="font-medium p-[10px]"
-					>
-						<ExternalLinkIcon className="size-4 mr-2 stroke-2" />
-						Task Details
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						onClick={onOpenProject}
-						className="font-medium p-[10px]"
-					>
-						<ExternalLinkIcon className="size-4 mr-2 stroke-2" />
-						Open Project
-					</DropdownMenuItem>
 					<DropdownMenuItem
 						onClick={() => open(id)}
 						className="font-medium p-[10px]"

--- a/src/features/tasks/components/task-activity.tsx
+++ b/src/features/tasks/components/task-activity.tsx
@@ -4,19 +4,32 @@ import { formatDistanceToNow } from "date-fns";
 import { DottedSeperator } from "@/components/dotted-seperator";
 import { useGetActivity } from "../api/use-get-activity";
 import { TaskActivity as TaskActivityType } from "../types";
+import { snakeCaseToTitleCase } from "@/lib/utils";
 
 interface TaskActivityProps {
 	taskId: string;
 }
 
+const ENUM_FIELDS = new Set(["status", "priority", "issueType"]);
+
+const formatValue = (field: string | undefined, value: string | undefined): string => {
+	if (!value) return "";
+	if (field && ENUM_FIELDS.has(field)) return snakeCaseToTitleCase(value);
+	return value;
+};
+
 const activityLabel = (entry: TaskActivityType): string => {
 	switch (entry.type) {
-		case "FIELD_CHANGE":
-			if (entry.oldValue && entry.newValue) {
-				return `changed ${entry.field} from "${entry.oldValue}" to "${entry.newValue}"`;
+		case "FIELD_CHANGE": {
+			const fieldLabel = entry.field ? snakeCaseToTitleCase(entry.field) : "field";
+			const oldVal = formatValue(entry.field, entry.oldValue);
+			const newVal = formatValue(entry.field, entry.newValue);
+			if (oldVal && newVal) {
+				return `changed ${fieldLabel} from "${oldVal}" to "${newVal}"`;
 			}
-			if (entry.newValue) return `set ${entry.field} to "${entry.newValue}"`;
-			return `cleared ${entry.field}`;
+			if (newVal) return `set ${fieldLabel} to "${newVal}"`;
+			return `cleared ${fieldLabel}`;
+		}
 		case "COMMENT_ADDED":
 			return "added a comment";
 		case "ATTACHMENT_ADDED":
@@ -31,6 +44,10 @@ const activityLabel = (entry: TaskActivityType): string => {
 			return entry.newValue ? `linked task ${entry.newValue}` : "added a link";
 		case "LINK_REMOVED":
 			return "removed a link";
+		case "WORK_LOGGED":
+			return entry.newValue ? `logged ${entry.newValue} of work` : "logged work";
+		case "WORKLOG_DELETED":
+			return "deleted a work log entry";
 		default:
 			return "performed an action";
 	}

--- a/src/features/tasks/components/task-attachments.tsx
+++ b/src/features/tasks/components/task-attachments.tsx
@@ -91,7 +91,7 @@ export const TaskAttachments = ({ taskId, workspaceId, projectId }: TaskAttachme
 					disabled={isUploading}
 				>
 					<PlusIcon className="size-4 mr-1" />
-					Add Attachment
+					Add
 				</Button>
 				<input
 					ref={fileInputRef}

--- a/src/features/tasks/components/task-links.tsx
+++ b/src/features/tasks/components/task-links.tsx
@@ -57,7 +57,7 @@ export const TaskLinks = ({ taskId, workspaceId, projectId }: TaskLinksProps) =>
 				<p className="text-lg font-semibold">Links</p>
 				<Button size="sm" variant="secondary" onClick={() => setShowForm((v) => !v)}>
 					<PlusIcon className="size-4 mr-1" />
-					Add Link
+					Add
 				</Button>
 			</div>
 			<DottedSeperator className="my-4" />

--- a/src/features/tasks/components/task-overview.tsx
+++ b/src/features/tasks/components/task-overview.tsx
@@ -86,6 +86,13 @@ export const TaskOverview = ({ task }: TaskOverviewProps) => {
 							</Badge>
 						</OverviewProperty>
 					)}
+					{task.storyPoints !== undefined && task.storyPoints !== null && (
+						<OverviewProperty label="Story Points">
+							<Badge variant="secondary">
+								{task.storyPoints} pts
+							</Badge>
+						</OverviewProperty>
+					)}
 					{task.fixVersionId && (
 						<OverviewProperty label="Version">
 							<Badge variant="outline">

--- a/src/features/tasks/components/task-view-switcher.tsx
+++ b/src/features/tasks/components/task-view-switcher.tsx
@@ -14,10 +14,12 @@ import { DataTable } from "./data-table";
 import { columns } from "./columns";
 import { DataKanban } from "./data-kanban";
 import { useCallback } from "react";
-import { TaskStatus } from "../types";
+import { TaskStatus, Task } from "../types";
 import { useBulkUpdateTasks } from "../api/use-bulk-update-tasks";
 import { DataCalender } from "./data-calendar";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
+import { useRouter } from "next/navigation";
+import { getTaskRoute } from "@/lib/task-routes";
 
 interface TaskViewSwitcherProps {
 	hideProjectFilter?: boolean;
@@ -34,6 +36,7 @@ export const TaskViewSwitcher = ({
 		defaultValue: "table",
 	});
 	const workspaceId = useWorkspaceId();
+	const router = useRouter();
 	const { data: tasks, isLoading: isLoadingTasks } = useGetTasks({
 		workspaceId,
 		projectId: paramProjectId || projectId,
@@ -101,6 +104,7 @@ export const TaskViewSwitcher = ({
 							<DataTable
 								columns={columns}
 								data={tasks?.documents ?? []}
+								onRowClick={(task) => router.push(getTaskRoute(workspaceId, (task as Task).projectId, task as Task))}
 							/>
 						</TabsContent>
 						<TabsContent className="mt-0" value="kanban">

--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -139,7 +139,7 @@ const app = new Hono()
 			}
 
 			const uniqueProjectIds = Array.from(new Set(tasks.map((task: any) => task.projectId)));
-			const assigneeIds = Array.from(new Set(tasks.map((task: any) => task.assigneeId)));
+			const assigneeIds = Array.from(new Set(tasks.map((task: any) => task.assigneeId).filter(Boolean)));
 			
 			const projects: Project[] = [];
 			for (const pId of uniqueProjectIds) {
@@ -243,15 +243,16 @@ const app = new Hono()
 			$createdAt: normalizeDate(projectData),
 		} as Project : null;
 		
+		let assignee = null;
+		if (task.assigneeId) {
 		const memberDoc = await databases.collection("members").doc(task.assigneeId).get();
 		const mData = memberDoc.data();
-		const memberData = memberDoc.exists ? { 
+		const memberData = memberDoc.exists ? {
 			...mData,
-			$id: memberDoc.id, 
+			$id: memberDoc.id,
 			$createdAt: normalizeDate(mData),
 		} as any : null;
-		
-		let assignee = null;
+
 		if (memberData) {
 			let u: { displayName?: string | null; email?: string } = {};
 			try {
@@ -265,7 +266,8 @@ const app = new Hono()
 				email: u.email ?? "",
 			};
 		}
-		
+		} // end if (task.assigneeId)
+
 		return c.json({ data: { ...task, project, assignee } });
 	})
 	.post(
@@ -536,6 +538,18 @@ workspaceId,
 			}
 			if (dueDate !== undefined && dueDate.toISOString() !== existingDueDate) {
 				activityEntries.push({ field: "dueDate", oldValue: existingDueDate, newValue: dueDate.toISOString() });
+			}
+			if (storyPoints !== undefined && storyPoints !== existingTask.storyPoints) {
+				activityEntries.push({ field: "storyPoints", oldValue: existingTask.storyPoints?.toString(), newValue: storyPoints.toString() });
+			}
+			if (epicId !== undefined && epicId !== existingTask.epicId) {
+				activityEntries.push({ field: "epicId", oldValue: existingTask.epicId ?? undefined, newValue: epicId ?? undefined });
+			}
+			if (sprintId !== undefined && sprintId !== existingTask.sprintId) {
+				activityEntries.push({ field: "sprintId", oldValue: existingTask.sprintId ?? undefined, newValue: sprintId ?? undefined });
+			}
+			if (fixVersionId !== undefined && fixVersionId !== existingTask.fixVersionId) {
+				activityEntries.push({ field: "fixVersion", oldValue: existingTask.fixVersionId ?? undefined, newValue: fixVersionId ?? undefined });
 			}
 
 			let updateRef = taskDoc.ref;


### PR DESCRIPTION
## Summary

- **Assignee fix (definitive):** Filter null `assigneeIds` from bulk Firestore query; guard single-task fetch against null `assigneeId` — resolves "Unknown" showing for assigned tasks
- **Task title position:** Moved `<h1>` task name to top of page above breadcrumbs; removed from center column so all three columns align vertically
- **Navbar cleanup on detail pages:** Suppress redundant title and breadcrumbs in Navbar when viewing task detail (epic/story/spike/bug routes)
- **Sidebar dark mode border:** `dark:border-muted-foreground/30` on sub-item left border — was invisible against dark background
- **Button overflow:** "Add Attachment" / "Add Link" → "Add" to prevent overflow in card header
- **Story points in Overview:** Added `OverviewProperty` row; conditionally shown when set
- **Near-realtime activity & comments:** 5s polling via `refetchInterval`; task update and comment creation both invalidate the `["activity", taskId]` query for immediate feedback
- **Broader activity tracking:** `storyPoints`, `epicId`, `sprintId`, `fixVersion` changes now recorded in activity log
- **Type column in table:** Added after Task Name with uniform `w-14 justify-center` badge; applies `snakeCaseToTitleCase`
- **Clickable table rows:** `onRowClick` prop on `DataTable`; entire row navigates to task detail; three-dots wrapper uses `stopPropagation`
- **Three-dots menu cleanup:** Removed "Task Details" and "Open Project" items — row click and breadcrumbs handle navigation
- **Activity label improvements:** `snakeCaseToTitleCase` applied to status/priority values ("In Progress" not "IN_PROGRESS"); `WORK_LOGGED` and `WORKLOG_DELETED` have specific messages
- **Uniform issue type badge width:** `w-14 justify-center` in both table and backlog views
- **Settings page redesign:** Matches workspace/project settings style — `border-none shadow-none` card, `← Back` button via `router.back()`, `DottedSeperator` between sections, no nested card wrappers

## Test plan

- [ ] Open task assigned to a member → Overview shows member name (not "Unknown")
- [ ] Task detail page shows task name as `<h1>` at top; Navbar shows no title/crumbs on detail pages
- [ ] Toggle dark mode → sidebar sub-item left border visible
- [ ] Links and Attachments headers show "Add" button without overflow
- [ ] Task with story points shows them in Overview
- [ ] Update a task field → Activity section refreshes within 5s without page reload
- [ ] Update story points → activity entry appears
- [ ] Project/stories/etc. table shows Type column with uniform-width badges
- [ ] Click table row → navigates to task detail; three-dots still works
- [ ] Three-dots menu shows only Edit Task and Delete Task
- [ ] Activity shows "In Progress" / "Done" (not raw enum); work log shows "logged work"
- [ ] Settings page has ← Back button and matches app visual style

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Story points badge shown in task overview
  * Issue type column added to task tables (title-cased)
  * Clickable task rows navigate to task details
  * Settings redesigned into a single card with tabs and a Back button

* **Bug Fixes**
  * Activity feed and comments refresh after posting
  * Activity and comments auto-refetch every 5s and on focus

* **Style**
  * Shortened action button labels (e.g., “Add”)
  * Navbar hides header/crumbs on task detail pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/57)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->