### PR TITLE
fix: assignee shows Unknown for Google Sign In users

### DIFF
--- a/src/app/api/mcp/[[...mcp]]/route.ts
+++ b/src/app/api/mcp/[[...mcp]]/route.ts
@@ -366,7 +366,15 @@ function taskDocRef(wId: string, pId: string, taskId: string) { return tasksCol(
 function sprintsCol(wId: string, pId: string) { return projRef(wId, pId).collection("sprints"); }
 function versionsCol(wId: string, pId: string) { return projRef(wId, pId).collection("versions"); }
 
-function computeAnalytics(allTasks: any[], userId: string) {
+async function computeAnalytics(allTasks: any[], workspaceId: string, userId: string) {
+  // Resolve Firestore member doc ID so it matches the assigneeId stored in tasks
+  const memberSnap = await adminDb.collection("members")
+    .where("workspaceId", "==", workspaceId)
+    .where("userId", "==", userId)
+    .limit(1)
+    .get();
+  const memberId = memberSnap.empty ? userId : memberSnap.docs[0].id;
+
   const now = new Date();
   const nowIso = now.toISOString();
   const thisMonthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
@@ -377,7 +385,7 @@ function computeAnalytics(allTasks: any[], userId: string) {
 
   const metrics = (tasks: any[]) => ({
     taskCount: tasks.length,
-    assignedTaskCount: tasks.filter((t) => t.assigneeId === userId).length,
+    assignedTaskCount: tasks.filter((t) => t.assigneeId === memberId).length,
     incompleteTaskCount: tasks.filter((t) => t.status !== TaskStatus.DONE).length,
     completedTaskCount: tasks.filter((t) => t.status === TaskStatus.DONE).length,
     overdueTaskCount: tasks.filter((t) => t.dueDate && t.dueDate < nowIso && t.status !== TaskStatus.DONE).length,
@@ -1319,7 +1327,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
           const tasksSnap = await tasksCol(args.workspaceId, pDoc.id).get();
           allTasks.push(...tasksSnap.docs.map((d: any) => d.data()));
         }
-        return textResult(computeAnalytics(allTasks, userId));
+        return textResult(await computeAnalytics(allTasks, args.workspaceId, userId));
       }
     );
 
@@ -1338,7 +1346,7 @@ const handler = globalForMcp.mcpHandler || createMcpHandler(
         const userId = getMcpUserId();
         const tasksSnap = await tasksCol(args.workspaceId, args.projectId).get();
         const allTasks = tasksSnap.docs.map((d: any) => d.data());
-        return textResult(computeAnalytics(allTasks, userId));
+        return textResult(await computeAnalytics(allTasks, args.workspaceId, userId));
       }
     );
 

--- a/src/features/projects/server/route.ts
+++ b/src/features/projects/server/route.ts
@@ -265,9 +265,28 @@ const app = new Hono()
 			userRecords.users.forEach((u) => userMap.set(u.uid, u));
 		}
 
+		// Join with the workspace-level members collection to get the Firestore
+		// doc ID that tasks store as assigneeId, and the cached display name.
+		const wsMembersSnap = await databases
+			.collection("members")
+			.where("workspaceId", "==", workspaceId)
+			.get();
+		const wsMemberByUserId = new Map<string, { id: string; name?: string; email?: string }>();
+		wsMembersSnap.docs.forEach((doc: any) => {
+			const d = doc.data();
+			wsMemberByUserId.set(d.userId as string, { id: doc.id, name: d.name, email: d.email });
+		});
+
 		const populated = projectMembers.map((pm) => {
-			const u = userMap.get(pm.userId) ?? { displayName: "Unknown", email: "" };
-			return { ...pm, name: u.displayName || u.email, email: u.email };
+			const wsMember = wsMemberByUserId.get(pm.userId);
+			const u = userMap.get(pm.userId) ?? { displayName: null, email: "" };
+			const name = wsMember?.name || u.displayName || u.email || "Unknown";
+			return {
+				...pm,
+				$id: wsMember?.id ?? pm.userId,
+				name,
+				email: u.email || wsMember?.email || "",
+			};
 		});
 
 		return c.json({ data: { documents: populated, total: populated.length } });

--- a/src/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/src/features/tasks/components/edit-task-form-wrapper.tsx
@@ -63,15 +63,11 @@ export const EditTaskFormWrapper = ({
 		userId: member.userId,
 	}));
 
-	// Normalize the stored assigneeId: if it's a legacy Firebase UID the resolved
-	// assignee.$id holds the correct Firestore member doc ID to use instead.
-	const normalizedAssigneeId = initialValues?.assignee?.$id ?? initialValues?.assigneeId;
-
 	const memberOptions = (() => {
-		if (!normalizedAssigneeId) return rawMemberOptions;
-		const already = rawMemberOptions.some((m) => m.id === normalizedAssigneeId);
+		if (!initialValues?.assigneeId) return rawMemberOptions;
+		const already = rawMemberOptions.some((m) => m.id === initialValues.assigneeId);
 		if (already) return rawMemberOptions;
-		return [...rawMemberOptions, { id: normalizedAssigneeId, name: "Former member", userId: "" }];
+		return [...rawMemberOptions, { id: initialValues.assigneeId, name: "Former member", userId: "" }];
 	})();
 
 	const versionOptions = (versions?.documents ?? [])
@@ -106,7 +102,7 @@ export const EditTaskFormWrapper = ({
 	}
 	return (
 		<EditTaskForm
-			initalValues={{ ...initialValues, assigneeId: normalizedAssigneeId ?? initialValues.assigneeId }}
+			initalValues={initialValues}
 			onCancel={onCancel}
 			projectOptions={projectOptions ?? []}
 			memberOptions={memberOptions}

--- a/src/features/tasks/components/edit-task-form-wrapper.tsx
+++ b/src/features/tasks/components/edit-task-form-wrapper.tsx
@@ -63,11 +63,15 @@ export const EditTaskFormWrapper = ({
 		userId: member.userId,
 	}));
 
+	// Normalize the stored assigneeId: if it's a legacy Firebase UID the resolved
+	// assignee.$id holds the correct Firestore member doc ID to use instead.
+	const normalizedAssigneeId = initialValues?.assignee?.$id ?? initialValues?.assigneeId;
+
 	const memberOptions = (() => {
-		if (!initialValues?.assigneeId) return rawMemberOptions;
-		const already = rawMemberOptions.some((m) => m.id === initialValues.assigneeId);
+		if (!normalizedAssigneeId) return rawMemberOptions;
+		const already = rawMemberOptions.some((m) => m.id === normalizedAssigneeId);
 		if (already) return rawMemberOptions;
-		return [...rawMemberOptions, { id: initialValues.assigneeId, name: "Former member", userId: "" }];
+		return [...rawMemberOptions, { id: normalizedAssigneeId, name: "Former member", userId: "" }];
 	})();
 
 	const versionOptions = (versions?.documents ?? [])
@@ -102,7 +106,7 @@ export const EditTaskFormWrapper = ({
 	}
 	return (
 		<EditTaskForm
-			initalValues={initialValues}
+			initalValues={{ ...initialValues, assigneeId: normalizedAssigneeId ?? initialValues.assigneeId }}
 			onCancel={onCancel}
 			projectOptions={projectOptions ?? []}
 			memberOptions={memberOptions}

--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -65,30 +65,16 @@ async function resolveAssigneeName(
 ): Promise<string | undefined> {
 	if (!assigneeId) return undefined;
 	const assigneeDoc = await databases.collection("members").doc(assigneeId).get();
-	if (assigneeDoc.exists) {
-		const ad = assigneeDoc.data();
-		if (ad?.name) return ad.name as string;
-		if (ad?.userId) {
-			try {
-				const au = await adminAuth.getUser(ad.userId as string);
-				return au.displayName || au.email || undefined;
-			} catch (err) {
-				console.error("Failed to resolve assignee name:", err);
-			}
+	if (!assigneeDoc.exists) return undefined;
+	const ad = assigneeDoc.data();
+	if (ad?.name) return ad.name as string;
+	if (ad?.userId) {
+		try {
+			const au = await adminAuth.getUser(ad.userId as string);
+			return au.displayName || au.email || undefined;
+		} catch (err) {
+			console.error("Failed to resolve assignee name:", err);
 		}
-		return undefined;
-	}
-	// Fallback: assigneeId might be a Firebase UID stored by an older code path
-	try {
-		const snap = await databases.collection("members").where("userId", "==", assigneeId).limit(1).get();
-		if (!snap.empty) {
-			const d = snap.docs[0].data();
-			if (d?.name) return d.name as string;
-		}
-		const au = await adminAuth.getUser(assigneeId);
-		return au.displayName || au.email || undefined;
-	} catch (err) {
-		console.error("Failed to resolve assignee name (uid fallback):", err);
 	}
 	return undefined;
 }
@@ -169,18 +155,10 @@ async function resolveAssigneeDoc(
 	normalizeDate: (d: Record<string, unknown> | undefined) => string | undefined
 ): Promise<any> {
 	if (!assigneeId) return null;
-	let memberSnap: FirebaseFirestore.DocumentSnapshot | FirebaseFirestore.QueryDocumentSnapshot | null = null;
-	const byId = await databases.collection("members").doc(assigneeId).get();
-	if (byId.exists) {
-		memberSnap = byId;
-	} else {
-		// Fallback: assigneeId might be a Firebase UID stored by an older code path
-		const q = await databases.collection("members").where("userId", "==", assigneeId).limit(1).get();
-		if (!q.empty) memberSnap = q.docs[0];
-	}
-	if (!memberSnap) return null;
-	const mData = memberSnap.data();
-	const memberData = { ...mData, $id: memberSnap.id, $createdAt: normalizeDate(mData) } as any;
+	const memberDoc = await databases.collection("members").doc(assigneeId).get();
+	if (!memberDoc.exists) return null;
+	const mData = memberDoc.data();
+	const memberData = { ...mData, $id: memberDoc.id, $createdAt: normalizeDate(mData) } as any;
 	if (memberData.name) return { ...memberData, email: memberData.email ?? "" };
 	let u: { displayName?: string | null; email?: string } = {};
 	try {
@@ -294,21 +272,10 @@ const app = new Hono()
 				const chunk = assigneeIds.slice(i, i + 30);
 				if (chunk.length === 0) break;
 				const membersSnapshot = await databases.collection("members").where("__name__", "in", chunk).get();
-				const foundDocIds = new Set(membersSnapshot.docs.map((d: any) => d.id));
 				members.push(...membersSnapshot.docs.map((doc: any) => {
 					const data = doc.data();
 					return { ...data, $id: doc.id, $createdAt: normalizeDate(data) };
 				}));
-				// Fallback: any IDs not found by doc ID may be Firebase UIDs from an older code path
-				const notFoundIds = chunk.filter((id: string) => !foundDocIds.has(id));
-				for (let j = 0; j < notFoundIds.length; j += 10) {
-					const uidChunk = notFoundIds.slice(j, j + 10);
-					const byUidSnap = await databases.collection("members").where("userId", "in", uidChunk).get();
-					members.push(...byUidSnap.docs.map((doc: any) => {
-						const data = doc.data();
-						return { ...data, $id: doc.id, $createdAt: normalizeDate(data) };
-					}));
-				}
 			}
 
 			const assignees = await Promise.all(
@@ -332,8 +299,7 @@ const app = new Hono()
 
 			const populatedTasks = tasks.map((task: any) => {
 				const project = projects.find((p: any) => p.$id === task.projectId);
-				// Match by Firestore doc ID (normal) or by userId field (legacy tasks that stored Firebase UID)
-				const assignee = assignees.find((a: any) => a.$id === task.assigneeId || a.userId === task.assigneeId);
+				const assignee = assignees.find((a: any) => a.$id === task.assigneeId);
 				return {
 					...task,
 					project,

--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -65,16 +65,30 @@ async function resolveAssigneeName(
 ): Promise<string | undefined> {
 	if (!assigneeId) return undefined;
 	const assigneeDoc = await databases.collection("members").doc(assigneeId).get();
-	if (!assigneeDoc.exists) return undefined;
-	const ad = assigneeDoc.data();
-	if (ad?.name) return ad.name as string;
-	if (ad?.userId) {
-		try {
-			const au = await adminAuth.getUser(ad.userId as string);
-			return au.displayName || au.email || undefined;
-		} catch (err) {
-			console.error("Failed to resolve assignee name:", err);
+	if (assigneeDoc.exists) {
+		const ad = assigneeDoc.data();
+		if (ad?.name) return ad.name as string;
+		if (ad?.userId) {
+			try {
+				const au = await adminAuth.getUser(ad.userId as string);
+				return au.displayName || au.email || undefined;
+			} catch (err) {
+				console.error("Failed to resolve assignee name:", err);
+			}
 		}
+		return undefined;
+	}
+	// Fallback: assigneeId might be a Firebase UID stored by an older code path
+	try {
+		const snap = await databases.collection("members").where("userId", "==", assigneeId).limit(1).get();
+		if (!snap.empty) {
+			const d = snap.docs[0].data();
+			if (d?.name) return d.name as string;
+		}
+		const au = await adminAuth.getUser(assigneeId);
+		return au.displayName || au.email || undefined;
+	} catch (err) {
+		console.error("Failed to resolve assignee name (uid fallback):", err);
 	}
 	return undefined;
 }
@@ -155,10 +169,18 @@ async function resolveAssigneeDoc(
 	normalizeDate: (d: Record<string, unknown> | undefined) => string | undefined
 ): Promise<any> {
 	if (!assigneeId) return null;
-	const memberDoc = await databases.collection("members").doc(assigneeId).get();
-	if (!memberDoc.exists) return null;
-	const mData = memberDoc.data();
-	const memberData = { ...mData, $id: memberDoc.id, $createdAt: normalizeDate(mData) } as any;
+	let memberSnap: FirebaseFirestore.DocumentSnapshot | FirebaseFirestore.QueryDocumentSnapshot | null = null;
+	const byId = await databases.collection("members").doc(assigneeId).get();
+	if (byId.exists) {
+		memberSnap = byId;
+	} else {
+		// Fallback: assigneeId might be a Firebase UID stored by an older code path
+		const q = await databases.collection("members").where("userId", "==", assigneeId).limit(1).get();
+		if (!q.empty) memberSnap = q.docs[0];
+	}
+	if (!memberSnap) return null;
+	const mData = memberSnap.data();
+	const memberData = { ...mData, $id: memberSnap.id, $createdAt: normalizeDate(mData) } as any;
 	if (memberData.name) return { ...memberData, email: memberData.email ?? "" };
 	let u: { displayName?: string | null; email?: string } = {};
 	try {
@@ -272,16 +294,23 @@ const app = new Hono()
 				const chunk = assigneeIds.slice(i, i + 30);
 				if (chunk.length === 0) break;
 				const membersSnapshot = await databases.collection("members").where("__name__", "in", chunk).get();
+				const foundDocIds = new Set(membersSnapshot.docs.map((d: any) => d.id));
 				members.push(...membersSnapshot.docs.map((doc: any) => {
 					const data = doc.data();
-					return { 
-						...data,
-						$id: doc.id, 
-						$createdAt: normalizeDate(data),
-					};
+					return { ...data, $id: doc.id, $createdAt: normalizeDate(data) };
 				}));
+				// Fallback: any IDs not found by doc ID may be Firebase UIDs from an older code path
+				const notFoundIds = chunk.filter((id: string) => !foundDocIds.has(id));
+				for (let j = 0; j < notFoundIds.length; j += 10) {
+					const uidChunk = notFoundIds.slice(j, j + 10);
+					const byUidSnap = await databases.collection("members").where("userId", "in", uidChunk).get();
+					members.push(...byUidSnap.docs.map((doc: any) => {
+						const data = doc.data();
+						return { ...data, $id: doc.id, $createdAt: normalizeDate(data) };
+					}));
+				}
 			}
-			
+
 			const assignees = await Promise.all(
 				members.map(async (m) => {
 					if (m.name) {
@@ -300,10 +329,11 @@ const app = new Hono()
 					};
 				})
 			);
-			
+
 			const populatedTasks = tasks.map((task: any) => {
 				const project = projects.find((p: any) => p.$id === task.projectId);
-				const assignee = assignees.find((a: any) => a.$id === task.assigneeId);
+				// Match by Firestore doc ID (normal) or by userId field (legacy tasks that stored Firebase UID)
+				const assignee = assignees.find((a: any) => a.$id === task.assigneeId || a.userId === task.assigneeId);
 				return {
 					...task,
 					project,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause**: When project membership was added (commit `8b1568d`), the assignee dropdown switched from `useGetMembers` (workspace members with Firestore auto-IDs) to `useGetProjectMembers` (project sub-collection where doc IDs = Firebase UIDs). Tasks were then saved with `assigneeId` = Firebase UID, but all resolution code still queried the top-level `members` collection by Firestore doc ID → no match → `assignee = undefined` → "Unknown" in UI.
- **Fix 1 (root cause)**: `GET /api/projects/:projectId/members` now joins with the workspace-level `members` collection and returns the Firestore doc ID as `$id`. New tasks will store the correct Firestore member doc ID.
- **Fix 2 (backward compat)**: `resolveAssigneeName`, `resolveAssigneeDoc`, and the bulk task-list resolver all fall back to a `userId`-field query when a doc-ID lookup finds nothing — fixing tasks already saved with a Firebase UID as `assigneeId`.

## Test plan

- [ ] Sign in with Google
- [ ] Create or edit a task and assign it to yourself (or another member)
- [ ] Confirm the assignee column shows the display name, not "Unknown"
- [ ] Confirm tasks created before this fix (if any) also resolve the name correctly
- [ ] Confirm the assignee filter in the task list works correctly

https://claude.ai/code/session_01WsQEDk4uhYXa9aM3dZsD97
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WsQEDk4uhYXa9aM3dZsD97)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of workspace and project analytics computations.
  * Enhanced member information display with complete workspace-level metadata.

* **Style**
  * Code formatting updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->