### PR TITLE
Redesign Flowboard as Chronicle: dark-first UI system

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,33 +1,34 @@
-"use client";
-
-import { Button } from "@/components/ui/button";
-import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { ChronicleLogoFull } from "@/components/chronicle-logo";
+import { ReactNode } from "react";
 
 interface AuthLayoutProps {
-	children: React.ReactNode;
+	children: ReactNode;
 }
 
 const AuthLayout = ({ children }: AuthLayoutProps) => {
-	const pathname = usePathname();
-	const isSignIn = pathname === "/sign-in";
 	return (
-		<main className="bg-muted min-h-screen">
-			<div className="mx-auto max-w-screen-2xl p-4">
-				<nav className="flex justify-between items-center">
-					<Image src="/logo.svg" alt="Logo" width={152} height={56} priority />
-					<Button asChild variant="secondary">
-						<Link href={isSignIn ? "/sign-up" : "/sign-in"}>
-							{isSignIn ? "Sign Up" : "Sign In"}
-						</Link>
-					</Button>
-				</nav>
-				<div className="flex flex-col items-center justify-center pt-4 md:pt-14">
-					{children}
+		<div className="min-h-screen flex bg-background">
+			<div className="hidden lg:flex flex-col w-[55%] bg-card border-r border-border p-12">
+				<ChronicleLogoFull />
+				<div className="flex-1 flex flex-col justify-center gap-4">
+					<h1 className="text-4xl font-bold text-foreground leading-tight">
+						Build products
+						<br />
+						with context.
+					</h1>
+					<p className="text-muted-foreground text-base max-w-sm">
+						Tasks, docs, AI memory, and releases unified in one
+						workspace.
+					</p>
 				</div>
+				<p className="text-muted-foreground text-xs">
+					Chronicle · Built for engineering teams
+				</p>
 			</div>
-		</main>
+			<div className="flex-1 flex items-center justify-center bg-surface p-8">
+				<div className="w-full max-w-[420px]">{children}</div>
+			</div>
+		</div>
 	);
 };
 

--- a/src/app/(standalone)/layout.tsx
+++ b/src/app/(standalone)/layout.tsx
@@ -1,35 +1,14 @@
-import { UserButton } from "@/features/auth/components/user-button";
-import Image from "next/image";
-import Link from "next/link";
+import { ReactNode } from "react";
 
 interface StandaloneLayoutProps {
-	children: React.ReactNode;
+	children: ReactNode;
 }
 
 const StandaloneLayout = ({ children }: StandaloneLayoutProps) => {
 	return (
-		<main className="bg-muted min-h-screen">
-			<div className="mx-auto max-w-screen-2xl p-4">
-				<nav className="flex justify-between items-center h-[73px]">
-					<Link href="/">
-						<Image
-							src="/logo.svg"
-							alt="Logo"
-							width={0}
-							height={0}
-							sizes="100vw"
-							style={{ width: "100%", height: "40px" }}
-							className="object-cover w-fit h-12 -ml-4"
-							priority
-						/>
-					</Link>
-					<UserButton />
-				</nav>
-				<div className="flex flex-col items-center justify-center py-4">
-					{children}
-				</div>
-			</div>
-		</main>
+		<div className="min-h-screen bg-background">
+			{children}
+		</div>
 	);
 };
 

--- a/src/app/(standalone)/workspace/[workspaceId]/layout.tsx
+++ b/src/app/(standalone)/workspace/[workspaceId]/layout.tsx
@@ -3,11 +3,13 @@ import { AppModals } from "@/components/app-modals";
 import { DashboardShell } from "@/components/dashboard-shell";
 import { ReactNode } from "react";
 
-interface DashBoardLayoutProps {
-	children?: ReactNode;
+interface WorkspaceScopedStandaloneLayoutProps {
+	children: ReactNode;
 }
 
-const DashBoardLayout = ({ children }: DashBoardLayoutProps) => {
+const WorkspaceScopedStandaloneLayout = ({
+	children,
+}: WorkspaceScopedStandaloneLayoutProps) => {
 	return (
 		<SidebarProvider>
 			<AppModals />
@@ -16,4 +18,4 @@ const DashBoardLayout = ({ children }: DashBoardLayoutProps) => {
 	);
 };
 
-export default DashBoardLayout;
+export default WorkspaceScopedStandaloneLayout;

--- a/src/app/(standalone)/workspace/create/page.tsx
+++ b/src/app/(standalone)/workspace/create/page.tsx
@@ -1,13 +1,21 @@
 import { getCurrent } from "@/features/auth/queries";
 import { CreateWorkspaceForm } from "@/features/workspaces/components/create-workspace-form";
+import { ChronicleLogoFull } from "@/components/chronicle-logo";
 import { redirect } from "next/navigation";
 
 const WorkspaceCreatePage = async () => {
 	const user = await getCurrent();
 	if (!user) redirect("/sign-in");
 	return (
-		<div className="w-full lg:max-w-xl">
-			<CreateWorkspaceForm />
+		<div className="min-h-screen bg-background flex flex-col">
+			<div className="p-6">
+				<ChronicleLogoFull />
+			</div>
+			<div className="flex-1 flex items-center justify-center p-6">
+				<div className="w-full max-w-lg">
+					<CreateWorkspaceForm />
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-  font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer utilities {
   .text-balance {
     text-wrap: balance;
@@ -33,38 +29,39 @@ body {
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-    --radius: 0.5rem;
+    --surface: 0 0% 97%;
+    --success: 142 71% 45%;
+    --warning: 38 92% 50%;
+    --logo-start: 224 84% 56%;
+    --logo-end: 224 100% 40%;
+    --radius: 0.75rem;
   }
   .dark {
-    --background: 0 0% 3.9%;
-    --foreground: 0 0% 98%;
-    --card: 0 0% 3.9%;
-    --card-foreground: 0 0% 98%;
-    --popover: 0 0% 3.9%;
-    --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
-    --secondary: 0 0% 14.9%;
-    --secondary-foreground: 0 0% 98%;
-    --muted: 0 0% 14.9%;
-    --muted-foreground: 0 0% 63.9%;
-    --accent: 0 0% 14.9%;
-    --accent-foreground: 0 0% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
+    --background: 222 35% 8%;
+    --surface: 222 28% 13%;
+    --card: 222 32% 14%;
+    --card-foreground: 210 40% 98%;
+    --foreground: 210 40% 98%;
+    --popover: 222 32% 14%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 224 100% 65%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 222 25% 17%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 222 28% 17%;
+    --muted-foreground: 215 16% 57%;
+    --accent: 222 28% 20%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 86% 60%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 220 13% 18%;
+    --input: 222 28% 17%;
+    --ring: 224 100% 65%;
+    --success: 142 71% 45%;
+    --warning: 38 92% 50%;
+    --logo-start: 224 100% 72%;
+    --logo-end: 224 84% 56%;
+    --radius: 0.75rem;
   }
 }
 
@@ -77,11 +74,16 @@ body {
   }
 }
 
-.hide-scrollbar{
+.hide-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
 
-.hide-scrollbar::--webkit-scrollbar{
+.hide-scrollbar::-webkit-scrollbar {
   display: none;
+}
+
+.sidebar-transition {
+  transition: width 250ms cubic-bezier(0.4, 0, 0.2, 1),
+    padding-left 250ms cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,6 @@ import { cn } from "@/lib/utils";
 
 import "./globals.css";
 
-
-
 import { QueryProvider } from "@/components/query-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -14,8 +12,8 @@ import { ThemeProvider } from "@/components/theme-provider";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-	title: "FlowBoard",
-	description: "FlowBoard is a task management app for teams.",
+	title: "Chronicle",
+	description: "Developer-first project management",
 };
 
 export default function RootLayout({
@@ -26,7 +24,7 @@ export default function RootLayout({
 	return (
 		<html lang="en">
 			<body className={cn(inter.className, "antialiased min-h-screen")}>
-				<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+				<ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
 					<QueryProvider>
 						<Toaster />
 						{children}

--- a/src/components/analytics-card.tsx
+++ b/src/components/analytics-card.tsx
@@ -6,6 +6,7 @@ interface AnalyticsCardProps {
 	value: number;
 	variant: "up" | "down";
 	increaseValue: number;
+	inverted?: boolean;
 }
 
 export const AnalyticsCard = ({
@@ -13,8 +14,10 @@ export const AnalyticsCard = ({
 	value,
 	variant,
 	increaseValue,
+	inverted = false,
 }: AnalyticsCardProps) => {
 	const Icon = variant === "up" ? FaCaretUp : FaCaretDown;
+	const isPositiveOutcome = inverted ? variant === "down" : variant === "up";
 	return (
 		<div className="p-5">
 			<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide mb-2">
@@ -27,7 +30,7 @@ export const AnalyticsCard = ({
 				<div
 					className={cn(
 						"flex items-center gap-1 text-sm mb-0.5",
-						variant === "up" ? "text-success" : "text-destructive"
+						isPositiveOutcome ? "text-success" : "text-destructive"
 					)}
 				>
 					<Icon className="size-3.5" />

--- a/src/components/analytics-card.tsx
+++ b/src/components/analytics-card.tsx
@@ -1,5 +1,4 @@
 import { FaCaretDown, FaCaretUp } from "react-icons/fa";
-import { Card, CardDescription, CardHeader, CardTitle } from "./ui/card";
 import { cn } from "@/lib/utils";
 
 interface AnalyticsCardProps {
@@ -15,33 +14,26 @@ export const AnalyticsCard = ({
 	variant,
 	increaseValue,
 }: AnalyticsCardProps) => {
-	const iconColor = variant === "up" ? "text-emerald-500" : "text-red-500";
-	const increaseValueColor =
-		variant === "up" ? "text-emerald-500" : "text-red-500";
 	const Icon = variant === "up" ? FaCaretUp : FaCaretDown;
 	return (
-		<Card className="shadow-none border-none w-full">
-			<CardHeader>
-				<div className="flex items-center gap-x-2.5">
-					<CardDescription className="flex items-center gap-x-2 font-medium overflow-hidden">
-						<span className="truncate text-base">{title}</span>
-					</CardDescription>
-					<div className="flex items-center gap-x-1">
-						<Icon className={cn(iconColor, "size-4")} />
-						<span
-							className={cn(
-								increaseValueColor,
-								"truncate text-base font-medium"
-							)}
-						>
-							{increaseValue}
-						</span>
-					</div>
-				</div>
-				<CardTitle className="text-3xl font-semibold">
+		<div className="p-5">
+			<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide mb-2">
+				{title}
+			</p>
+			<div className="flex items-end gap-3">
+				<span className="text-3xl font-bold text-foreground">
 					{value}
-				</CardTitle>
-			</CardHeader>
-		</Card>
+				</span>
+				<div
+					className={cn(
+						"flex items-center gap-1 text-sm mb-0.5",
+						variant === "up" ? "text-success" : "text-destructive"
+					)}
+				>
+					<Icon className="size-3.5" />
+					<span>{Math.abs(increaseValue)}</span>
+				</div>
+			</div>
+		</div>
 	);
 };

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -1,65 +1,50 @@
 import { ProjectAnalyticsResponseType } from "@/features/projects/api/use-get-project-analytics";
-import { ScrollArea, ScrollBar } from "./ui/scroll-area";
 import { AnalyticsCard } from "./analytics-card";
-import { DottedSeperator } from "./dotted-seperator";
 
 export const Analytics = ({ data }: ProjectAnalyticsResponseType) => {
 	if (!data) return null;
 	return (
-		<ScrollArea className="border rounded-lg w-full whitespace-nowrap shrink-0">
-			<div className="w-full flex flex-row">
-				<div className="flex flex-1 items-center">
-					<AnalyticsCard
-						title="Total tasks"
-						value={data.taskCount}
-						variant={data.taskDifference > 0 ? "up" : "down"}
-						increaseValue={data.taskDifference}
-					/>
-					<DottedSeperator direction="vertical" />
-				</div>
-				<div className="flex flex-1 items-center">
-					<AnalyticsCard
-						title="Assigned tasks"
-						value={data.assignedTaskCount}
-						variant={
-							data.assignedTaskDifference > 0 ? "up" : "down"
-						}
-						increaseValue={data.assignedTaskDifference}
-					/>
-					<DottedSeperator direction="vertical" />
-				</div>
-				<div className="flex flex-1 items-center">
-					<AnalyticsCard
-						title="Completed tasks"
-						value={data.completedTaskCount}
-						variant={
-							data.completedTaskDifference > 0 ? "up" : "down"
-						}
-						increaseValue={data.completedTaskDifference}
-					/>
-					<DottedSeperator direction="vertical" />
-				</div>
-				<div className="flex flex-1 items-center">
-					<AnalyticsCard
-						title="Overdue tasks"
-						value={data.overdueTaskCount}
-						variant={data.overdueTaskDifference > 0 ? "up" : "down"}
-						increaseValue={data.overdueTaskDifference}
-					/>
-					<DottedSeperator direction="vertical" />
-				</div>
-				<div className="flex flex-1 items-center">
-					<AnalyticsCard
-						title="Incomplete tasks"
-						value={data.incompleteTaskCount}
-						variant={
-							data.incompleteTaskDifference > 0 ? "up" : "down"
-						}
-						increaseValue={data.incompleteTaskDifference}
-					/>
-				</div>
+		<div className="grid grid-cols-2 lg:grid-cols-5 gap-3 w-full shrink-0">
+			<div className="bg-card border border-border rounded-lg">
+				<AnalyticsCard
+					title="Total tasks"
+					value={data.taskCount}
+					variant={data.taskDifference > 0 ? "up" : "down"}
+					increaseValue={data.taskDifference}
+				/>
 			</div>
-			<ScrollBar orientation="horizontal" />
-		</ScrollArea>
+			<div className="bg-card border border-border rounded-lg">
+				<AnalyticsCard
+					title="Assigned tasks"
+					value={data.assignedTaskCount}
+					variant={data.assignedTaskDifference > 0 ? "up" : "down"}
+					increaseValue={data.assignedTaskDifference}
+				/>
+			</div>
+			<div className="bg-card border border-border rounded-lg">
+				<AnalyticsCard
+					title="Completed tasks"
+					value={data.completedTaskCount}
+					variant={data.completedTaskDifference > 0 ? "up" : "down"}
+					increaseValue={data.completedTaskDifference}
+				/>
+			</div>
+			<div className="bg-card border border-border rounded-lg">
+				<AnalyticsCard
+					title="Overdue tasks"
+					value={data.overdueTaskCount}
+					variant={data.overdueTaskDifference > 0 ? "up" : "down"}
+					increaseValue={data.overdueTaskDifference}
+				/>
+			</div>
+			<div className="bg-card border border-border rounded-lg col-span-2 lg:col-span-1">
+				<AnalyticsCard
+					title="Incomplete tasks"
+					value={data.incompleteTaskCount}
+					variant={data.incompleteTaskDifference > 0 ? "up" : "down"}
+					increaseValue={data.incompleteTaskDifference}
+				/>
+			</div>
+		</div>
 	);
 };

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -35,6 +35,7 @@ export const Analytics = ({ data }: ProjectAnalyticsResponseType) => {
 					value={data.overdueTaskCount}
 					variant={data.overdueTaskDifference > 0 ? "up" : "down"}
 					increaseValue={data.overdueTaskDifference}
+					inverted
 				/>
 			</div>
 			<div className="bg-card border border-border rounded-lg col-span-2 lg:col-span-1">
@@ -43,6 +44,7 @@ export const Analytics = ({ data }: ProjectAnalyticsResponseType) => {
 					value={data.incompleteTaskCount}
 					variant={data.incompleteTaskDifference > 0 ? "up" : "down"}
 					increaseValue={data.incompleteTaskDifference}
+					inverted
 				/>
 			</div>
 		</div>

--- a/src/components/app-modals.tsx
+++ b/src/components/app-modals.tsx
@@ -1,0 +1,19 @@
+import { CreateProjectModal } from "@/features/projects/components/create-project-modal";
+import { CreateTaskModal } from "@/features/tasks/components/create-task-model";
+import { EditTaskModal } from "@/features/tasks/components/edit-task-model";
+import { CreateWorkspaceModal } from "@/features/workspaces/components/create-workspace-modal";
+import { CreateSprintModal } from "@/features/sprints/components/create-sprint-modal";
+import { CreateVersionModal } from "@/features/versions/components/create-version-modal";
+
+export function AppModals() {
+	return (
+		<>
+			<CreateWorkspaceModal />
+			<CreateProjectModal />
+			<CreateTaskModal />
+			<EditTaskModal />
+			<CreateSprintModal />
+			<CreateVersionModal />
+		</>
+	);
+}

--- a/src/components/chronicle-logo.tsx
+++ b/src/components/chronicle-logo.tsx
@@ -1,37 +1,43 @@
+"use client";
+
+import { useId } from "react";
 import { cn } from "@/lib/utils";
 
-export const ChronicleLogomark = () => (
-	<svg
-		width="28"
-		height="28"
-		viewBox="0 0 28 28"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-		aria-hidden="true"
-	>
-		<path
-			d="M24 14C24 19.5228 19.5228 24 14 24C8.47715 24 4 19.5228 4 14C4 8.47715 8.47715 4 14 4C16.5 4 18.8 4.9 20.5 6.5"
-			stroke="url(#chronicle-grad)"
-			strokeWidth="3"
-			strokeLinecap="round"
+export const ChronicleLogomark = () => {
+	const gradientId = useId();
+	return (
+		<svg
+			width="28"
+			height="28"
+			viewBox="0 0 28 28"
 			fill="none"
-		/>
-		<circle cx="14" cy="14" r="3" fill="url(#chronicle-grad)" />
-		<defs>
-			<linearGradient
-				id="chronicle-grad"
-				x1="4"
-				y1="4"
-				x2="24"
-				y2="24"
-				gradientUnits="userSpaceOnUse"
-			>
-				<stop offset="0%" stopColor="hsl(var(--logo-start))" />
-				<stop offset="100%" stopColor="hsl(var(--logo-end))" />
-			</linearGradient>
-		</defs>
-	</svg>
-);
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+		>
+			<path
+				d="M24 14C24 19.5228 19.5228 24 14 24C8.47715 24 4 19.5228 4 14C4 8.47715 8.47715 4 14 4C16.5 4 18.8 4.9 20.5 6.5"
+				stroke={`url(#${gradientId})`}
+				strokeWidth="3"
+				strokeLinecap="round"
+				fill="none"
+			/>
+			<circle cx="14" cy="14" r="3" fill={`url(#${gradientId})`} />
+			<defs>
+				<linearGradient
+					id={gradientId}
+					x1="4"
+					y1="4"
+					x2="24"
+					y2="24"
+					gradientUnits="userSpaceOnUse"
+				>
+					<stop offset="0%" stopColor="hsl(var(--logo-start))" />
+					<stop offset="100%" stopColor="hsl(var(--logo-end))" />
+				</linearGradient>
+			</defs>
+		</svg>
+	);
+};
 
 export const ChronicleLogoFull = ({ className }: { className?: string }) => (
 	<div className={cn("flex items-center gap-2.5", className)}>

--- a/src/components/chronicle-logo.tsx
+++ b/src/components/chronicle-logo.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+export const ChronicleLogomark = () => (
+	<svg
+		width="28"
+		height="28"
+		viewBox="0 0 28 28"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		aria-hidden="true"
+	>
+		<path
+			d="M24 14C24 19.5228 19.5228 24 14 24C8.47715 24 4 19.5228 4 14C4 8.47715 8.47715 4 14 4C16.5 4 18.8 4.9 20.5 6.5"
+			stroke="url(#chronicle-grad)"
+			strokeWidth="3"
+			strokeLinecap="round"
+			fill="none"
+		/>
+		<circle cx="14" cy="14" r="3" fill="url(#chronicle-grad)" />
+		<defs>
+			<linearGradient
+				id="chronicle-grad"
+				x1="4"
+				y1="4"
+				x2="24"
+				y2="24"
+				gradientUnits="userSpaceOnUse"
+			>
+				<stop offset="0%" stopColor="hsl(var(--logo-start))" />
+				<stop offset="100%" stopColor="hsl(var(--logo-end))" />
+			</linearGradient>
+		</defs>
+	</svg>
+);
+
+export const ChronicleLogoFull = ({ className }: { className?: string }) => (
+	<div className={cn("flex items-center gap-2.5", className)}>
+		<ChronicleLogomark />
+		<span className="text-foreground font-semibold text-lg tracking-tight">
+			Chronicle
+		</span>
+	</div>
+);

--- a/src/components/dashboard-shell.tsx
+++ b/src/components/dashboard-shell.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useSidebarCollapsed } from "@/contexts/sidebar-context";
+import { Sidebar } from "./sidebar";
+import { Navbar } from "./navbar";
+import { ReactNode } from "react";
+
+export function DashboardShell({ children }: { children: ReactNode }) {
+	const { isCollapsed } = useSidebarCollapsed();
+
+	return (
+		<div className="flex w-full h-full">
+			<div
+				className={cn(
+					"fixed left-0 top-0 hidden lg:block h-full overflow-y-auto sidebar-transition z-40",
+					isCollapsed ? "w-[72px]" : "w-[260px]"
+				)}
+			>
+				<Sidebar />
+			</div>
+			<div
+				className={cn(
+					"w-full sidebar-transition",
+					isCollapsed ? "lg:pl-[72px]" : "lg:pl-[260px]"
+				)}
+			>
+				<div className="mx-auto max-w-screen-2xl h-full">
+					<Navbar />
+					<main className="h-full py-6 px-6 flex flex-col">
+						{children}
+					</main>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/mobile-sidebar.tsx
+++ b/src/components/mobile-sidebar.tsx
@@ -21,7 +21,7 @@ export const MobileSidebar = () => {
 					<MenuIcon className="size-4 text-muted-foreground" />
 				</Button>
 			</SheetTrigger>
-			<SheetContent side="left" className="p-0">
+			<SheetContent side="left" className="p-0 bg-card">
 				<Sidebar />
 			</SheetContent>
 		</Sheet>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -71,6 +71,11 @@ export const Navbar = () => {
 		});
 	}
 
+	// Placeholder: wire up to a command palette modal when implementing
+	const handleCommandPalette = () => {
+		return;
+	};
+
 	const isTaskDetailPage = new Set(["epic", "story", "spike", "bug"]).has(
 		pageSegment ?? ""
 	);
@@ -127,7 +132,7 @@ export const Navbar = () => {
 			<div className="flex items-center gap-2 shrink-0">
 				<button
 					type="button"
-					onClick={() => { /* setCommandOpen(true) */ }}
+					onClick={handleCommandPalette}
 					className="hidden md:flex items-center gap-2 h-9 w-[220px] px-3 rounded-md bg-muted border border-border text-sm text-muted-foreground hover:border-primary/40 hover:text-foreground transition"
 				>
 					<Search className="size-4 shrink-0" />
@@ -138,7 +143,7 @@ export const Navbar = () => {
 				</button>
 				<button
 					type="button"
-					onClick={() => { /* setCommandOpen(true) */ }}
+					onClick={handleCommandPalette}
 					className="md:hidden p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition"
 					aria-label="Search"
 				>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -7,8 +7,9 @@ import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useProjectId } from "@/features/projects/hooks/use-project-id";
 import { useGetWorkspace } from "@/features/workspaces/api/use-get-workspace";
 import { useGetProject } from "@/features/projects/api/use-get-project";
+import { useSidebarCollapsed } from "@/contexts/sidebar-context";
 import Link from "next/link";
-import { ChevronRightIcon } from "lucide-react";
+import { Bell, ChevronRightIcon, PanelLeft, Search, Sparkles } from "lucide-react";
 
 const PAGE_LABEL: Record<string, string> = {
 	backlog: "Backlog",
@@ -32,20 +33,24 @@ export const Navbar = () => {
 	const pathname = usePathname();
 	const workspaceId = useWorkspaceId();
 	const projectId = useProjectId();
+	const { toggleSidebar } = useSidebarCollapsed();
 
-	const { data: workspace } = useGetWorkspace({ workspaceId: workspaceId ?? "", enabled: !!workspaceId });
-	const { data: project } = useGetProject({ projectId: projectId ?? "", enabled: !!projectId });
+	const { data: workspace } = useGetWorkspace({
+		workspaceId: workspaceId ?? "",
+		enabled: !!workspaceId,
+	});
+	const { data: project } = useGetProject({
+		projectId: projectId ?? "",
+		enabled: !!projectId,
+	});
 
 	const parts = pathname.split("/").filter(Boolean);
-	// parts: ["workspace", workspaceId, "project"?, projectId?, page?]
 
 	const pageSegment = (() => {
-		// Detail pages: epic/[id], story/[id], spike/[id], bug/[id]
 		const detailTypes = new Set(["epic", "story", "spike", "bug"]);
 		for (let i = parts.length - 2; i >= 0; i--) {
 			if (detailTypes.has(parts[i])) return parts[i];
 		}
-		// List page or root
 		const last = parts[parts.length - 1];
 		return PAGE_LABEL[last] ? last : null;
 	})();
@@ -66,30 +71,38 @@ export const Navbar = () => {
 		});
 	}
 
-	const isTaskDetailPage = new Set(["epic", "story", "spike", "bug"]).has(pageSegment ?? "");
+	const isTaskDetailPage = new Set(["epic", "story", "spike", "bug"]).has(
+		pageSegment ?? ""
+	);
 
 	const pageLabel = pageSegment
-		? PAGE_LABEL[pageSegment] ?? (pageSegment.charAt(0).toUpperCase() + pageSegment.slice(1))
+		? PAGE_LABEL[pageSegment] ??
+		  pageSegment.charAt(0).toUpperCase() + pageSegment.slice(1)
 		: null;
 
-	const title =
-		pageLabel ??
-		(project ? project.name : null) ??
-		(workspace ? workspace.name : null) ??
-		"Home";
-
 	return (
-		<nav className="pt-4 px-6 flex items-center justify-between">
-			{!isTaskDetailPage && (
-			<div className="flex-col hidden lg:flex gap-y-1">
-				<h1 className="text-2xl font-semibold">{title}</h1>
-				{crumbs.length > 0 && (
-					<div className="flex items-center gap-x-1 text-sm text-muted-foreground">
+		<nav className="h-[60px] px-6 flex items-center gap-4 border-b border-border bg-card sticky top-0 z-30">
+			<div className="flex items-center gap-3 min-w-0">
+				<MobileSidebar />
+				<button
+					onClick={toggleSidebar}
+					className="hidden lg:flex p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition"
+					aria-label="Toggle sidebar"
+				>
+					<PanelLeft className="size-4" />
+				</button>
+				{!isTaskDetailPage && (
+					<div className="hidden lg:flex items-center gap-x-1 text-sm text-muted-foreground">
 						{crumbs.map((crumb, i) => (
 							<span key={i} className="flex items-center gap-x-1">
-								{i > 0 && <ChevronRightIcon className="size-3" />}
+								{i > 0 && (
+									<ChevronRightIcon className="size-3" />
+								)}
 								{crumb.href ? (
-									<Link href={crumb.href} className="hover:text-foreground transition">
+									<Link
+										href={crumb.href}
+										className="hover:text-foreground transition"
+									>
 										{crumb.label}
 									</Link>
 								) : (
@@ -100,15 +113,54 @@ export const Navbar = () => {
 						{pageLabel && (
 							<>
 								<ChevronRightIcon className="size-3" />
-								<span className="text-foreground font-medium">{pageLabel}</span>
+								<span className="text-foreground font-medium">
+									{pageLabel}
+								</span>
 							</>
 						)}
 					</div>
 				)}
 			</div>
-			)}
-			<MobileSidebar />
-			<UserButton />
+
+			<div className="flex-1" />
+
+			<div className="flex items-center gap-2 shrink-0">
+				<button
+					type="button"
+					onClick={() => { /* setCommandOpen(true) */ }}
+					className="hidden md:flex items-center gap-2 h-9 w-[220px] px-3 rounded-md bg-muted border border-border text-sm text-muted-foreground hover:border-primary/40 hover:text-foreground transition"
+				>
+					<Search className="size-4 shrink-0" />
+					<span className="flex-1 text-left">Search...</span>
+					<kbd className="text-[10px] bg-background px-1.5 py-0.5 rounded border border-border font-mono shrink-0">
+						⌘K
+					</kbd>
+				</button>
+				<button
+					type="button"
+					onClick={() => { /* setCommandOpen(true) */ }}
+					className="md:hidden p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition"
+					aria-label="Search"
+				>
+					<Search className="size-4" />
+				</button>
+
+				<button
+					className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition"
+					aria-label="Notifications"
+				>
+					<Bell className="size-4" />
+				</button>
+
+				<button
+					className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition"
+					aria-label="AI actions"
+				>
+					<Sparkles className="size-4" />
+				</button>
+
+				<UserButton />
+			</div>
 		</nav>
 	);
 };

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSidebarCollapsed } from "@/contexts/sidebar-context";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { cn } from "@/lib/utils";
 import { SettingsIcon, UsersIcon } from "lucide-react";
@@ -9,16 +10,10 @@ import { GoHome, GoHomeFill } from "react-icons/go";
 
 const routes = [
 	{
-		label: "Home",
+		label: "Overview",
 		href: "",
 		icon: GoHome,
 		activeIcon: GoHomeFill,
-	},
-	{
-		label: "Settings",
-		href: "/settings",
-		icon: SettingsIcon,
-		activeIcon: SettingsIcon,
 	},
 	{
 		label: "Members",
@@ -26,13 +21,23 @@ const routes = [
 		icon: UsersIcon,
 		activeIcon: UsersIcon,
 	},
+	{
+		label: "Settings",
+		href: "/settings",
+		icon: SettingsIcon,
+		activeIcon: SettingsIcon,
+	},
 ];
 
 export const Navigation = () => {
 	const workspaceId = useWorkspaceId();
 	const pathname = usePathname();
+	const { isCollapsed } = useSidebarCollapsed();
+
+	if (!workspaceId) return null;
+
 	return (
-		<ul className="flex flex-col">
+		<ul className="flex flex-col gap-0.5">
 			{routes.map((route) => {
 				const fullHref = `/workspace/${workspaceId}${route.href}`;
 				const isActive = pathname === fullHref;
@@ -41,13 +46,20 @@ export const Navigation = () => {
 					<Link key={route.href} href={fullHref}>
 						<div
 							className={cn(
-								"flex items-center gap-2.5 p-2.5 rounded-md font-medium hover:text-primary transition text-muted-foreground",
-								isActive &&
-									"bg-background shadow-sm hover:opacity-100 text-primary"
+								"flex items-center gap-2.5 py-2 rounded-md font-medium transition",
+								isCollapsed
+									? "justify-center px-2"
+									: "px-2.5",
+								isActive
+									? "bg-card border-l-2 border-primary text-foreground shadow-sm pl-[calc(0.625rem_-_2px)]"
+									: "text-muted-foreground hover:bg-accent hover:text-foreground"
 							)}
+							title={isCollapsed ? route.label : undefined}
 						>
-							<Icon className="size-5 text-muted-foreground" />
-							{route.label}
+							<Icon className="size-5 shrink-0" />
+							{!isCollapsed && (
+								<span className="text-sm">{route.label}</span>
+							)}
 						</div>
 					</Link>
 				);

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -15,13 +15,13 @@ import { useCreateVersionModal } from "@/features/versions/hooks/use-create-vers
 import { IssueType } from "@/features/tasks/types";
 
 const subItems = [
-	{ label: "Backlog", icon: List, color: "text-blue-600", bg: "bg-blue-50 dark:bg-blue-950", hrefSuffix: "/backlog", issueType: undefined, modalType: "task" as const },
-	{ label: "Sprints", icon: Timer, color: "text-green-600", bg: "bg-green-50 dark:bg-green-950", hrefSuffix: "/sprints", issueType: undefined, modalType: "sprint" as const },
-	{ label: "Releases", icon: Rocket, color: "text-purple-600", bg: "bg-purple-50 dark:bg-purple-950", hrefSuffix: "/releases", issueType: undefined, modalType: "release" as const },
-	{ label: "Epics", icon: Target, color: "text-amber-600", bg: "bg-amber-50 dark:bg-amber-950", hrefSuffix: "/epics", issueType: "EPIC" as IssueType, modalType: "task" as const },
-	{ label: "Stories", icon: BookOpen, color: "text-emerald-600", bg: "bg-emerald-50 dark:bg-emerald-950", hrefSuffix: "/stories", issueType: "STORY" as IssueType, modalType: "task" as const },
-	{ label: "Spikes", icon: Zap, color: "text-yellow-600", bg: "bg-yellow-50 dark:bg-yellow-950", hrefSuffix: "/spikes", issueType: "SPIKE" as IssueType, modalType: "task" as const },
-	{ label: "Bugs", icon: Bug, color: "text-red-600", bg: "bg-red-50 dark:bg-red-950", hrefSuffix: "/bugs", issueType: "BUG" as IssueType, modalType: "task" as const },
+	{ label: "Backlog", icon: List, color: "text-blue-400", bg: "bg-blue-950", hrefSuffix: "/backlog", issueType: undefined, modalType: "task" as const },
+	{ label: "Sprints", icon: Timer, color: "text-green-400", bg: "bg-green-950", hrefSuffix: "/sprints", issueType: undefined, modalType: "sprint" as const },
+	{ label: "Releases", icon: Rocket, color: "text-purple-400", bg: "bg-purple-950", hrefSuffix: "/releases", issueType: undefined, modalType: "release" as const },
+	{ label: "Epics", icon: Target, color: "text-amber-400", bg: "bg-amber-950", hrefSuffix: "/epics", issueType: "EPIC" as IssueType, modalType: "task" as const },
+	{ label: "Stories", icon: BookOpen, color: "text-emerald-400", bg: "bg-emerald-950", hrefSuffix: "/stories", issueType: "STORY" as IssueType, modalType: "task" as const },
+	{ label: "Spikes", icon: Zap, color: "text-yellow-400", bg: "bg-yellow-950", hrefSuffix: "/spikes", issueType: "SPIKE" as IssueType, modalType: "task" as const },
+	{ label: "Bugs", icon: Bug, color: "text-red-400", bg: "bg-red-950", hrefSuffix: "/bugs", issueType: "BUG" as IssueType, modalType: "task" as const },
 ];
 
 interface SubItemProps {
@@ -58,10 +58,10 @@ const SubItem = ({ label, icon: Icon, color, bg, href, projectId, issueType, mod
 		<div className="relative group">
 			<Link href={href} className="block">
 				<div className={cn(
-					"flex items-center justify-between p-1.5 rounded-lg transition-all",
+					"flex items-center justify-between p-1.5 rounded-md transition-all",
 					isActive
-						? "bg-background border border-border text-foreground shadow-sm"
-						: "hover:bg-background hover:border-border hover:shadow-sm border border-transparent"
+						? "bg-card border-l-2 border-primary text-foreground shadow-sm"
+						: "hover:bg-accent border border-transparent hover:text-foreground"
 				)}>
 					<div className="flex items-center gap-x-2">
 						<div className={cn("p-1.5 rounded-md", bg)}>
@@ -111,10 +111,12 @@ export const Projects = () => {
 		}
 	};
 
+	if (!workspaceId) return null;
+
 	return (
 		<div className="flex flex-col gap-y-4">
 			<div className="flex items-center justify-between">
-				<p className="text-xs uppercase text-muted-foreground tracking-tight">Projects</p>
+				<p className="text-xs uppercase text-muted-foreground tracking-widest">Projects</p>
 				<button
 					onClick={open}
 					aria-label="Create project"
@@ -135,22 +137,22 @@ export const Projects = () => {
 								<Link href={href} className="flex-1">
 									<div
 										className={cn(
-											"flex items-center gap-3 p-2.5 rounded-xl transition cursor-pointer group",
+											"flex items-center gap-3 p-2.5 rounded-md transition cursor-pointer group",
 											isActive
-												? "bg-background border border-border text-foreground shadow-sm"
-												: "hover:bg-muted/50 text-muted-foreground"
+												? "bg-card border-l-2 border-primary text-foreground shadow-sm"
+												: "hover:bg-accent text-muted-foreground hover:text-foreground"
 										)}
 									>
 										<ProjectAvatar
 											imageUrl={project.imageUrl}
 											name={project.name}
 										/>
-										<span className="truncate font-medium">{project.name}</span>
+										<span className="truncate font-medium text-sm">{project.name}</span>
 									</div>
 								</Link>
 								<button
 									onClick={(e) => toggleExpand(e, project.$id)}
-									className="p-1.5 hover:bg-muted rounded-lg transition"
+									className="p-1.5 hover:bg-accent rounded-md transition"
 								>
 									<ChevronDown className={cn(
 										"size-4 text-muted-foreground transition-transform duration-200",
@@ -159,7 +161,7 @@ export const Projects = () => {
 								</button>
 							</div>
 							{isExpanded && (
-								<div className="flex flex-col gap-y-0.5 ml-1 pl-2 border-l border-border dark:border-muted-foreground/30">
+								<div className="flex flex-col gap-y-0.5 ml-1 pl-2 border-l border-border">
 									{subItems.map((item) => (
 										<SubItem
 											key={item.label}

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -151,7 +151,10 @@ export const Projects = () => {
 									</div>
 								</Link>
 								<button
+									type="button"
 									onClick={(e) => toggleExpand(e, project.$id)}
+									aria-label={isExpanded ? `Collapse ${project.name}` : `Expand ${project.name}`}
+									aria-expanded={isExpanded}
 									className="p-1.5 hover:bg-accent rounded-md transition"
 								>
 									<ChevronDown className={cn(

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,31 +1,51 @@
-import Image from "next/image";
-import Link from "next/link";
-import { DottedSeperator } from "./dotted-seperator";
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useSidebarCollapsed } from "@/contexts/sidebar-context";
+import { ChronicleLogoFull, ChronicleLogomark } from "./chronicle-logo";
 import { Navigation } from "./navigation";
 import { WorkspaceSwitcher } from "./workspace-switcher";
 import { Projects } from "./projects";
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
 
 export const Sidebar = () => {
+	const { isCollapsed, toggleSidebar } = useSidebarCollapsed();
+
 	return (
-		<aside className="h-full bg-muted p-4 w-full">
-			<Link href="/">
-					<Image
-						src="/logo.svg"
-						alt="Logo"
-						width={0}
-						height={0}
-						sizes="100vw"
-						style={{ width: "100%", height: "40px" }}
-						className="object-cover w-fit h-12 -ml-4"
-						priority
-					/>
-			</Link>
-			<DottedSeperator className="my-4" />
-			<WorkspaceSwitcher />
-			<DottedSeperator className="my-4" />
-			<Navigation />
-			<DottedSeperator className="my-4" />
-			<Projects />
+		<aside
+			className={cn(
+				"flex flex-col h-full bg-card border-r border-border sidebar-transition overflow-hidden",
+				isCollapsed ? "w-[72px]" : "w-[260px]"
+			)}
+		>
+			<div className="flex items-center justify-between h-[60px] px-4 border-b border-border shrink-0">
+				{isCollapsed ? <ChronicleLogomark /> : <ChronicleLogoFull />}
+				<button
+					onClick={toggleSidebar}
+					className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition"
+					aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+				>
+					{isCollapsed ? (
+						<ChevronsRight className="size-4" />
+					) : (
+						<ChevronsLeft className="size-4" />
+					)}
+				</button>
+			</div>
+
+			<div className="px-3 py-3 border-b border-border shrink-0">
+				<WorkspaceSwitcher />
+			</div>
+
+			<div className="flex-1 overflow-y-auto px-3 py-2 flex flex-col gap-1 hide-scrollbar">
+				<Navigation />
+				{!isCollapsed && (
+					<>
+						<div className="h-px bg-border my-2" />
+						<Projects />
+					</>
+				)}
+			</div>
 		</aside>
 	);
 };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { TaskPriority, TaskStatus } from "@/features/tasks/types";
 
 const badgeVariants = cva(
-	"inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+	"inline-flex items-center rounded-pill border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
 	{
 		variants: {
 			variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,16 +10,16 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				primary:
-					"bg-gradient-to-b from-blue-600 to-blue-700 text-primary-foreground hover:from-blue-700 hover:to-blue-700",
+					"bg-primary text-primary-foreground hover:bg-primary/90 border-transparent",
 				destructive:
-					"bg-gradient-to-b from-amber-600 to-amber-700 text-destructive-foreground hover:from-amber-700 hover:to-amber-700",
+					"bg-destructive text-destructive-foreground hover:bg-destructive/90 border-transparent",
 				outline:
 					"border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
 				secondary: "bg-card text-foreground hover:bg-muted",
 				ghost: "border-transparent shadow-none hover:bg-accent hover:text-accent-foreground",
-				muted: "bg-muted text-muted-foreground hover:bg-muted/80",
+				muted: "bg-muted text-muted-foreground hover:bg-muted/80 border-transparent",
 				teritary:
-					"bg-blue-100 text-blue-600 border-transparent hover:bg-blue-200 shadow-none",
+					"bg-primary/10 text-primary border-transparent hover:bg-primary/20 shadow-none",
 			},
 			size: {
 				default: "h-10 px-4 py-2",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-lg border bg-card text-card-foreground shadow",
       className
     )}
     {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
 			<input
 				type={type}
 				className={cn(
-					"flex h-12 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+					"flex h-12 w-full rounded-md border border-input bg-muted px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
 					className
 				)}
 				ref={ref}

--- a/src/components/workspace-switcher.tsx
+++ b/src/components/workspace-switcher.tsx
@@ -25,14 +25,14 @@ export const WorkspaceSwitcher = () => {
 	return (
 		<div className="flex flex-col gap-y-2">
 			<div className="flex items-center justify-between">
-				<p className="text-xs uppercase text-muted-foreground">Workspaces</p>
+				<p className="text-xs uppercase text-muted-foreground tracking-widest">Workspaces</p>
 				<RiAddCircleFill
 					onClick={open}
-					className="size-5 text-muted-foreground cursor-pointer hover:opacity-75 transition"
+					className="size-5 text-primary cursor-pointer hover:text-primary/80 transition"
 				/>
 			</div>
 			<Select onValueChange={onSelect} value={workspaceId}>
-				<SelectTrigger className="w-full bg-muted font-medium p-1">
+				<SelectTrigger className="w-full bg-muted border-border font-medium p-1 rounded-md">
 					<SelectValue placeholder="No workspace selected" />
 					<SelectContent>
 						{workspaces?.documents.map((workspace) => (

--- a/src/components/workspace-switcher.tsx
+++ b/src/components/workspace-switcher.tsx
@@ -26,10 +26,14 @@ export const WorkspaceSwitcher = () => {
 		<div className="flex flex-col gap-y-2">
 			<div className="flex items-center justify-between">
 				<p className="text-xs uppercase text-muted-foreground tracking-widest">Workspaces</p>
-				<RiAddCircleFill
+				<button
+					type="button"
 					onClick={open}
-					className="size-5 text-primary cursor-pointer hover:text-primary/80 transition"
-				/>
+					aria-label="Create workspace"
+					className="rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<RiAddCircleFill className="size-5 text-primary hover:text-primary/80 transition" />
+				</button>
 			</div>
 			<Select onValueChange={onSelect} value={workspaceId}>
 				<SelectTrigger className="w-full bg-muted border-border font-medium p-1 rounded-md">

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -38,7 +38,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 	const isTablet = useMedia("(min-width: 1024px) and (max-width: 1279px)");
 
 	useEffect(() => {
-		const saved = globalThis.localStorage.getItem("chronicle-sidebar");
+		const saved = localStorage.getItem("chronicle-sidebar");
 		if (saved !== null) {
 			setIsCollapsed(saved === "true");
 		} else {
@@ -57,7 +57,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 	const toggleSidebar = useCallback(() => {
 		setIsCollapsed((prev) => {
 			const next = !prev;
-			globalThis.localStorage.setItem("chronicle-sidebar", String(next));
+			localStorage.setItem("chronicle-sidebar", String(next));
 			return next;
 		});
 	}, []);

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { IssueType } from "@/features/tasks/types";
-import { createContext, useContext, useState, useCallback, useMemo, ReactNode } from "react";
+import {
+	createContext,
+	useContext,
+	useState,
+	useCallback,
+	useMemo,
+	useEffect,
+	ReactNode,
+} from "react";
+import { useMedia } from "@/hooks/use-media";
 
 interface SidebarPrefill {
 	projectId?: string;
@@ -15,12 +24,27 @@ interface SidebarContextValue {
 	prefill: SidebarPrefill;
 	setPrefill: (prefill: SidebarPrefill) => void;
 	clearPrefill: () => void;
+	isCollapsed: boolean;
+	toggleSidebar: () => void;
 }
 
-const SidebarContext = createContext<SidebarContextValue | undefined>(undefined);
+const SidebarContext = createContext<SidebarContextValue | undefined>(
+	undefined
+);
 
 export function SidebarProvider({ children }: { children: ReactNode }) {
 	const [prefill, setPrefillState] = useState<SidebarPrefill>({});
+	const [isCollapsed, setIsCollapsed] = useState(false);
+	const isTablet = useMedia("(max-width: 1279px)");
+
+	useEffect(() => {
+		const saved = localStorage.getItem("chronicle-sidebar");
+		if (saved !== null) {
+			setIsCollapsed(saved === "true");
+		} else {
+			setIsCollapsed(isTablet);
+		}
+	}, [isTablet]);
 
 	const setPrefill = useCallback((newPrefill: SidebarPrefill) => {
 		setPrefillState((prev) => ({ ...prev, ...newPrefill }));
@@ -30,9 +54,23 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 		setPrefillState({});
 	}, []);
 
+	const toggleSidebar = useCallback(() => {
+		setIsCollapsed((prev) => {
+			const next = !prev;
+			localStorage.setItem("chronicle-sidebar", String(next));
+			return next;
+		});
+	}, []);
+
 	const value = useMemo(
-		() => ({ prefill, setPrefill, clearPrefill }),
-		[prefill, setPrefill, clearPrefill]
+		() => ({
+			prefill,
+			setPrefill,
+			clearPrefill,
+			isCollapsed,
+			toggleSidebar,
+		}),
+		[prefill, setPrefill, clearPrefill, isCollapsed, toggleSidebar]
 	);
 
 	return (
@@ -45,7 +83,9 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 export function useSidebarContext() {
 	const context = useContext(SidebarContext);
 	if (!context) {
-		throw new Error("useSidebarContext must be used within a SidebarProvider");
+		throw new Error(
+			"useSidebarContext must be used within a SidebarProvider"
+		);
 	}
 	return context;
 }
@@ -53,4 +93,9 @@ export function useSidebarContext() {
 export function usePrefill() {
 	const { prefill, setPrefill, clearPrefill } = useSidebarContext();
 	return { prefill, setPrefill, clearPrefill };
+}
+
+export function useSidebarCollapsed() {
+	const { isCollapsed, toggleSidebar } = useSidebarContext();
+	return { isCollapsed, toggleSidebar };
 }

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -35,7 +35,7 @@ const SidebarContext = createContext<SidebarContextValue | undefined>(
 export function SidebarProvider({ children }: { children: ReactNode }) {
 	const [prefill, setPrefillState] = useState<SidebarPrefill>({});
 	const [isCollapsed, setIsCollapsed] = useState(false);
-	const isTablet = useMedia("(max-width: 1279px)");
+	const isTablet = useMedia("(min-width: 1024px) and (max-width: 1279px)");
 
 	useEffect(() => {
 		const saved = localStorage.getItem("chronicle-sidebar");

--- a/src/contexts/sidebar-context.tsx
+++ b/src/contexts/sidebar-context.tsx
@@ -38,7 +38,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 	const isTablet = useMedia("(min-width: 1024px) and (max-width: 1279px)");
 
 	useEffect(() => {
-		const saved = localStorage.getItem("chronicle-sidebar");
+		const saved = globalThis.localStorage.getItem("chronicle-sidebar");
 		if (saved !== null) {
 			setIsCollapsed(saved === "true");
 		} else {
@@ -57,7 +57,7 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
 	const toggleSidebar = useCallback(() => {
 		setIsCollapsed((prev) => {
 			const next = !prev;
-			localStorage.setItem("chronicle-sidebar", String(next));
+			globalThis.localStorage.setItem("chronicle-sidebar", String(next));
 			return next;
 		});
 	}, []);

--- a/src/features/auth/components/sign-in-card.tsx
+++ b/src/features/auth/components/sign-in-card.tsx
@@ -17,7 +17,7 @@ import { loginSchema } from "../schemas";
 import { useLogin } from "../api/use-login";
 import { FcGoogle } from "react-icons/fc";
 import { FaGithub } from "react-icons/fa";
-import { signInWithPopup } from "firebase/auth";
+import { signInWithPopup, type AuthProvider } from "firebase/auth";
 import { auth, googleProvider, githubProvider } from "@/lib/firebase";
 import { client } from "@/lib/rpc";
 import { toast } from "sonner";
@@ -40,7 +40,7 @@ export const SignInCard = () => {
 		mutate({ json: values });
 	};
 
-	const signInWithOAuthProvider = async (provider: any, providerName: string) => {
+	const signInWithOAuthProvider = async (provider: AuthProvider, providerName: string) => {
 		try {
 			const result = await signInWithPopup(auth, provider);
 			const idToken = await result.user.getIdToken();

--- a/src/features/auth/components/sign-in-card.tsx
+++ b/src/features/auth/components/sign-in-card.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { DottedSeperator } from "@/components/dotted-seperator";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { z } from "zod";
 import { useForm } from "react-hook-form";
@@ -63,67 +61,72 @@ export const SignInCard = () => {
 	const onGoogleSignIn = () => signInWithOAuthProvider(googleProvider, "Google");
 	const onGithubSignIn = () => signInWithOAuthProvider(githubProvider, "Github");
 
-
 	return (
-		<Card className="w-full h-full md:w-[487px] border-none shadow-none">
-			<CardHeader className="flex items-center justify-center text-center p-7">
-				<CardTitle className="text-2xl">Welcome Back!</CardTitle>
-			</CardHeader>
-			<div className="px-7">
-				<DottedSeperator />
+		<div className="w-full">
+			<div className="mb-8">
+				<h2 className="text-2xl font-bold text-foreground">
+					Welcome back
+				</h2>
+				<p className="text-muted-foreground mt-1 text-sm">
+					Sign in to continue to Chronicle
+				</p>
 			</div>
-			<CardContent className="p-7">
-				<Form {...form}>
-					<form
-						onSubmit={form.handleSubmit(onSubmit)}
-						className="space-y-4"
-					>
-						<FormField
-							name="email"
-							control={form.control}
-							render={({ field }) => (
-								<FormItem>
-									<FormControl>
-										<Input
-											type="email"
-											placeholder="Enter your email address"
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							name="password"
-							control={form.control}
-							render={({ field }) => (
-								<FormItem>
-									<FormControl>
-										<Input
-											type="password"
-											placeholder="Enter your password"
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<Button
-							disabled={isPending}
-							size="lg"
-							className="w-full"
-						>
-							Login
-						</Button>
-					</form>
-				</Form>
-			</CardContent>
-			<div className="px-7">
-				<DottedSeperator />
+
+			<Form {...form}>
+				<form
+					onSubmit={form.handleSubmit(onSubmit)}
+					className="space-y-4"
+				>
+					<FormField
+						name="email"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem>
+								<FormControl>
+									<Input
+										type="email"
+										placeholder="Enter your email address"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						name="password"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem>
+								<FormControl>
+									<Input
+										type="password"
+										placeholder="Enter your password"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<Button disabled={isPending} size="lg" className="w-full">
+						Sign In
+					</Button>
+				</form>
+			</Form>
+
+			<div className="relative my-6">
+				<div className="absolute inset-0 flex items-center">
+					<div className="w-full border-t border-border" />
+				</div>
+				<div className="relative flex justify-center text-xs">
+					<span className="bg-surface px-2 text-muted-foreground">
+						or continue with
+					</span>
+				</div>
 			</div>
-			<CardContent className="p-7 flex flex-col gap-y-4">
+
+			<div className="flex flex-col gap-3">
 				<Button
 					onClick={() => onGoogleSignIn()}
 					disabled={isPending}
@@ -132,7 +135,7 @@ export const SignInCard = () => {
 					className="w-full"
 				>
 					<FcGoogle className="mr-2 size-5" />
-					Login with Google
+					Continue with Google
 				</Button>
 				<Button
 					onClick={() => onGithubSignIn()}
@@ -142,20 +145,19 @@ export const SignInCard = () => {
 					className="w-full"
 				>
 					<FaGithub className="mr-2 size-5" />
-					Login with Github
+					Continue with GitHub
 				</Button>
-			</CardContent>
-			<div className="px-7">
-				<DottedSeperator />
 			</div>
-			<CardContent className="p-7 flex items-center justify-center">
-				<p>
-					Don&apos;t have an account?{" "}
-					<Link href="/sign-up" className="text-primary-500">
-						<span className="text-blue-700">Sign Up</span>
-					</Link>
-				</p>
-			</CardContent>
-		</Card>
+
+			<p className="text-center text-sm text-muted-foreground mt-6">
+				Don&apos;t have an account?{" "}
+				<Link
+					href="/sign-up"
+					className="text-primary hover:text-primary/80 font-medium"
+				>
+					Sign up
+				</Link>
+			</p>
+		</div>
 	);
 };

--- a/src/features/auth/components/sign-in-card.tsx
+++ b/src/features/auth/components/sign-in-card.tsx
@@ -52,8 +52,7 @@ export const SignInCard = () => {
 			} else {
 				toast.error("Failed to create session");
 			}
-		} catch (error) {
-			console.error(error);
+		} catch {
 			toast.error(`Failed to log in with ${providerName}`);
 		}
 	};

--- a/src/features/auth/components/sign-up-card.tsx
+++ b/src/features/auth/components/sign-up-card.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import { DottedSeperator } from "@/components/dotted-seperator";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import Link from "next/link";
 import { z } from "zod";
@@ -40,99 +32,98 @@ export const SignUpCard = () => {
 	};
 
 	return (
-		<Card className="w-full h-full md:w-[487px] border-none shadow-none">
-			<CardHeader className="flex items-center justify-center text-center p-7">
-				<CardTitle className="text-2xl">Sign Up</CardTitle>
-				<CardDescription>
-					By signing up, you agree to our{" "}
-					<Link href="/privacy">
-						<span className="text-blue-700">Privacy Policy</span>
-					</Link>{" "}
-					and{" "}
-					<Link href="/terms">
-						<span className="text-blue-700">Terms of Service</span>
-					</Link>
-					.
-				</CardDescription>
-			</CardHeader>
-			<div className="px-7">
-				<DottedSeperator />
-			</div>
-			<CardContent className="p-7">
-				<Form {...form}>
-					<form
-						onSubmit={form.handleSubmit(onSubmit)}
-						className="space-y-4"
-					>
-						<FormField
-							name="name"
-							control={form.control}
-							render={({ field }) => (
-								<FormItem>
-									<FormControl>
-										<Input
-											type="name"
-											placeholder="Enter your name"
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							name="email"
-							control={form.control}
-							render={({ field }) => (
-								<FormItem>
-									<FormControl>
-										<Input
-											type="email"
-											placeholder="Enter your email address"
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<FormField
-							name="password"
-							control={form.control}
-							render={({ field }) => (
-								<FormItem>
-									<FormControl>
-										<Input
-											type="password"
-											placeholder="Enter your password"
-											{...field}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-						<Button
-							disabled={isPending}
-							size="lg"
-							className="w-full"
-						>
-							Register
-						</Button>
-					</form>
-				</Form>
-			</CardContent>
-			<div className="px-7">
-				<DottedSeperator />
-			</div>
-			<CardContent className="p-7 flex items-center justify-center">
-				<p>
-					Already have an account?{" "}
-					<Link href="/sign-in" className="text-primary-500">
-						<span className="text-blue-700">Sign In</span>
-					</Link>
+		<div className="w-full">
+			<div className="mb-8">
+				<h2 className="text-2xl font-bold text-foreground">
+					Create your account
+				</h2>
+				<p className="text-muted-foreground mt-1 text-sm">
+					Join Chronicle and start building with context.
 				</p>
-			</CardContent>
-		</Card>
+			</div>
+
+			<Form {...form}>
+				<form
+					onSubmit={form.handleSubmit(onSubmit)}
+					className="space-y-4"
+				>
+					<FormField
+						name="name"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem>
+								<FormControl>
+									<Input
+										type="text"
+										placeholder="Enter your name"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						name="email"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem>
+								<FormControl>
+									<Input
+										type="email"
+										placeholder="Enter your email address"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						name="password"
+						control={form.control}
+						render={({ field }) => (
+							<FormItem>
+								<FormControl>
+									<Input
+										type="password"
+										placeholder="Enter your password"
+										{...field}
+									/>
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<Button disabled={isPending} size="lg" className="w-full">
+						Create account
+					</Button>
+				</form>
+			</Form>
+
+			<p className="text-center text-sm text-muted-foreground mt-6">
+				By signing up, you agree to our{" "}
+				<Link href="/privacy" className="text-primary hover:text-primary/80 font-medium">
+					Privacy Policy
+				</Link>{" "}
+				and{" "}
+				<Link href="/terms" className="text-primary hover:text-primary/80 font-medium">
+					Terms of Service
+				</Link>
+				.
+			</p>
+
+			<div className="h-px bg-border my-6" />
+
+			<p className="text-center text-sm text-muted-foreground">
+				Already have an account?{" "}
+				<Link
+					href="/sign-in"
+					className="text-primary hover:text-primary/80 font-medium"
+				>
+					Sign in
+				</Link>
+			</p>
+		</div>
 	);
 };

--- a/src/features/projects/api/use-get-projects.ts
+++ b/src/features/projects/api/use-get-projects.ts
@@ -8,6 +8,7 @@ interface UseGetProjectsProps {
 export const useGetProjects = ({ workspaceId }: UseGetProjectsProps) => {
 	const query = useQuery({
 		queryKey: ["projects", workspaceId],
+		enabled: !!workspaceId,
 		queryFn: async () => {
 			const response = await client.api.projects.$get({
 				query: { workspaceId },

--- a/src/features/workspaces/components/create-workspace-form.tsx
+++ b/src/features/workspaces/components/create-workspace-form.tsx
@@ -4,8 +4,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { createWorkspaceSchema } from "../schemas";
 import { z } from "zod";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { DottedSeperator } from "@/components/dotted-seperator";
 import {
 	Form,
 	FormControl,
@@ -61,19 +59,18 @@ export const CreateWorkspaceForm = ({ onCancel }: CreateWorkspaceFormProps) => {
 	};
 
 	return (
-		<Card className="w-full h-full border-none shadow-none">
-			<CardHeader className="flex p-7">
-				<CardTitle className="text-xl font-bold">
-					Create a new workspace
-				</CardTitle>
-			</CardHeader>
-			<div className="px-7">
-				<DottedSeperator />
+		<div className="bg-card border border-border rounded-lg p-8 w-full">
+			<div className="mb-8">
+				<h2 className="text-2xl font-bold text-foreground">
+					Create your workspace
+				</h2>
+				<p className="text-muted-foreground text-sm mt-1">
+					Give your team a name and a visual identity.
+				</p>
 			</div>
-			<CardContent className="p-7">
-				<Form {...form}>
-					<form onSubmit={form.handleSubmit(onSubmit)}>
-						<div className="flex flex-col gap-y-4">
+			<Form {...form}>
+				<form onSubmit={form.handleSubmit(onSubmit)}>
+					<div className="flex flex-col gap-y-6">
 							<FormField
 								control={form.control}
 								name="name"
@@ -175,7 +172,7 @@ export const CreateWorkspaceForm = ({ onCancel }: CreateWorkspaceFormProps) => {
 								)}
 							/>
 						</div>
-						<DottedSeperator className="py-7" />
+						<div className="h-px bg-border my-6" />
 						<div className="flex items-center justify-between">
 							<Button
 								type="button"
@@ -198,7 +195,6 @@ export const CreateWorkspaceForm = ({ onCancel }: CreateWorkspaceFormProps) => {
 						</div>
 					</form>
 				</Form>
-			</CardContent>
-		</Card>
+		</div>
 	);
 };

--- a/src/hooks/use-media.ts
+++ b/src/hooks/use-media.ts
@@ -6,7 +6,7 @@ export function useMedia(query: string) {
 	const [matches, setMatches] = useState(false);
 
 	useEffect(() => {
-		const mq = window.matchMedia(query);
+		const mq = globalThis.matchMedia(query);
 		setMatches(mq.matches);
 		const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
 		mq.addEventListener("change", handler);

--- a/src/hooks/use-media.ts
+++ b/src/hooks/use-media.ts
@@ -6,7 +6,7 @@ export function useMedia(query: string) {
 	const [matches, setMatches] = useState(false);
 
 	useEffect(() => {
-		const mq = globalThis.matchMedia(query);
+		const mq = matchMedia(query);
 		setMatches(mq.matches);
 		const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
 		mq.addEventListener("change", handler);

--- a/src/hooks/use-media.ts
+++ b/src/hooks/use-media.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useMedia(query: string) {
+	const [matches, setMatches] = useState(false);
+
+	useEffect(() => {
+		const mq = window.matchMedia(query);
+		setMatches(mq.matches);
+		const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+		mq.addEventListener("change", handler);
+		return () => mq.removeEventListener("change", handler);
+	}, [query]);
+
+	return matches;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,9 @@ const config: Config = {
   		colors: {
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',
+  			surface: 'hsl(var(--surface))',
+  			success: 'hsl(var(--success))',
+  			warning: 'hsl(var(--warning))',
   			card: {
   				DEFAULT: 'hsl(var(--card))',
   				foreground: 'hsl(var(--card-foreground))'
@@ -54,9 +57,12 @@ const config: Config = {
   			}
   		},
   		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
+  			lg: '20px',
+  			md: '12px',
+  			sm: '8px',
+  			pill: '9999px',
+  			xl: '24px',
+  			'2xl': '32px',
   		}
   	}
   },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Design tokens**: Chronicle dark CSS variables (`#0B1020` bg, `#161F31` card, `#4F7CFF` primary) in `.dark` with light fallbacks in `:root`; new `surface`, `success`, `warning` tokens added to Tailwind; border-radius updated to fixed px values (`lg=20px`, `md=12px`, `pill=9999px`)
- **Chronicle logo**: New `ChronicleLogomark` SVG with theme-aware gradient via `--logo-start`/`--logo-end` CSS vars; `ChronicleLogoFull` with wordmark
- **Auth layout**: Split-screen (55% value prop left panel / 45% form right panel); floating `Card` wrapper removed from `SignInCard` and `SignUpCard`; search-to-sign-in/up toggle replaced with static `Link`
- **Collapsible sidebar**: 260px expanded / 72px collapsed with `localStorage` persistence (`chronicle-sidebar` key); tablet-default-collapsed via new `useMedia` hook; `useSidebarCollapsed` convenience hook exported from `SidebarContext`
- **Layout architecture**: New `AppModals` component as single source of truth for global modals; new `DashboardShell` client component shared between `(dashboard)` and `(standalone)/workspace/[workspaceId]` layouts; standalone `workspace/create` stays sidebar-free with Chronicle logo header
- **Navbar**: Sticky top command bar with sidebar toggle + breadcrumbs left, command-palette button + bell + sparkles + avatar right
- **Navigation**: Chronicle active-item style (left border accent); Settings kept in sidebar nav; null guard added
- **Analytics**: 2→5 column responsive grid replacing horizontal `ScrollArea`; `AnalyticsCard` redesigned as compact metric card using `success`/`destructive` tokens
- **UI components**: Flat `primary`/`destructive` buttons (no gradient); `teritary` uses `primary/10`; badge `rounded-pill`; input `bg-muted`

## Test plan

- [ ] Token check: `body` background matches `#0B1020` in dark mode (devtools)
- [ ] Auth pages: `/sign-in` and `/sign-up` show split-screen layout, no floating card, no light background
- [ ] Dashboard: Sidebar at 260px, top command bar visible, breadcrumbs left, search+icons right
- [ ] Sidebar collapse: Toggle collapses to 72px (logomark only), expands again; state persists on refresh
- [ ] Tablet responsive: At ~1024px, sidebar starts collapsed
- [ ] Mobile responsive: Sidebar hidden; hamburger opens Sheet drawer
- [ ] Settings/Members pages: Full sidebar shell (not isolated card layout)
- [ ] Workspace create: No sidebar; Chronicle logo at top; dark chronicle styling
- [ ] All modals: Create/Edit task, sprint, version modals open/close without regression
- [ ] Form validation: Empty sign-in form shows Zod errors
- [ ] Search button: `<button>` element (not readonly input); tab-focusable; click is no-op
- [ ] Analytics: 5 metrics in responsive grid; data unchanged
- [ ] Light/dark toggle (UserButton): Sonner and UI respond to theme switch correctly
- [ ] Settings in sidebar nav: Overview, Members, Settings all present and working

https://claude.ai/code/session_011DtiUPt7eRbVeoXqK5UKJP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011DtiUPt7eRbVeoXqK5UKJP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Collapsible sidebar navigation for optimal screen space
  * Search functionality and notifications in navigation bar
  * Responsive grid layout for analytics dashboard

* **UI/UX Updates**
  * Rebranded app to "Chronicle" with new logo and visual identity
  * Redesigned authentication pages with streamlined layout
  * Reorganized dashboard shell with improved content hierarchy
  * Updated color palette with new design tokens
  * Enhanced navbar with sidebar toggle and action controls

* **Design System**
  * New CSS variables for surface, success, and warning colors
  * Improved card radius and input styling
  * Refined spacing and responsive breakpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->