### PR TITLE
Chronicle UX refactor: design token consistency + shared primitives

### DIFF
--- a/src/app/(dashboard)/workspace/[workspaceId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/client.tsx
@@ -6,6 +6,7 @@ import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetWorkspace } from "@/features/workspaces/api/use-get-workspace";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useGetWorkspaceAnalytics } from "@/features/workspaces/api/use-get-workspace-analytics";
+import { useCurrent } from "@/features/auth/api/use-current";
 import { PageLoader } from "@/components/page-loader";
 import { IntelligencePanel } from "@/components/intelligence-panel";
 import { TaskStatus } from "@/features/tasks/types";
@@ -16,9 +17,6 @@ import {
   Rocket,
   GitPullRequest,
   Sparkles,
-  TrendingUp,
-  TrendingDown,
-  Minus,
 } from "lucide-react";
 import {
   ResponsiveContainer,
@@ -29,24 +27,20 @@ import {
   Tooltip,
   CartesianGrid,
 } from "recharts";
+import { useTheme } from "next-themes";
+import { DashboardCard } from "@/components/chronicle/dashboard-card";
 import { useMemo, useState, useEffect } from "react";
 import { format, subDays, isBefore } from "date-fns";
 
 const DATE_FMT = "MMM d";
-const TREND_NEUTRAL = "neutral";
 const AREA_TYPE = "monotone";
 
-const SURFACE = "#0F172A";
-const BORDER_SUBTLE = "rgba(255,255,255,0.06)";
-const BG_HOVER = "rgba(255,255,255,0.04)";
-const TEXT_DIM = "rgba(255,255,255,0.3)";
-const PRIMARY = "#4F7CFF";
-const SUCCESS = "#22C55E";
-const DANGER = "#EF4444";
-const BORDER_1PX = `1px solid ${BORDER_SUBTLE}`;
-
-const TREND_ICON = { up: TrendingUp, down: TrendingDown, neutral: Minus } as const;
-const TREND_COLOR = { up: SUCCESS, down: DANGER, neutral: TEXT_DIM } as const;
+/* Chronicle brand colors — used in SVG chart rendering where CSS vars can't reach */
+const C_PRIMARY = "#4F7CFF";
+const C_SUCCESS = "#22C55E";
+const C_DANGER = "#EF4444";
+const C_WARNING = "#F59E0B";
+const C_PURPLE = "#8B5CF6";
 
 // Helper: hour-based greeting
 function getGreeting(name?: string | null) {
@@ -76,128 +70,12 @@ function buildSparklineData(tasks: { $createdAt: string; status: string }[]) {
   return days;
 }
 
-interface IntelCardProps {
-  readonly title: string;
-  readonly value: string | number;
-  readonly subtitle: string;
-  readonly icon: React.ElementType;
-  readonly iconBg: string;
-  readonly iconColor: string;
-  readonly trend?: "up" | "down" | "neutral";
-  readonly trendLabel?: string;
-  readonly accent?: string;
-  readonly chart?: { day: string; count: number }[];
-}
-
-function IntelCard({
-  title,
-  value,
-  subtitle,
-  icon: Icon,
-  iconBg,
-  iconColor,
-  trend,
-  trendLabel,
-  accent,
-  chart,
-}: IntelCardProps) {
-  const TrendIcon = TREND_ICON[trend ?? TREND_NEUTRAL];
-  const trendColor = TREND_COLOR[trend ?? TREND_NEUTRAL];
-
-  return (
-    <div
-      className="relative flex flex-col justify-between p-5 rounded-card overflow-hidden"
-      style={{
-        background: SURFACE,
-        border: BORDER_1PX,
-        boxShadow:
-          "0 0 0 1px rgba(255,255,255,0.04), 0 4px 16px rgba(0,0,0,0.2)",
-        minHeight: 140,
-      }}
-    >
-      {/* Top row */}
-      <div className="flex items-start justify-between">
-        <div className="flex flex-col gap-1">
-          <span
-            className="text-[11px] font-semibold uppercase tracking-widest"
-            style={{ color: "rgba(255,255,255,0.35)" }}
-          >
-            {title}
-          </span>
-          <span className="text-3xl font-bold text-white leading-none">
-            {value}
-          </span>
-          <span
-            className="text-[13px]"
-            style={{ color: "rgba(255,255,255,0.45)" }}
-          >
-            {subtitle}
-          </span>
-        </div>
-        <div
-          className="flex items-center justify-center size-10 rounded-xl shrink-0"
-          style={{ background: iconBg }}
-        >
-          <Icon className="size-5" style={{ color: iconColor }} />
-        </div>
-      </div>
-
-      {/* Bottom: trend or mini chart */}
-      <div className="flex items-end justify-between mt-3">
-        {trendLabel && (
-          <div className="flex items-center gap-1.5">
-            <TrendIcon className="size-3.5" style={{ color: trendColor }} />
-            <span className="text-[12px]" style={{ color: trendColor }}>
-              {trendLabel}
-            </span>
-          </div>
-        )}
-        {chart && chart.some((d) => d.count > 0) && (
-          <div className="w-full h-10 -mb-1">
-            <ResponsiveContainer width="100%" height="100%">
-              <AreaChart
-                data={chart}
-                margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
-              >
-                <defs>
-                  <linearGradient
-                    id={`grad-${title}`}
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
-                    <stop
-                      offset="0%"
-                      stopColor={accent ?? PRIMARY}
-                      stopOpacity={0.3}
-                    />
-                    <stop
-                      offset="100%"
-                      stopColor={accent ?? PRIMARY}
-                      stopOpacity={0}
-                    />
-                  </linearGradient>
-                </defs>
-                <Area
-                  type={AREA_TYPE}
-                  dataKey="count"
-                  stroke={accent ?? PRIMARY}
-                  strokeWidth={1.5}
-                  fill={`url(#grad-${title})`}
-                  dot={false}
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
 
 export const WorkspaceIdClient = () => {
   const workspaceId = useWorkspaceId();
+  const { data: user } = useCurrent();
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme !== "light";
   const { data: workspace } = useGetWorkspace({
     workspaceId,
     enabled: !!workspaceId,
@@ -258,124 +136,99 @@ export const WorkspaceIdClient = () => {
     <div className="flex flex-col gap-8">
       {/* Greeting header */}
       <div>
-        <h1 className="text-2xl font-bold text-white">
-          {getGreeting(workspace?.name)}
+        <h1 className="text-2xl font-bold text-foreground">
+          {getGreeting(user?.name)}
         </h1>
-        <p
-          className="text-[15px] mt-1"
-          style={{ color: "rgba(255,255,255,0.45)" }}
-        >
-          Here&apos;s what&apos;s happening across your workspace
+        <p className="text-[15px] mt-1 text-muted-foreground">
+          Here&apos;s what&apos;s happening across {workspace?.name ?? "your workspace"}
         </p>
       </div>
 
       {/* 6 intelligence cards */}
       <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-        <IntelCard
+        <DashboardCard
           title="Today's Focus"
           value={todayDue.length}
           subtitle={todayDue.length === 1 ? "item due today" : "items due today"}
           icon={Target}
-          iconBg="rgba(79,124,255,0.12)"
-          iconColor={PRIMARY}
-          trend={todayDue.length > 3 ? "down" : TREND_NEUTRAL}
-          trendLabel={
-            todayDue.length > 0
-              ? `${todayDue.length} need attention`
-              : "All clear"
-          }
-          accent={PRIMARY}
+          iconBgClass="bg-primary/10"
+          iconColorClass="text-primary"
+          trend={todayDue.length > 3 ? "down" : "neutral"}
+          trendLabel={todayDue.length > 0 ? `${todayDue.length} need attention` : "All clear"}
+          accentColor={C_PRIMARY}
           chart={sparkData}
         />
-        <IntelCard
+        <DashboardCard
           title="Blocked Work"
           value={blocked.length}
-          subtitle={
-            blocked.length === 1 ? "blocker active" : "blockers active"
-          }
+          subtitle={blocked.length === 1 ? "blocker active" : "blockers active"}
           icon={AlertCircle}
-          iconBg="rgba(239,68,68,0.12)"
-          iconColor={DANGER}
-          trend={blocked.length > 0 ? "down" : TREND_NEUTRAL}
+          iconBgClass="bg-destructive/10"
+          iconColorClass="text-destructive"
+          trend={blocked.length > 0 ? "down" : "neutral"}
           trendLabel={blocked.length > 0 ? "Review blockers" : "No blockers"}
-          accent={DANGER}
+          accentColor={C_DANGER}
         />
-        <IntelCard
+        <DashboardCard
           title="Sprint Health"
           value={`${completionPct}%`}
           subtitle={`${inProgress.length} in progress · ${done.length} done`}
           icon={Zap}
-          iconBg="rgba(34,197,94,0.12)"
-          iconColor={SUCCESS}
+          iconBgClass="bg-success/10"
+          iconColorClass="text-success"
           trend={completionPct >= 50 ? "up" : "down"}
           trendLabel={`${tasks.length} total items`}
-          accent={SUCCESS}
+          accentColor={C_SUCCESS}
         />
-        <IntelCard
+        <DashboardCard
           title="Upcoming Releases"
           value={projects.length}
           subtitle="active projects"
           icon={Rocket}
-          iconBg="rgba(139,92,246,0.12)"
-          iconColor="#8B5CF6"
-          trend={TREND_NEUTRAL}
+          iconBgClass="bg-purple/10"
+          iconColorClass="text-purple"
+          trend="neutral"
           trendLabel={`${members.length} team members`}
-          accent="#8B5CF6"
+          accentColor={C_PURPLE}
         />
-        <IntelCard
+        <DashboardCard
           title="PRs Waiting Review"
           value="—"
           subtitle="GitHub integration coming"
           icon={GitPullRequest}
-          iconBg={BORDER_SUBTLE}
-          iconColor={TEXT_DIM}
-          trend={TREND_NEUTRAL}
+          iconBgClass="bg-muted"
+          iconColorClass="text-muted-foreground"
+          trend="neutral"
           trendLabel="Connect GitHub"
-          accent={PRIMARY}
+          accentColor={C_PRIMARY}
         />
-        <IntelCard
+        <DashboardCard
           title="AI Suggestions"
           value={blocked.length + todayDue.length}
           subtitle="items need attention"
           icon={Sparkles}
-          iconBg="rgba(245,158,11,0.12)"
-          iconColor="#F59E0B"
+          iconBgClass="bg-warning/10"
+          iconColorClass="text-warning"
           trend={blocked.length + todayDue.length > 0 ? "down" : "up"}
-          trendLabel={
-            blocked.length + todayDue.length > 0 ? "Review now" : "Looking good"
-          }
-          accent="#F59E0B"
+          trendLabel={blocked.length + todayDue.length > 0 ? "Review now" : "Looking good"}
+          accentColor={C_WARNING}
         />
       </div>
 
       {/* Sprint & burndown row */}
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         {/* Velocity chart */}
-        <div
-          className="p-6 rounded-card"
-          style={{
-            background: SURFACE,
-            border: BORDER_1PX,
-            boxShadow:
-              "0 0 0 1px rgba(255,255,255,0.04), 0 8px 30px rgba(0,0,0,0.25)",
-          }}
-        >
+        <div className="p-6 rounded-card bg-surface border border-border/40 shadow-chronicle-sm">
           <div className="flex items-center justify-between mb-5">
             <div>
-              <h2 className="text-base font-semibold text-white">
+              <h2 className="text-base font-semibold text-foreground">
                 Sprint Progress
               </h2>
-              <p
-                className="text-[13px] mt-0.5"
-                style={{ color: "rgba(255,255,255,0.4)" }}
-              >
+              <p className="text-[13px] mt-0.5 text-muted-foreground">
                 Completed items over last 14 days
               </p>
             </div>
-            <span
-              className="text-xs px-2.5 py-1 rounded-full font-medium"
-              style={{ background: "rgba(34,197,94,0.12)", color: SUCCESS }}
-            >
+            <span className="text-xs px-2.5 py-1 rounded-full font-medium bg-success/10 text-success">
               {completionPct}% complete
             </span>
           </div>
@@ -386,55 +239,41 @@ export const WorkspaceIdClient = () => {
                 margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
               >
                 <defs>
-                  <linearGradient
-                    id="grad-completed"
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
-                    <stop
-                      offset="0%"
-                      stopColor={SUCCESS}
-                      stopOpacity={0.25}
-                    />
-                    <stop
-                      offset="100%"
-                      stopColor={SUCCESS}
-                      stopOpacity={0}
-                    />
+                  <linearGradient id="grad-completed" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={C_SUCCESS} stopOpacity={0.25} />
+                    <stop offset="100%" stopColor={C_SUCCESS} stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid
                   strokeDasharray="3 3"
-                  stroke={BG_HOVER}
+                  stroke={isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.06)"}
                   vertical={false}
                 />
                 <XAxis
                   dataKey="day"
-                  tick={{ fontSize: 11, fill: TEXT_DIM }}
+                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
                   axisLine={false}
                   tickLine={false}
                   interval={3}
                 />
                 <YAxis
-                  tick={{ fontSize: 11, fill: TEXT_DIM }}
+                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <Tooltip
                   contentStyle={{
-                    background: "#16233F",
-                    border: "1px solid rgba(255,255,255,0.08)",
+                    background: isDark ? "hsl(222,40%,17%)" : "hsl(0,0%,100%)",
+                    border: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.1)"}`,
                     borderRadius: 10,
                     fontSize: 12,
-                    color: "#fff",
+                    color: isDark ? "#fff" : "#0f172a",
                   }}
                 />
                 <Area
                   type={AREA_TYPE}
                   dataKey="completed"
-                  stroke={SUCCESS}
+                  stroke={C_SUCCESS}
                   strokeWidth={2}
                   fill="url(#grad-completed)"
                   dot={false}
@@ -446,29 +285,15 @@ export const WorkspaceIdClient = () => {
         </div>
 
         {/* Burndown chart */}
-        <div
-          className="p-6 rounded-card"
-          style={{
-            background: SURFACE,
-            border: BORDER_1PX,
-            boxShadow:
-              "0 0 0 1px rgba(255,255,255,0.04), 0 8px 30px rgba(0,0,0,0.25)",
-          }}
-        >
+        <div className="p-6 rounded-card bg-surface border border-border/40 shadow-chronicle-sm">
           <div className="flex items-center justify-between mb-5">
             <div>
-              <h2 className="text-base font-semibold text-white">Burndown</h2>
-              <p
-                className="text-[13px] mt-0.5"
-                style={{ color: "rgba(255,255,255,0.4)" }}
-              >
+              <h2 className="text-base font-semibold text-foreground">Burndown</h2>
+              <p className="text-[13px] mt-0.5 text-muted-foreground">
                 Remaining work items over time
               </p>
             </div>
-            <span
-              className="text-xs px-2.5 py-1 rounded-full font-medium"
-              style={{ background: "rgba(79,124,255,0.12)", color: PRIMARY }}
-            >
+            <span className="text-xs px-2.5 py-1 rounded-full font-medium bg-primary/10 text-primary">
               {tasks.filter((t) => t.status !== TaskStatus.DONE).length}{" "}
               remaining
             </span>
@@ -480,55 +305,41 @@ export const WorkspaceIdClient = () => {
                 margin={{ top: 4, right: 4, left: -20, bottom: 0 }}
               >
                 <defs>
-                  <linearGradient
-                    id="grad-remaining"
-                    x1="0"
-                    y1="0"
-                    x2="0"
-                    y2="1"
-                  >
-                    <stop
-                      offset="0%"
-                      stopColor={PRIMARY}
-                      stopOpacity={0.25}
-                    />
-                    <stop
-                      offset="100%"
-                      stopColor={PRIMARY}
-                      stopOpacity={0}
-                    />
+                  <linearGradient id="grad-remaining" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={C_PRIMARY} stopOpacity={0.25} />
+                    <stop offset="100%" stopColor={C_PRIMARY} stopOpacity={0} />
                   </linearGradient>
                 </defs>
                 <CartesianGrid
                   strokeDasharray="3 3"
-                  stroke={BG_HOVER}
+                  stroke={isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.06)"}
                   vertical={false}
                 />
                 <XAxis
                   dataKey="day"
-                  tick={{ fontSize: 11, fill: TEXT_DIM }}
+                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
                   axisLine={false}
                   tickLine={false}
                   interval={3}
                 />
                 <YAxis
-                  tick={{ fontSize: 11, fill: TEXT_DIM }}
+                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <Tooltip
                   contentStyle={{
-                    background: "#16233F",
-                    border: "1px solid rgba(255,255,255,0.08)",
+                    background: isDark ? "hsl(222,40%,17%)" : "hsl(0,0%,100%)",
+                    border: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.1)"}`,
                     borderRadius: 10,
                     fontSize: 12,
-                    color: "#fff",
+                    color: isDark ? "#fff" : "#0f172a",
                   }}
                 />
                 <Area
                   type={AREA_TYPE}
                   dataKey="remaining"
-                  stroke={PRIMARY}
+                  stroke={C_PRIMARY}
                   strokeWidth={2}
                   fill="url(#grad-remaining)"
                   dot={false}

--- a/src/app/(dashboard)/workspace/[workspaceId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/client.tsx
@@ -76,6 +76,11 @@ export const WorkspaceIdClient = () => {
   const { data: user } = useCurrent();
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme !== "light";
+  const CHART_GRID = isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.06)";
+  const CHART_TICK = isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)";
+  const CHART_TOOLTIP_BG = isDark ? "hsl(222,40%,17%)" : "hsl(0,0%,100%)";
+  const CHART_TOOLTIP_BORDER = `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.1)"}`;
+  const CHART_TOOLTIP_FG = isDark ? "#fff" : "#0f172a";
   const { data: workspace } = useGetWorkspace({
     workspaceId,
     enabled: !!workspaceId,
@@ -246,28 +251,28 @@ export const WorkspaceIdClient = () => {
                 </defs>
                 <CartesianGrid
                   strokeDasharray="3 3"
-                  stroke={isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.06)"}
+                  stroke={CHART_GRID}
                   vertical={false}
                 />
                 <XAxis
                   dataKey="day"
-                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
+                  tick={{ fontSize: 11, fill: CHART_TICK }}
                   axisLine={false}
                   tickLine={false}
                   interval={3}
                 />
                 <YAxis
-                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
+                  tick={{ fontSize: 11, fill: CHART_TICK }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <Tooltip
                   contentStyle={{
-                    background: isDark ? "hsl(222,40%,17%)" : "hsl(0,0%,100%)",
-                    border: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.1)"}`,
+                    background: CHART_TOOLTIP_BG,
+                    border: CHART_TOOLTIP_BORDER,
                     borderRadius: 10,
                     fontSize: 12,
-                    color: isDark ? "#fff" : "#0f172a",
+                    color: CHART_TOOLTIP_FG,
                   }}
                 />
                 <Area
@@ -312,28 +317,28 @@ export const WorkspaceIdClient = () => {
                 </defs>
                 <CartesianGrid
                   strokeDasharray="3 3"
-                  stroke={isDark ? "rgba(255,255,255,0.04)" : "rgba(0,0,0,0.06)"}
+                  stroke={CHART_GRID}
                   vertical={false}
                 />
                 <XAxis
                   dataKey="day"
-                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
+                  tick={{ fontSize: 11, fill: CHART_TICK }}
                   axisLine={false}
                   tickLine={false}
                   interval={3}
                 />
                 <YAxis
-                  tick={{ fontSize: 11, fill: isDark ? "rgba(255,255,255,0.3)" : "rgba(0,0,0,0.4)" }}
+                  tick={{ fontSize: 11, fill: CHART_TICK }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <Tooltip
                   contentStyle={{
-                    background: isDark ? "hsl(222,40%,17%)" : "hsl(0,0%,100%)",
-                    border: `1px solid ${isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.1)"}`,
+                    background: CHART_TOOLTIP_BG,
+                    border: CHART_TOOLTIP_BORDER,
                     borderRadius: 10,
                     fontSize: 12,
-                    color: isDark ? "#fff" : "#0f172a",
+                    color: CHART_TOOLTIP_FG,
                   }}
                 />
                 <Area

--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/active-sprint/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/active-sprint/client.tsx
@@ -27,22 +27,18 @@ import {
 } from "lucide-react";
 import { format, differenceInDays } from "date-fns";
 
-const SURFACE = "#0F172A";
-const BORDER_SUBTLE = "rgba(255,255,255,0.06)";
-const TEXT_LABEL = "rgba(255,255,255,0.35)";
-const PRIMARY = "#4F7CFF";
 const STAT_COL_CLS = "flex flex-col gap-1";
-const STAT_LABEL_CLS = "text-[11px] uppercase tracking-widest";
+const STAT_LABEL_CLS = "text-[11px] uppercase tracking-widest text-muted-foreground/60";
 
 const VIEWS = [
   { label: "List", value: "table", icon: List },
   { label: "Board", value: "kanban", icon: LayoutGrid },
 ] as const;
 
-function getDaysLeftColor(days: number): string {
-  if (days <= 2) return "#EF4444";
-  if (days <= 5) return "#F59E0B";
-  return "#22C55E";
+function getDaysLeftColorClass(days: number): string {
+  if (days <= 2) return "text-destructive";
+  if (days <= 5) return "text-warning";
+  return "text-success";
 }
 
 export const ActiveSprintClient = () => {
@@ -50,7 +46,7 @@ export const ActiveSprintClient = () => {
   const projectId = useProjectId();
   const router = useRouter();
   const { open: openCreateModal } = useCreateTaskModal();
-  const { mutate: bulkUpdate } = useBulkUpdateTasks();
+  const { mutate: bulkUpdate, isPending: isBulkUpdating } = useBulkUpdateTasks();
   const [view, setView] = useQueryState("view", { defaultValue: "kanban" });
 
   const { data: sprintsData, isLoading: loadingSprints } = useGetSprints({ workspaceId, projectId });
@@ -87,30 +83,23 @@ export const ActiveSprintClient = () => {
   if (isLoading) {
     mainContent = (
       <div className="flex items-center justify-center h-64">
-        <Loader className="size-5 animate-spin" style={{ color: "rgba(255,255,255,0.3)" }} />
+        <Loader className="size-5 animate-spin text-muted-foreground" />
       </div>
     );
   } else if (activeSprint) {
     mainContent = (
       <>
         {/* ── Sprint meta card ── */}
-        <div
-          className="grid grid-cols-2 lg:grid-cols-4 gap-4 p-5 rounded-card"
-          style={{ background: SURFACE, border: `1px solid ${BORDER_SUBTLE}` }}
-        >
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 p-5 rounded-card bg-surface border border-border/40">
           <div className={STAT_COL_CLS}>
-            <p className={STAT_LABEL_CLS} style={{ color: TEXT_LABEL }}>
-              Sprint
-            </p>
-            <p className="text-base font-semibold text-white">{activeSprint.name}</p>
+            <p className={STAT_LABEL_CLS}>Sprint</p>
+            <p className="text-base font-semibold text-foreground">{activeSprint.name}</p>
           </div>
           {activeSprint.startDate && activeSprint.endDate && (
             <div className={STAT_COL_CLS}>
-              <p className={STAT_LABEL_CLS} style={{ color: TEXT_LABEL }}>
-                Duration
-              </p>
-              <p className="text-sm font-medium text-white flex items-center gap-1.5">
-                <Calendar className="size-3.5" style={{ color: "rgba(255,255,255,0.4)" }} />
+              <p className={STAT_LABEL_CLS}>Duration</p>
+              <p className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                <Calendar className="size-3.5 text-muted-foreground" />
                 {format(new Date(activeSprint.startDate), "MMM d")} –{" "}
                 {format(new Date(activeSprint.endDate), "MMM d")}
               </p>
@@ -118,34 +107,24 @@ export const ActiveSprintClient = () => {
           )}
           {daysLeft !== null && (
             <div className={STAT_COL_CLS}>
-              <p className={STAT_LABEL_CLS} style={{ color: TEXT_LABEL }}>
-                Days Left
-              </p>
-              <p
-                className="text-base font-semibold"
-                style={{ color: getDaysLeftColor(daysLeft) }}
-              >
+              <p className={STAT_LABEL_CLS}>Days Left</p>
+              <p className={`text-base font-semibold ${getDaysLeftColorClass(daysLeft)}`}>
                 {daysLeft}d
               </p>
             </div>
           )}
           <div className="flex flex-col gap-2">
-            <p className={STAT_LABEL_CLS} style={{ color: TEXT_LABEL }}>
-              Progress
-            </p>
+            <p className={STAT_LABEL_CLS}>Progress</p>
             <div className="flex items-center gap-2">
-              <div className="flex-1 h-1.5 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.08)" }}>
+              <div className="flex-1 h-1.5 rounded-full overflow-hidden bg-border/40">
                 <div
-                  className="h-full rounded-full transition-all duration-500"
-                  style={{
-                    width: `${completion}%`,
-                    background: completion === 100 ? "#22C55E" : PRIMARY,
-                  }}
+                  className={`h-full rounded-full transition-all duration-500 ${completion === 100 ? "bg-success" : "bg-primary"}`}
+                  style={{ width: `${completion}%` }}
                 />
               </div>
-              <span className="text-xs font-medium text-white shrink-0">{completion}%</span>
+              <span className="text-xs font-medium text-foreground shrink-0">{completion}%</span>
             </div>
-            <p className="text-xs" style={{ color: TEXT_LABEL }}>
+            <p className="text-xs text-muted-foreground/60">
               {done} / {total} done
             </p>
           </div>
@@ -153,44 +132,33 @@ export const ActiveSprintClient = () => {
 
         {/* ── View toggle ── */}
         <div className="flex items-center gap-3">
-          <div
-            className="flex items-center p-1 rounded-btn gap-0.5"
-            style={{ background: "rgba(255,255,255,0.04)", border: `1px solid ${BORDER_SUBTLE}` }}
-          >
+          <div className="flex items-center p-1 rounded-btn gap-0.5 bg-surface border border-border/40">
             {VIEWS.map(({ label, value, icon: Icon }) => (
               <button
                 key={value}
                 type="button"
                 onClick={() => setView(value)}
-                className="flex items-center gap-1.5 px-3 py-1 text-sm rounded transition-all duration-150"
-                style={
+                className={`flex items-center gap-1.5 px-3 py-1 text-sm rounded transition-all duration-150 ${
                   view === value
-                    ? { background: "rgba(255,255,255,0.08)", color: "#FFFFFF" }
-                    : { color: "rgba(255,255,255,0.4)" }
-                }
+                    ? "bg-surface-2 text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
               >
                 <Icon className="size-3.5" />
                 {label}
               </button>
             ))}
           </div>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>
+          <p className="text-sm text-muted-foreground/60">
             {total} items
           </p>
         </div>
 
         {/* ── Work items ── */}
-        <div
-          className="rounded-card overflow-hidden"
-          style={{
-            background: SURFACE,
-            border: `1px solid ${BORDER_SUBTLE}`,
-            boxShadow: "0 0 0 1px rgba(255,255,255,0.04), 0 8px 30px rgba(0,0,0,0.25)",
-          }}
-        >
+        <div className="rounded-card overflow-hidden bg-surface border border-border/40 shadow-chronicle-sm">
           {view === "kanban" ? (
             <div className="p-4">
-              <DataKanban data={tasks} onChange={onKanbanChange} />
+              <DataKanban data={tasks} onChange={onKanbanChange} isPending={isBulkUpdating} />
             </div>
           ) : (
             <DataTable
@@ -209,31 +177,20 @@ export const ActiveSprintClient = () => {
   } else {
     mainContent = (
       /* ── No active sprint empty state ── */
-      <div
-        className="flex flex-col items-center justify-center gap-6 py-20 rounded-card"
-        style={{ background: SURFACE, border: `1px solid ${BORDER_SUBTLE}` }}
-      >
-        <div
-          className="flex items-center justify-center size-16 rounded-2xl"
-          style={{ background: "rgba(79,124,255,0.08)", border: "1px solid rgba(79,124,255,0.15)" }}
-        >
-          <Timer className="size-7" style={{ color: PRIMARY }} />
+      <div className="flex flex-col items-center justify-center gap-6 py-20 rounded-card bg-surface border border-border/40">
+        <div className="flex items-center justify-center size-16 rounded-2xl bg-primary/10 border border-primary/20">
+          <Timer className="size-7 text-primary" />
         </div>
         <div className="text-center flex flex-col gap-2 max-w-sm">
-          <h2 className="text-xl font-bold text-white">No Active Sprint</h2>
-          <p className="text-sm leading-relaxed" style={{ color: "rgba(255,255,255,0.45)" }}>
+          <h2 className="text-xl font-bold text-foreground">No Active Sprint</h2>
+          <p className="text-sm leading-relaxed text-muted-foreground">
             Start a sprint from the Backlog to begin tracking your team&apos;s
             progress here.
           </p>
         </div>
         <Link
           href={`/workspace/${workspaceId}/project/${projectId}/backlog`}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all"
-          style={{
-            background: "rgba(79,124,255,0.12)",
-            color: PRIMARY,
-            border: "1px solid rgba(79,124,255,0.25)",
-          }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary/10 text-primary border border-primary/25 hover:bg-primary/20 transition-all"
         >
           Go to Backlog
           <ArrowRight className="size-4" />
@@ -247,10 +204,10 @@ export const ActiveSprintClient = () => {
       {/* ── Page header ── */}
       <div className="flex items-start justify-between">
         <div className={STAT_COL_CLS}>
-          <h1 className="text-2xl font-bold tracking-tight text-white">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">
             Active Sprint
           </h1>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.45)" }}>
+          <p className="text-sm text-muted-foreground">
             {activeSprint
               ? `Currently running ${activeSprint.name}`
               : "No sprint is currently active"}
@@ -260,14 +217,7 @@ export const ActiveSprintClient = () => {
           <button
             type="button"
             onClick={() => openCreateModal({ projectId })}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all duration-150"
-            style={{
-              background: PRIMARY,
-              color: "#FFFFFF",
-              boxShadow: "0 0 0 1px rgba(79,124,255,0.3), 0 4px 12px rgba(79,124,255,0.25)",
-            }}
-            onMouseEnter={(e) => { e.currentTarget.style.background = "#3d6ae8"; }}
-            onMouseLeave={(e) => { e.currentTarget.style.background = PRIMARY; }}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary text-white hover:bg-primary/90 transition-all duration-150 shadow-glow-primary"
           >
             <Plus className="size-4" />
             Add to Sprint

--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/epic/[taskId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/epic/[taskId]/client.tsx
@@ -29,63 +29,40 @@ import {
 import ReactMarkdown from "react-markdown";
 import Link from "next/link";
 import { getTaskRoute } from "@/lib/task-routes";
+import { cn } from "@/lib/utils";
 
-const SURFACE = "#0F172A";
-const BORDER_SUBTLE = "rgba(255,255,255,0.06)";
-const TEXT_FAINT = "rgba(255,255,255,0.4)";
-const TEXT_BODY = "rgba(255,255,255,0.65)";
-const TEXT_LABEL = "rgba(255,255,255,0.35)";
-const PRIMARY = "#4F7CFF";
-const SUCCESS = "#22C55E";
-const WARNING = "#F59E0B";
-const PRIMARY_MUTED = "rgba(79,124,255,0.15)";
-const TEXT_XS = "text-[12px]";
-const BG_FAINT = "rgba(255,255,255,0.02)";
-const TEXT_CENTER = "text-center";
-const TEXT_SM_MT = "text-[13px] mt-1";
-const FLEX_BETWEEN = "flex items-center justify-between";
-const ICON_SM = "size-3.5";
-const LABEL_CLS = "text-[14px] font-semibold text-white";
-const TAB_OVERVIEW = "overview";
-const FLEX_GAP_XS = "flex items-center gap-1.5 text-[12px]";
-const CARD_PAD = "rounded-2xl p-5";
-
-const STATUS_CONFIG: Record<TaskStatus, { label: string; color: string; bg: string }> = {
-  [TaskStatus.BACKLOG]: { label: "Backlog", color: "#6B7280", bg: "rgba(107,114,128,0.12)" },
-  [TaskStatus.TODO]: { label: "To Do", color: "#94A3B8", bg: "rgba(148,163,184,0.12)" },
-  [TaskStatus.IN_PROGRESS]: { label: "In Progress", color: PRIMARY, bg: "rgba(79,124,255,0.12)" },
-  [TaskStatus.UNDER_REVIEW]: { label: "In Review", color: WARNING, bg: "rgba(245,158,11,0.12)" },
-  [TaskStatus.DONE]: { label: "Done", color: SUCCESS, bg: "rgba(34,197,94,0.12)" },
+/* ── Status classes (Tailwind tokens only) ── */
+const STATUS_CLASS: Record<TaskStatus, { label: string; cls: string }> = {
+  [TaskStatus.BACKLOG]:      { label: "Backlog",     cls: "bg-muted/30 text-muted-foreground" },
+  [TaskStatus.TODO]:         { label: "To Do",       cls: "bg-muted/30 text-muted-foreground/80" },
+  [TaskStatus.IN_PROGRESS]:  { label: "In Progress", cls: "bg-primary/10 text-primary" },
+  [TaskStatus.UNDER_REVIEW]: { label: "In Review",   cls: "bg-warning/10 text-warning" },
+  [TaskStatus.DONE]:         { label: "Done",        cls: "bg-success/10 text-success" },
 };
 
-const PRIORITY_CONFIG: Record<TaskPriority, { label: string; color: string }> = {
-  [TaskPriority.CRITICAL]: { label: "Critical", color: "#EF4444" },
-  [TaskPriority.HIGH]: { label: "High", color: "#F97316" },
-  [TaskPriority.MEDIUM]: { label: "Medium", color: WARNING },
-  [TaskPriority.LOW]: { label: "Low", color: SUCCESS },
-  [TaskPriority.BLOCKER]: { label: "Blocker", color: "#B91C1C" },
-  [TaskPriority.TRIVIAL]: { label: "Trivial", color: "#9CA3AF" },
+const PRIORITY_CLASS: Record<TaskPriority, { label: string; dotCls: string }> = {
+  [TaskPriority.BLOCKER]:  { label: "Blocker",  dotCls: "bg-destructive" },
+  [TaskPriority.CRITICAL]: { label: "Critical", dotCls: "bg-destructive" },
+  [TaskPriority.HIGH]:     { label: "High",     dotCls: "bg-orange-500" },
+  [TaskPriority.MEDIUM]:   { label: "Medium",   dotCls: "bg-warning" },
+  [TaskPriority.LOW]:      { label: "Low",      dotCls: "bg-success" },
+  [TaskPriority.TRIVIAL]:  { label: "Trivial",  dotCls: "bg-muted-foreground" },
 };
 
-const TYPE_CONFIG: Record<IssueType, { label: string; color: string; bg: string }> = {
-  [IssueType.EPIC]: { label: "Epic", color: "#8B5CF6", bg: "rgba(139,92,246,0.15)" },
-  [IssueType.STORY]: { label: "Story", color: PRIMARY, bg: PRIMARY_MUTED },
-  [IssueType.BUG]: { label: "Bug", color: "#EF4444", bg: "rgba(239,68,68,0.15)" },
-  [IssueType.SPIKE]: { label: "Spike", color: WARNING, bg: "rgba(245,158,11,0.15)" },
-  [IssueType.TASK]: { label: "Task", color: SUCCESS, bg: "rgba(34,197,94,0.15)" },
+const TYPE_CLASS: Record<IssueType, { label: string; cls: string }> = {
+  [IssueType.EPIC]:  { label: "Epic",  cls: "bg-purple/15 text-purple" },
+  [IssueType.STORY]: { label: "Story", cls: "bg-primary/10 text-primary" },
+  [IssueType.BUG]:   { label: "Bug",   cls: "bg-destructive/10 text-destructive" },
+  [IssueType.SPIKE]: { label: "Spike", cls: "bg-warning/10 text-warning" },
+  [IssueType.TASK]:  { label: "Task",  cls: "bg-success/10 text-success" },
 };
-
-function getButtonLabel(isPending: boolean, hasNotes: boolean): string {
-  if (isPending) return "Generating…";
-  return hasNotes ? "Regenerate" : "Generate AI Notes";
-}
 
 function ProgressBar({ value }: { readonly value: number }) {
   return (
-    <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ background: BORDER_SUBTLE }}>
+    <div className="w-full h-1.5 rounded-full overflow-hidden bg-border/40">
       <div
-        className="h-full rounded-full transition-all"
-        style={{ width: `${value}%`, background: value === 100 ? SUCCESS : PRIMARY }}
+        className={cn("h-full rounded-full transition-all", value === 100 ? "bg-success" : "bg-primary")}
+        style={{ width: `${value}%` }}
       />
     </div>
   );
@@ -93,61 +70,43 @@ function ProgressBar({ value }: { readonly value: number }) {
 
 function WorkItemRow({ task, workspaceId, projectId }: { readonly task: Task; readonly workspaceId: string; readonly projectId: string }) {
   const href = getTaskRoute(workspaceId, projectId, task);
-  const typeCfg = task.issueType ? TYPE_CONFIG[task.issueType] : TYPE_CONFIG[IssueType.TASK];
-  const statusCfg = STATUS_CONFIG[task.status];
+  const typeCfg = task.issueType ? TYPE_CLASS[task.issueType] : TYPE_CLASS[IssueType.TASK];
+  const statusCfg = STATUS_CLASS[task.status];
 
   return (
     <Link
       href={href}
-      className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group"
-      style={{ background: BG_FAINT, border: "1px solid rgba(255,255,255,0.05)" }}
+      className="flex items-center gap-3 px-4 py-3 rounded-xl transition-all group bg-surface hover:bg-surface-2 border border-border/40"
     >
-      <span
-        className="text-[11px] font-semibold px-2 py-0.5 rounded-md shrink-0"
-        style={{ background: typeCfg.bg, color: typeCfg.color }}
-      >
+      <span className={cn("text-[11px] font-semibold px-2 py-0.5 rounded-md shrink-0", typeCfg.cls)}>
         {typeCfg.label}
       </span>
-
-      <span className="flex-1 text-[14px] text-white/80 truncate group-hover:text-white transition-colors">
+      <span className="flex-1 text-[14px] text-foreground/80 truncate group-hover:text-foreground transition-colors">
         {task.name}
       </span>
-
-      <span
-        className="text-[11px] font-medium px-2 py-0.5 rounded-md shrink-0"
-        style={{ background: statusCfg.bg, color: statusCfg.color }}
-      >
+      <span className={cn("text-[11px] font-medium px-2 py-0.5 rounded-md shrink-0", statusCfg.cls)}>
         {statusCfg.label}
       </span>
-
       {task.assignee && (
         <MemberAvatar name={task.assignee.name ?? "?"} className="size-5 shrink-0" />
       )}
-
       {task.dueDate && (
-        <TaskDate value={task.dueDate} className="text-[12px] text-white/40 shrink-0" />
+        <TaskDate value={task.dueDate} className="text-[12px] text-muted-foreground shrink-0" />
       )}
-
-      <ChevronRight className="size-3.5 text-white/20 group-hover:text-white/50 transition-colors shrink-0" />
+      <ChevronRight className="size-3.5 text-muted-foreground/30 group-hover:text-muted-foreground/60 transition-colors shrink-0" />
     </Link>
   );
 }
 
 function TimelineTab() {
   return (
-    <div
-      className="flex flex-col items-center justify-center py-20 rounded-2xl gap-4"
-      style={{ background: BG_FAINT, border: "1px dashed rgba(255,255,255,0.08)" }}
-    >
-      <div
-        className="flex items-center justify-center size-14 rounded-2xl"
-        style={{ background: "rgba(79,124,255,0.08)", border: "1px solid rgba(79,124,255,0.15)" }}
-      >
-        <GitBranch className="size-6" style={{ color: PRIMARY }} />
+    <div className="flex flex-col items-center justify-center py-20 rounded-2xl gap-4 bg-surface border border-dashed border-border/40">
+      <div className="flex items-center justify-center size-14 rounded-2xl bg-primary/8 border border-primary/15">
+        <GitBranch className="size-6 text-primary" />
       </div>
-      <div className={TEXT_CENTER}>
-        <p className="text-[15px] font-semibold text-white">Timeline View</p>
-        <p className={TEXT_SM_MT} style={{ color: TEXT_LABEL }}>
+      <div className="text-center">
+        <p className="text-[15px] font-semibold text-foreground">Timeline View</p>
+        <p className="text-[13px] mt-1 text-muted-foreground">
           Gantt-style timeline coming in a future release.
         </p>
       </div>
@@ -156,24 +115,29 @@ function TimelineTab() {
 }
 
 const MdH2 = ({ children }: { children?: React.ReactNode }) => (
-  <h2 className="text-[14px] font-semibold text-white mt-5 mb-2 first:mt-0">{children}</h2>
+  <h2 className="text-[14px] font-semibold text-foreground mt-5 mb-2 first:mt-0">{children}</h2>
 );
 const MdP = ({ children }: { children?: React.ReactNode }) => (
-  <p className="text-[13px] leading-relaxed mb-3" style={{ color: TEXT_BODY }}>{children}</p>
+  <p className="text-[13px] leading-relaxed mb-3 text-foreground/70">{children}</p>
 );
 const MdUl = ({ children }: { children?: React.ReactNode }) => (
   <ul className="list-none pl-0 flex flex-col gap-1.5 mb-3">{children}</ul>
 );
 const MdLi = ({ children }: { children?: React.ReactNode }) => (
-  <li className="flex items-start gap-2 text-[13px]" style={{ color: TEXT_BODY }}>
-    <span className="mt-1.5 size-1.5 rounded-full bg-blue-500/60 shrink-0" />
+  <li className="flex items-start gap-2 text-[13px] text-foreground/70">
+    <span className="mt-1.5 size-1.5 rounded-full bg-primary/60 shrink-0" />
     <span>{children}</span>
   </li>
 );
 const MdStrong = ({ children }: { children?: React.ReactNode }) => (
-  <strong className="text-white font-semibold">{children}</strong>
+  <strong className="text-foreground font-semibold">{children}</strong>
 );
 const MD_COMPONENTS = { h2: MdH2, p: MdP, ul: MdUl, li: MdLi, strong: MdStrong };
+
+function getButtonLabel(isPending: boolean, hasNotes: boolean): string {
+  if (isPending) return "Generating…";
+  return hasNotes ? "Regenerate" : "Generate AI Notes";
+}
 
 function AiNotesTab({ epic, childTasks }: { readonly epic: Task; readonly childTasks: Task[] }) {
   const { mutate: generateNotes, isPending, data: notes, isIdle, isError } = useGetEpicNotes();
@@ -194,46 +158,35 @@ function AiNotesTab({ epic, childTasks }: { readonly epic: Task; readonly childT
 
   return (
     <div className="flex flex-col gap-4">
-      <div className={FLEX_BETWEEN}>
+      <div className="flex items-center justify-between">
         <div>
-          <h3 className="text-[15px] font-semibold text-white">AI Notes</h3>
-          <p className="text-[13px] mt-0.5" style={{ color: TEXT_FAINT }}>
+          <h3 className="text-[15px] font-semibold text-foreground">AI Notes</h3>
+          <p className="text-[13px] mt-0.5 text-muted-foreground">
             Generated by Claude based on this epic&apos;s data.
           </p>
         </div>
         <button
           onClick={handleGenerate}
           disabled={isPending}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-60"
-          style={{
-            background: isPending ? PRIMARY_MUTED : "rgba(79,124,255,0.12)",
-            color: PRIMARY,
-            border: "1px solid rgba(79,124,255,0.25)",
-          }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary/10 text-primary border border-primary/25 hover:bg-primary/20 transition-all disabled:opacity-60"
         >
           {isPending ? (
             <RefreshCw className="size-3.5 animate-spin" />
           ) : (
-            <Sparkles className={ICON_SM} />
+            <Sparkles className="size-3.5" />
           )}
           {getButtonLabel(isPending, !!notes)}
         </button>
       </div>
 
       {isIdle && !notes && (
-        <div
-          className="flex flex-col items-center justify-center py-16 rounded-2xl gap-4"
-          style={{ background: "rgba(79,124,255,0.04)", border: "1px dashed rgba(79,124,255,0.15)" }}
-        >
-          <div
-            className="flex items-center justify-center size-14 rounded-2xl"
-            style={{ background: "rgba(79,124,255,0.08)", border: "1px solid rgba(79,124,255,0.15)" }}
-          >
-            <Sparkles className="size-6" style={{ color: PRIMARY }} />
+        <div className="flex flex-col items-center justify-center py-16 rounded-2xl gap-4 bg-primary/[0.04] border border-dashed border-primary/15">
+          <div className="flex items-center justify-center size-14 rounded-2xl bg-primary/8 border border-primary/15">
+            <Sparkles className="size-6 text-primary" />
           </div>
-          <div className={TEXT_CENTER}>
-            <p className={LABEL_CLS}>Generate AI Notes</p>
-            <p className={TEXT_SM_MT} style={{ color: TEXT_LABEL }}>
+          <div className="text-center">
+            <p className="text-[14px] font-semibold text-foreground">Generate AI Notes</p>
+            <p className="text-[13px] mt-1 text-muted-foreground">
               Claude will analyze this epic and provide a summary, risks, and next steps.
             </p>
           </div>
@@ -241,20 +194,14 @@ function AiNotesTab({ epic, childTasks }: { readonly epic: Task; readonly childT
       )}
 
       {isError && (
-        <div
-          className="flex items-center gap-3 px-4 py-3 rounded-xl"
-          style={{ background: "rgba(239,68,68,0.08)", border: "1px solid rgba(239,68,68,0.2)" }}
-        >
-          <AlertTriangle className="size-4 text-red-400 shrink-0" />
-          <p className="text-[13px] text-red-400">Failed to generate AI notes. Please try again.</p>
+        <div className="flex items-center gap-3 px-4 py-3 rounded-xl bg-destructive/8 border border-destructive/20">
+          <AlertTriangle className="size-4 text-destructive shrink-0" />
+          <p className="text-[13px] text-destructive">Failed to generate AI notes. Please try again.</p>
         </div>
       )}
 
       {notes && (
-        <div
-          className="rounded-2xl p-6"
-          style={{ background: SURFACE, border: "1px solid rgba(255,255,255,0.07)" }}
-        >
+        <div className="rounded-2xl p-6 bg-surface border border-border/40">
           <div className="prose prose-invert prose-sm max-w-none">
             <ReactMarkdown components={MD_COMPONENTS}>
               {notes}
@@ -275,7 +222,7 @@ export const EpicDetailClient = () => {
   const { data: epic, isLoading } = useGetTask({ taskId });
   const { data: allTasks } = useGetTasks({ workspaceId, projectId, enabled: !!epic });
 
-  const [activeTab, setActiveTab] = useState(TAB_OVERVIEW);
+  const [activeTab, setActiveTab] = useState("overview");
 
   if (isLoading) return <PageLoader />;
   if (!epic) return <PageError message="Epic not found" />;
@@ -284,61 +231,52 @@ export const EpicDetailClient = () => {
   const doneCount = childTasks.filter((t) => t.status === TaskStatus.DONE).length;
   const progressPct = childTasks.length > 0 ? Math.round((doneCount / childTasks.length) * 100) : 0;
 
-  const statusCfg = STATUS_CONFIG[epic.status];
-  const priorityCfg = epic.priority ? PRIORITY_CONFIG[epic.priority] : null;
+  const statusCfg = STATUS_CLASS[epic.status];
+  const priorityCfg = epic.priority ? PRIORITY_CLASS[epic.priority] : null;
 
   return (
     <div className="flex flex-col gap-6 w-full max-w-4xl">
       {/* Header */}
       <div className="flex flex-col gap-3">
         <div className="flex items-center gap-2">
-          <span
-            className="text-[11px] font-semibold px-2.5 py-1 rounded-md"
-            style={{ background: "rgba(139,92,246,0.15)", color: "#8B5CF6" }}
-          >
+          <span className="text-[11px] font-semibold px-2.5 py-1 rounded-md bg-purple/15 text-purple">
             EPIC
           </span>
           {epic.project && (
-            <span className="text-[13px]" style={{ color: TEXT_FAINT }}>
-              {epic.project.name}
-            </span>
+            <span className="text-[13px] text-muted-foreground">{epic.project.name}</span>
           )}
         </div>
 
         <div className="flex items-start justify-between gap-4">
-          <h1 className="text-2xl font-bold text-white leading-tight">{epic.name}</h1>
+          <h1 className="text-2xl font-bold text-foreground leading-tight">{epic.name}</h1>
           <button
             onClick={() => openEdit(epic.$id)}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg shrink-0 transition-all"
-            style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.6)", border: "1px solid rgba(255,255,255,0.08)" }}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg shrink-0 transition-all bg-surface-2 text-muted-foreground border border-border/40 hover:text-foreground"
           >
-            <PencilIcon className={ICON_SM} />
+            <PencilIcon className="size-3.5" />
             Edit
           </button>
         </div>
 
         {/* Meta row */}
         <div className="flex items-center gap-3 flex-wrap">
-          <span
-            className="text-[12px] font-medium px-2.5 py-1 rounded-md"
-            style={{ background: statusCfg.bg, color: statusCfg.color }}
-          >
+          <span className={cn("text-[12px] font-medium px-2.5 py-1 rounded-md", statusCfg.cls)}>
             {statusCfg.label}
           </span>
           {priorityCfg && (
-            <span className={FLEX_GAP_XS} style={{ color: "rgba(255,255,255,0.5)" }}>
-              <span className="size-1.5 rounded-full shrink-0" style={{ background: priorityCfg.color }} />
+            <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
+              <span className={cn("size-1.5 rounded-full shrink-0", priorityCfg.dotCls)} />
               {priorityCfg.label}
             </span>
           )}
           {epic.dueDate && (
-            <span className={FLEX_GAP_XS} style={{ color: TEXT_FAINT }}>
+            <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
               <Clock className="size-3" />
-              Due <TaskDate value={epic.dueDate} className={TEXT_XS} />
+              Due <TaskDate value={epic.dueDate} className="text-[12px]" />
             </span>
           )}
           {epic.assignee && (
-            <span className={FLEX_GAP_XS} style={{ color: "rgba(255,255,255,0.5)" }}>
+            <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground">
               <MemberAvatar name={epic.assignee.name} className="size-4" />
               {epic.assignee.name}
             </span>
@@ -348,14 +286,11 @@ export const EpicDetailClient = () => {
         {/* Progress bar */}
         {childTasks.length > 0 && (
           <div className="flex flex-col gap-1.5 mt-1">
-            <div className={FLEX_BETWEEN}>
-              <span className={TEXT_XS} style={{ color: TEXT_FAINT }}>
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] text-muted-foreground">
                 {doneCount} of {childTasks.length} work items complete
               </span>
-              <span
-                className="text-[12px] font-semibold"
-                style={{ color: progressPct === 100 ? SUCCESS : PRIMARY }}
-              >
+              <span className={cn("text-[12px] font-semibold", progressPct === 100 ? "text-success" : "text-primary")}>
                 {progressPct}%
               </span>
             </div>
@@ -366,28 +301,22 @@ export const EpicDetailClient = () => {
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList
-          className="flex items-center gap-1 p-1 rounded-xl w-fit"
-          style={{ background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.07)" }}
-        >
+        <TabsList className="flex items-center gap-1 p-1 rounded-xl w-fit bg-surface border border-border/40">
           {[
-            { value: TAB_OVERVIEW, icon: Circle, label: "Overview" },
-            { value: "work-items", icon: LayoutList, label: "Work Items", count: childTasks.length },
-            { value: "timeline", icon: GitBranch, label: "Timeline" },
-            { value: "ai-notes", icon: Sparkles, label: "AI Notes" },
+            { value: "overview",    icon: Circle,     label: "Overview" },
+            { value: "work-items",  icon: LayoutList,  label: "Work Items", count: childTasks.length },
+            { value: "timeline",    icon: GitBranch,   label: "Timeline" },
+            { value: "ai-notes",    icon: Sparkles,    label: "AI Notes" },
           ].map(({ value, icon: Icon, label, count }) => (
             <TabsTrigger
               key={value}
               value={value}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg transition-all data-[state=active]:text-white data-[state=inactive]:text-white/40 data-[state=active]:bg-white/[0.08] data-[state=inactive]:bg-transparent border-none shadow-none"
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg transition-all data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground data-[state=active]:bg-surface-2 data-[state=inactive]:bg-transparent border-none shadow-none"
             >
-              <Icon className={ICON_SM} />
+              <Icon className="size-3.5" />
               {label}
               {count != null && count > 0 && (
-                <span
-                  className="text-[11px] font-semibold px-1.5 py-0.5 rounded-full"
-                  style={{ background: "rgba(79,124,255,0.2)", color: PRIMARY }}
-                >
+                <span className="text-[11px] font-semibold px-1.5 py-0.5 rounded-full bg-primary/20 text-primary">
                   {count}
                 </span>
               )}
@@ -396,27 +325,23 @@ export const EpicDetailClient = () => {
         </TabsList>
 
         {/* Overview Tab */}
-        <TabsContent value={TAB_OVERVIEW} className="mt-6">
+        <TabsContent value="overview" className="mt-6">
           <div className="grid grid-cols-1 md:grid-cols-[1fr_280px] gap-5">
-            <div
-              className="rounded-2xl p-5 flex flex-col gap-4"
-              style={{ background: SURFACE, border: "1px solid rgba(255,255,255,0.06)" }}
-            >
-              <h3 className={LABEL_CLS}>Description</h3>
+            <div className="rounded-2xl p-5 flex flex-col gap-4 bg-surface border border-border/40">
+              <h3 className="text-[14px] font-semibold text-foreground">Description</h3>
               {epic.description ? (
-                <p className="text-[14px] leading-relaxed whitespace-pre-wrap" style={{ color: TEXT_BODY }}>
+                <p className="text-[14px] leading-relaxed whitespace-pre-wrap text-foreground/70">
                   {epic.description}
                 </p>
               ) : (
-                <p className="text-[13px] italic" style={{ color: "rgba(255,255,255,0.25)" }}>
+                <p className="text-[13px] italic text-muted-foreground/50">
                   No description provided.
                 </p>
               )}
-
               {epic.acceptanceCriteria && (
-                <div style={{ borderTop: `1px solid ${BORDER_SUBTLE}` }} className="pt-4">
-                  <h4 className="text-[13px] font-semibold text-white mb-2">Acceptance Criteria</h4>
-                  <p className="text-[13px] leading-relaxed whitespace-pre-wrap" style={{ color: TEXT_BODY }}>
+                <div className="pt-4 border-t border-border/40">
+                  <h4 className="text-[13px] font-semibold text-foreground mb-2">Acceptance Criteria</h4>
+                  <p className="text-[13px] leading-relaxed whitespace-pre-wrap text-foreground/70">
                     {epic.acceptanceCriteria}
                   </p>
                 </div>
@@ -425,20 +350,17 @@ export const EpicDetailClient = () => {
 
             <div className="flex flex-col gap-3">
               {/* Stats card */}
-              <div
-                className={CARD_PAD}
-                style={{ background: SURFACE, border: `1px solid ${BORDER_SUBTLE}` }}
-              >
-                <h3 className="text-[13px] font-semibold text-white/50 uppercase tracking-wider mb-4">Progress</h3>
+              <div className="rounded-2xl p-5 bg-surface border border-border/40">
+                <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wider mb-4">Progress</h3>
                 <div className="grid grid-cols-3 gap-3 mb-4">
                   {[
-                    { label: "Total", value: childTasks.length, color: PRIMARY },
-                    { label: "Done", value: doneCount, color: SUCCESS },
-                    { label: "Left", value: childTasks.length - doneCount, color: WARNING },
-                  ].map(({ label, value, color }) => (
+                    { label: "Total", value: childTasks.length, cls: "text-primary" },
+                    { label: "Done",  value: doneCount,         cls: "text-success" },
+                    { label: "Left",  value: childTasks.length - doneCount, cls: "text-warning" },
+                  ].map(({ label, value, cls }) => (
                     <div key={label} className="flex flex-col items-center gap-1">
-                      <span className="text-xl font-bold" style={{ color }}>{value}</span>
-                      <span className="text-[11px]" style={{ color: TEXT_FAINT }}>{label}</span>
+                      <span className={cn("text-xl font-bold", cls)}>{value}</span>
+                      <span className="text-[11px] text-muted-foreground">{label}</span>
                     </div>
                   ))}
                 </div>
@@ -446,33 +368,29 @@ export const EpicDetailClient = () => {
               </div>
 
               {/* Details card */}
-              <div
-                className="rounded-2xl p-5 flex flex-col gap-3"
-                style={{ background: SURFACE, border: `1px solid ${BORDER_SUBTLE}` }}
-              >
-                <h3 className="text-[13px] font-semibold text-white/50 uppercase tracking-wider">Details</h3>
+              <div className="rounded-2xl p-5 flex flex-col gap-3 bg-surface border border-border/40">
+                <h3 className="text-[13px] font-semibold text-muted-foreground uppercase tracking-wider">Details</h3>
                 {(
                   [
-                    { label: "Status", value: statusCfg.label, color: statusCfg.color },
-                    ...(priorityCfg ? [{ label: "Priority", value: priorityCfg.label, color: priorityCfg.color }] : []),
-                    ...(epic.storyPoints == null ? [] : [{ label: "Story Points", value: `${epic.storyPoints} pts`, color: TEXT_BODY }]),
-                  ] as { label: string; value: string; color: string }[]
+                    { label: "Status",   value: statusCfg.label,     cls: statusCfg.cls.split(" ").find(c => c.startsWith("text-")) ?? "text-foreground" },
+                    ...(priorityCfg ? [{ label: "Priority", value: priorityCfg.label, cls: "text-foreground/80" }] : []),
+                    ...(epic.storyPoints == null ? [] : [{ label: "Story Points", value: `${epic.storyPoints} pts`, cls: "text-foreground/80" }]),
+                  ] as { label: string; value: string; cls: string }[]
                 ).map((item) => (
-                  <div key={item.label} className={FLEX_BETWEEN}>
-                    <span className={TEXT_XS} style={{ color: TEXT_FAINT }}>{item.label}</span>
-                    <span className="text-[12px] font-medium" style={{ color: item.color }}>{item.value}</span>
+                  <div key={item.label} className="flex items-center justify-between">
+                    <span className="text-[12px] text-muted-foreground">{item.label}</span>
+                    <span className={cn("text-[12px] font-medium", item.cls)}>{item.value}</span>
                   </div>
                 ))}
 
                 {epic.labels && epic.labels.length > 0 && (
                   <div className="flex flex-col gap-1.5">
-                    <span className={TEXT_XS} style={{ color: TEXT_FAINT }}>Labels</span>
+                    <span className="text-[12px] text-muted-foreground">Labels</span>
                     <div className="flex flex-wrap gap-1.5">
                       {epic.labels.map((label) => (
                         <span
                           key={label}
-                          className="text-[11px] font-medium px-2 py-0.5 rounded-md"
-                          style={{ background: BORDER_SUBTLE, color: "rgba(255,255,255,0.6)" }}
+                          className="text-[11px] font-medium px-2 py-0.5 rounded-md bg-border/40 text-foreground/60"
                         >
                           {label}
                         </span>
@@ -487,26 +405,17 @@ export const EpicDetailClient = () => {
 
         {/* Work Items Tab */}
         <TabsContent value="work-items" className="mt-6">
-          <div
-            className={CARD_PAD}
-            style={{ background: SURFACE, border: `1px solid ${BORDER_SUBTLE}` }}
-          >
+          <div className="rounded-2xl p-5 bg-surface border border-border/40">
             <div className="flex items-center justify-between mb-4">
-              <h3 className={LABEL_CLS}>Work Items</h3>
-              <span className={TEXT_XS} style={{ color: TEXT_FAINT }}>
-                {childTasks.length} items
-              </span>
+              <h3 className="text-[14px] font-semibold text-foreground">Work Items</h3>
+              <span className="text-[12px] text-muted-foreground">{childTasks.length} items</span>
             </div>
-
             {childTasks.length === 0 ? (
-              <div
-                className="flex flex-col items-center justify-center py-12 rounded-xl gap-3"
-                style={{ background: BG_FAINT, border: "1px dashed rgba(255,255,255,0.08)" }}
-              >
-                <CheckCircle2 className="size-8" style={{ color: "rgba(255,255,255,0.15)" }} />
-                <div className={TEXT_CENTER}>
-                  <p className="text-[14px] font-medium text-white">No work items yet</p>
-                  <p className={TEXT_SM_MT} style={{ color: TEXT_LABEL }}>
+              <div className="flex flex-col items-center justify-center py-12 rounded-xl gap-3 bg-surface border border-dashed border-border/40">
+                <CheckCircle2 className="size-8 text-muted-foreground/20" />
+                <div className="text-center">
+                  <p className="text-[14px] font-medium text-foreground">No work items yet</p>
+                  <p className="text-[13px] mt-1 text-muted-foreground">
                     Create stories, bugs, or tasks and link them to this epic.
                   </p>
                 </div>
@@ -533,10 +442,7 @@ export const EpicDetailClient = () => {
 
         {/* AI Notes Tab */}
         <TabsContent value="ai-notes" className="mt-6">
-          <div
-            className={CARD_PAD}
-            style={{ background: SURFACE, border: `1px solid ${BORDER_SUBTLE}` }}
-          >
+          <div className="rounded-2xl p-5 bg-surface border border-border/40">
             <AiNotesTab epic={epic} childTasks={childTasks} />
           </div>
         </TabsContent>

--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/sprints/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/sprints/client.tsx
@@ -11,21 +11,15 @@ import { useGetTasks } from "@/features/tasks/api/use-get-tasks";
 import { TaskStatus } from "@/features/tasks/types";
 import { SprintStatus } from "@/features/sprints/types";
 import { SprintHeader } from "@/features/sprints/components/sprint-header";
+import { cn } from "@/lib/utils";
 import { Plus, Timer, CheckCircle2, AlertCircle, Zap } from "lucide-react";
 import { format, differenceInDays } from "date-fns";
 import Link from "next/link";
 
-const PRIMARY = "#4F7CFF";
-const TEXT_DIM = "rgba(255,255,255,0.3)";
-const FLEX_ROW = "flex items-center gap-2";
-const STAT_ICON_CLS = "flex items-center justify-center size-7 rounded-lg bg-white/[0.06]";
-const STAT_VAL_CLS = "text-sm font-semibold text-white";
-const TEXT_TINY_CLS = "text-[11px]";
-
-function getProgressColor(pct: number): string {
-  if (pct >= 70) return "#22C55E";
-  if (pct >= 40) return PRIMARY;
-  return "#F59E0B";
+function getProgressClass(pct: number): string {
+  if (pct >= 70) return "bg-success";
+  if (pct >= 40) return "bg-primary";
+  return "bg-warning";
 }
 
 export const SprintsClient = () => {
@@ -60,36 +54,22 @@ export const SprintsClient = () => {
   const activeCompleted = activeStats ? activeStats.done : 0;
   const activePct = activeTasks > 0 ? Math.round((activeCompleted / activeTasks) * 100) : 0;
   const daysLeft = activeSprint?.endDate ? differenceInDays(new Date(activeSprint.endDate), new Date()) : null;
-  let daysLeftText: string;
-  if (daysLeft == null) {
-    daysLeftText = "—";
-  } else if (daysLeft >= 0) {
-    daysLeftText = `${daysLeft}d left`;
-  } else {
-    daysLeftText = "Overdue";
-  }
+  const daysLeftText = daysLeft == null ? "—" : daysLeft >= 0 ? `${daysLeft}d left` : "Overdue";
 
   return (
     <div className="flex flex-col gap-6">
       {/* ── Page header ── */}
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-white">Sprints</h1>
-          <p className="text-[14px] mt-1" style={{ color: "rgba(255,255,255,0.45)" }}>
+          <h1 className="text-2xl font-bold text-foreground">Sprints</h1>
+          <p className="text-[14px] mt-1 text-muted-foreground">
             Plan and track iterations for {project.name}
           </p>
         </div>
         <button
           type="button"
           onClick={() => openCreateSprint({ projectId })}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all"
-          style={{
-            background: PRIMARY,
-            color: "#fff",
-            boxShadow: "0 0 0 1px rgba(79,124,255,0.3), 0 4px 12px rgba(79,124,255,0.25)",
-          }}
-          onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = "#3d6ae8"; }}
-          onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = PRIMARY; }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary text-white hover:bg-primary/90 transition-all shadow-glow-primary"
         >
           <Plus className="size-4" />
           New Sprint
@@ -98,79 +78,57 @@ export const SprintsClient = () => {
 
       {/* ── Active sprint health card ── */}
       {activeSprint && (
-        <div
-          className="p-5 rounded-card"
-          style={{
-            background: "linear-gradient(135deg, rgba(79,124,255,0.08) 0%, rgba(15,23,42,0) 60%), #0F172A",
-            border: "1px solid rgba(79,124,255,0.2)",
-            boxShadow: "0 0 0 1px rgba(255,255,255,0.04), 0 8px 30px rgba(0,0,0,0.25)",
-          }}
-        >
+        <div className="p-5 rounded-card bg-surface border border-primary/20 shadow-chronicle-sm">
           <div className="flex items-start justify-between mb-4">
             <div>
               <div className="flex items-center gap-2 mb-1">
-                <span className="size-2 rounded-full bg-green-400 animate-pulse" />
-                <span className="text-xs font-semibold uppercase tracking-widest text-green-400">Active Sprint</span>
+                <span className="size-2 rounded-full bg-success animate-pulse" />
+                <span className="text-xs font-semibold uppercase tracking-widest text-success">Active Sprint</span>
               </div>
-              <h2 className="text-lg font-bold text-white">{activeSprint.name}</h2>
+              <h2 className="text-lg font-bold text-foreground">{activeSprint.name}</h2>
               {activeSprint.startDate && activeSprint.endDate && (
-                <p className="text-[13px] mt-0.5" style={{ color: "rgba(255,255,255,0.45)" }}>
+                <p className="text-[13px] mt-0.5 text-muted-foreground">
                   {format(new Date(activeSprint.startDate), "MMM d")} – {format(new Date(activeSprint.endDate), "MMM d, yyyy")}
                 </p>
               )}
             </div>
             <div className="text-right">
-              <p className="text-3xl font-bold text-white">{activePct}%</p>
-              <p className="text-[13px]" style={{ color: "rgba(255,255,255,0.4)" }}>complete</p>
+              <p className="text-3xl font-bold text-foreground">{activePct}%</p>
+              <p className="text-[13px] text-muted-foreground">complete</p>
             </div>
           </div>
 
           {/* Progress bar */}
-          <div className="w-full h-1.5 rounded-full mb-4" style={{ background: "rgba(255,255,255,0.08)" }}>
+          <div className="w-full h-1.5 rounded-full mb-4 bg-border/40">
             <div
-              className="h-1.5 rounded-full transition-all duration-500"
-              style={{ width: `${activePct}%`, background: getProgressColor(activePct) }}
+              className={cn("h-1.5 rounded-full transition-all duration-500", getProgressClass(activePct))}
+              style={{ width: `${activePct}%` }}
             />
           </div>
 
           {/* Sprint stats */}
           <div className="grid grid-cols-3 gap-4">
-            <div className={FLEX_ROW}>
-              <div className={STAT_ICON_CLS}>
-                <Timer className="size-3.5 text-white/40" />
+            {[
+              { icon: Timer,        iconCls: "text-muted-foreground", val: daysLeftText,                   label: "Remaining" },
+              { icon: CheckCircle2, iconCls: "text-success",          val: `${activeCompleted}/${activeTasks}`, label: "Done" },
+              { icon: AlertCircle,  iconCls: "text-destructive",      val: activeStats?.blocked ?? 0,      label: "Blocked" },
+            ].map(({ icon: Icon, iconCls, val, label }) => (
+              <div key={label} className="flex items-center gap-2">
+                <div className="flex items-center justify-center size-7 rounded-lg bg-surface-2">
+                  <Icon className={cn("size-3.5", iconCls)} />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">{val}</p>
+                  <p className="text-[11px] text-muted-foreground/60">{label}</p>
+                </div>
               </div>
-              <div>
-                <p className={STAT_VAL_CLS}>
-                  {daysLeftText}
-                </p>
-                <p className={TEXT_TINY_CLS} style={{ color: TEXT_DIM }}>Remaining</p>
-              </div>
-            </div>
-            <div className={FLEX_ROW}>
-              <div className={STAT_ICON_CLS}>
-                <CheckCircle2 className="size-3.5 text-green-400" />
-              </div>
-              <div>
-                <p className={STAT_VAL_CLS}>{activeCompleted}/{activeTasks}</p>
-                <p className={TEXT_TINY_CLS} style={{ color: TEXT_DIM }}>Done</p>
-              </div>
-            </div>
-            <div className={FLEX_ROW}>
-              <div className={STAT_ICON_CLS}>
-                <AlertCircle className="size-3.5 text-red-400" />
-              </div>
-              <div>
-                <p className={STAT_VAL_CLS}>{activeStats?.blocked ?? 0}</p>
-                <p className={TEXT_TINY_CLS} style={{ color: TEXT_DIM }}>Blocked</p>
-              </div>
-            </div>
+            ))}
           </div>
 
           <div className="mt-4 flex items-center gap-2">
             <Link
               href={`/workspace/${workspaceId}/project/${projectId}/active-sprint`}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-btn transition-all"
-              style={{ background: PRIMARY, color: "#fff" }}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-btn bg-primary text-white hover:bg-primary/90 transition-all"
             >
               <Zap className="size-3.5" />
               View Board
@@ -182,27 +140,20 @@ export const SprintsClient = () => {
       {/* ── All sprints list ── */}
       <div className="flex flex-col gap-3">
         {sprints.length === 0 ? (
-          <div
-            className="flex flex-col items-center justify-center gap-4 py-16 rounded-card"
-            style={{ background: "#0F172A", border: "1px dashed rgba(255,255,255,0.1)" }}
-          >
-            <div
-              className="flex items-center justify-center size-14 rounded-2xl"
-              style={{ background: "rgba(79,124,255,0.08)", border: "1px solid rgba(79,124,255,0.15)" }}
-            >
-              <Timer className="size-6" style={{ color: PRIMARY }} />
+          <div className="flex flex-col items-center justify-center gap-4 py-16 rounded-card bg-surface border border-dashed border-border/40">
+            <div className="flex items-center justify-center size-14 rounded-2xl bg-primary/8 border border-primary/15">
+              <Timer className="size-6 text-primary" />
             </div>
             <div className="text-center">
-              <h3 className="text-base font-semibold text-white">No sprints yet</h3>
-              <p className="text-[13px] mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+              <h3 className="text-base font-semibold text-foreground">No sprints yet</h3>
+              <p className="text-[13px] mt-1 text-muted-foreground">
                 Create your first sprint to start planning
               </p>
             </div>
             <button
               type="button"
               onClick={() => openCreateSprint({ projectId })}
-              className="flex items-center gap-2 px-4 py-2 text-sm rounded-btn"
-              style={{ background: "rgba(79,124,255,0.12)", color: PRIMARY, border: "1px solid rgba(79,124,255,0.2)" }}
+              className="flex items-center gap-2 px-4 py-2 text-sm rounded-btn bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20 transition-all"
             >
               <Plus className="size-4" />
               Create Sprint

--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/work-items/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/work-items/client.tsx
@@ -36,6 +36,11 @@ const TYPE_FILTERS = [
   { label: "Spike", value: IssueType.SPIKE, icon: Zap },
 ] as const;
 
+/* Only types visible in the UI can become an active filter */
+const ALLOWED_FILTER_TYPES = new Set<string>(
+  TYPE_FILTERS.map((f) => f.value).filter((v) => v !== null)
+);
+
 const VIEWS = [
   { label: "List", value: "table", icon: List },
   { label: "Board", value: "kanban", icon: LayoutGrid },
@@ -64,7 +69,7 @@ export const WorkItemsClient = () => {
 
   const [typeParam, setTypeParam] = useQueryState("type");
   const activeType: IssueType | null =
-    typeParam && Object.values(IssueType).includes(typeParam as IssueType)
+    typeParam && ALLOWED_FILTER_TYPES.has(typeParam)
       ? (typeParam as IssueType)
       : null;
   const [view, setView] = useQueryState("view", { defaultValue: "table" });
@@ -145,7 +150,7 @@ export const WorkItemsClient = () => {
             Work Items
           </h1>
           <p className="text-sm text-muted-foreground">
-            Manage stories, bugs, spikes and tasks
+            Manage epics, stories, bugs and spikes
             {activeSprint_display && (
               <span className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-success/10 text-success border border-success/20">
                 <span className="size-1.5 rounded-full inline-block bg-success" />

--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/work-items/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/work-items/client.tsx
@@ -14,6 +14,7 @@ import { DataTable } from "@/features/tasks/components/data-table";
 import { columns } from "@/features/tasks/components/columns";
 import { getTaskRoute } from "@/lib/task-routes";
 import { useCallback } from "react";
+import { cn } from "@/lib/utils";
 import {
   Plus,
   Layers,
@@ -26,18 +27,13 @@ import {
   Loader,
 } from "lucide-react";
 
-const PRIMARY = "#4F7CFF";
-const SUCCESS = "#22C55E";
-const BORDER_SUBTLE = "rgba(255,255,255,0.06)";
-const BG_HOVER = "rgba(255,255,255,0.04)";
-
-/* ── Type filter pills ── */
+/* ── Type filter pills — Epic is an issue type, not a separate section ── */
 const TYPE_FILTERS = [
   { label: "All", value: null, icon: Layers },
+  { label: "Epic", value: IssueType.EPIC, icon: Target },
   { label: "Story", value: IssueType.STORY, icon: BookOpen },
   { label: "Bug", value: IssueType.BUG, icon: Bug },
   { label: "Spike", value: IssueType.SPIKE, icon: Zap },
-  { label: "Task", value: IssueType.TASK, icon: Target },
 ] as const;
 
 const VIEWS = [
@@ -45,21 +41,26 @@ const VIEWS = [
   { label: "Board", value: "kanban", icon: LayoutGrid },
 ] as const;
 
-/* ── Type badge colors ── */
-const TYPE_COLORS: Record<string, { bg: string; text: string }> = {
-  STORY: { bg: "rgba(34,197,94,0.12)", text: SUCCESS },
-  BUG: { bg: "rgba(239,68,68,0.12)", text: "#EF4444" },
-  SPIKE: { bg: "rgba(139,92,246,0.12)", text: "#8B5CF6" },
-  TASK: { bg: "rgba(79,124,255,0.12)", text: PRIMARY },
-  EPIC: { bg: "rgba(245,158,11,0.12)", text: "#F59E0B" },
+/* ── Type active classes (Tailwind tokens only) ── */
+const TYPE_ACTIVE_CLASS: Record<string, string> = {
+  EPIC: "bg-warning/10 text-warning border border-warning/20",
+  STORY: "bg-success/10 text-success border border-success/20",
+  BUG: "bg-destructive/10 text-destructive border border-destructive/20",
+  SPIKE: "bg-purple/10 text-purple border border-purple/20",
 };
+
+const TYPE_INACTIVE_CLASS =
+  "bg-surface text-muted-foreground border border-border/40 hover:text-foreground hover:bg-surface-2";
+
+const TYPE_ALL_ACTIVE_CLASS =
+  "bg-primary/10 text-primary border border-primary/20";
 
 export const WorkItemsClient = () => {
   const workspaceId = useWorkspaceId();
   const projectId = useProjectId();
   const router = useRouter();
   const { open: openCreateModal } = useCreateTaskModal();
-  const { mutate: bulkUpdate } = useBulkUpdateTasks();
+  const { mutate: bulkUpdate, isPending: isBulkUpdating } = useBulkUpdateTasks();
 
   const [typeParam, setTypeParam] = useQueryState("type");
   const activeType: IssueType | null =
@@ -69,9 +70,7 @@ export const WorkItemsClient = () => {
   const [view, setView] = useQueryState("view", { defaultValue: "table" });
 
   const { data: sprintsData } = useGetSprints({ workspaceId, projectId });
-  const activeSprint = sprintsData?.documents?.find(
-    (s) => s.status === "ACTIVE"
-  );
+  const activeSprint = sprintsData?.documents?.find((s) => s.status === "ACTIVE");
 
   const { data: tasksData, isLoading } = useGetTasks({
     workspaceId,
@@ -88,32 +87,29 @@ export const WorkItemsClient = () => {
     [bulkUpdate]
   );
 
-  const activeSprint_display = activeSprint
-    ? `${activeSprint.name} · active`
-    : null;
+  const activeSprint_display = activeSprint ? `${activeSprint.name} · active` : null;
 
   let contentArea: React.ReactNode;
   if (isLoading) {
     contentArea = (
       <div className="flex items-center justify-center h-64">
-        <Loader className="size-5 animate-spin" style={{ color: "rgba(255,255,255,0.3)" }} />
+        <Loader className="size-5 animate-spin text-muted-foreground" />
       </div>
     );
   } else if (tasks.length === 0) {
     contentArea = (
       <div className="flex flex-col items-center justify-center h-64 gap-3">
-        <Layers className="size-8" style={{ color: "rgba(255,255,255,0.15)" }} />
+        <Layers className="size-8 text-muted-foreground/30" />
         <div className="text-center">
-          <p className="text-sm font-medium text-white">No work items yet</p>
-          <p className="text-[13px] mt-1" style={{ color: "rgba(255,255,255,0.35)" }}>
+          <p className="text-sm font-medium text-foreground">No work items yet</p>
+          <p className="text-[13px] mt-1 text-muted-foreground">
             Create your first work item to get started
           </p>
         </div>
         <button
           type="button"
           onClick={() => openCreateModal({ projectId })}
-          className="flex items-center gap-2 px-4 py-2 text-sm rounded-btn transition-all"
-          style={{ background: "rgba(79,124,255,0.12)", color: PRIMARY, border: "1px solid rgba(79,124,255,0.2)" }}
+          className="flex items-center gap-2 px-4 py-2 text-sm rounded-btn bg-primary/10 text-primary border border-primary/20 hover:bg-primary/20 transition-all"
         >
           <Plus className="size-4" />
           Create Work Item
@@ -123,7 +119,7 @@ export const WorkItemsClient = () => {
   } else if (view === "kanban") {
     contentArea = (
       <div className="p-4">
-        <DataKanban data={tasks} onChange={onKanbanChange} />
+        <DataKanban data={tasks} onChange={onKanbanChange} isPending={isBulkUpdating} />
       </div>
     );
   } else {
@@ -145,17 +141,14 @@ export const WorkItemsClient = () => {
       {/* ── Page header ── */}
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-bold tracking-tight text-white">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">
             Work Items
           </h1>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.45)" }}>
+          <p className="text-sm text-muted-foreground">
             Manage stories, bugs, spikes and tasks
             {activeSprint_display && (
-              <span
-                className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium"
-                style={{ background: "rgba(34,197,94,0.1)", color: SUCCESS, border: "1px solid rgba(34,197,94,0.2)" }}
-              >
-                <span className="size-1.5 rounded-full inline-block" style={{ background: SUCCESS }} />
+              <span className="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-success/10 text-success border border-success/20">
+                <span className="size-1.5 rounded-full inline-block bg-success" />
                 {activeSprint_display}
               </span>
             )}
@@ -165,14 +158,7 @@ export const WorkItemsClient = () => {
         <button
           type="button"
           onClick={() => openCreateModal({ projectId })}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all duration-150"
-          style={{
-            background: PRIMARY,
-            color: "#FFFFFF",
-            boxShadow: "0 0 0 1px rgba(79,124,255,0.3), 0 4px 12px rgba(79,124,255,0.25)",
-          }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = "#3d6ae8"; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = PRIMARY; }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary text-white hover:bg-primary/90 transition-all duration-150 shadow-glow-primary"
         >
           <Plus className="size-4" />
           New Work Item
@@ -185,27 +171,20 @@ export const WorkItemsClient = () => {
         <div className="flex items-center gap-1.5">
           {TYPE_FILTERS.map(({ label, value, icon: Icon }) => {
             const isActive = activeType === value;
-            const color = value ? TYPE_COLORS[value] : null;
+            const activeClass =
+              value === null
+                ? TYPE_ALL_ACTIVE_CLASS
+                : TYPE_ACTIVE_CLASS[value] ?? TYPE_ALL_ACTIVE_CLASS;
 
             return (
               <button
                 key={label}
                 type="button"
                 onClick={() => setTypeParam(value)}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-btn text-sm font-medium transition-all duration-150"
-                style={
-                  isActive
-                    ? {
-                        background: color?.bg ?? "rgba(79,124,255,0.12)",
-                        color: color?.text ?? PRIMARY,
-                        border: `1px solid ${color?.text ? color.text + "30" : "rgba(79,124,255,0.3)"}`,
-                      }
-                    : {
-                        background: BG_HOVER,
-                        color: "rgba(255,255,255,0.5)",
-                        border: "1px solid rgba(255,255,255,0.06)",
-                      }
-                }
+                className={cn(
+                  "flex items-center gap-1.5 px-3 py-1.5 rounded-btn text-sm font-medium transition-all duration-150",
+                  isActive ? activeClass : TYPE_INACTIVE_CLASS
+                )}
               >
                 <Icon className="size-3.5" />
                 {label}
@@ -215,21 +194,18 @@ export const WorkItemsClient = () => {
         </div>
 
         {/* View toggle */}
-        <div
-          className="flex items-center p-1 rounded-btn gap-0.5"
-          style={{ background: BG_HOVER, border: `1px solid ${BORDER_SUBTLE}` }}
-        >
+        <div className="flex items-center p-1 rounded-btn gap-0.5 bg-surface border border-border/40">
           {VIEWS.map(({ label, value, icon: Icon }) => (
             <button
               key={value}
               type="button"
               onClick={() => setView(value)}
-              className="flex items-center gap-1.5 px-3 py-1 text-sm rounded transition-all duration-150"
-              style={
+              className={cn(
+                "flex items-center gap-1.5 px-3 py-1 text-sm rounded transition-all duration-150",
                 view === value
-                  ? { background: "rgba(255,255,255,0.08)", color: "#FFFFFF" }
-                  : { color: "rgba(255,255,255,0.4)" }
-              }
+                  ? "bg-surface-2 text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
+              )}
             >
               <Icon className="size-3.5" />
               {label}
@@ -239,14 +215,7 @@ export const WorkItemsClient = () => {
       </div>
 
       {/* ── Content ── */}
-      <div
-        className="rounded-card overflow-hidden"
-        style={{
-          background: "#0F172A",
-          border: `1px solid ${BORDER_SUBTLE}`,
-          boxShadow: `0 0 0 1px ${BG_HOVER}, 0 8px 30px rgba(0,0,0,0.25)`,
-        }}
-      >
+      <div className="rounded-card overflow-hidden bg-surface border border-border/40 shadow-chronicle-sm">
         {contentArea}
       </div>
     </div>

--- a/src/app/(dashboard)/workspace/[workspaceId]/projects/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/projects/client.tsx
@@ -10,9 +10,7 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { Plus, FolderKanban, Loader } from "lucide-react";
 import { MemberAvatar } from "@/features/members/components/member-avatar";
-
-const SURFACE = "#0F172A";
-const PRIMARY = "#4F7CFF";
+import { cn } from "@/lib/utils";
 
 export const ProjectsClient = () => {
   const workspaceId = useWorkspaceId();
@@ -35,32 +33,25 @@ export const ProjectsClient = () => {
   if (isLoading) {
     gridContent = (
       <div className="flex items-center justify-center h-64">
-        <Loader className="size-5 animate-spin" style={{ color: "rgba(255,255,255,0.3)" }} />
+        <Loader className="size-5 animate-spin text-muted-foreground/60" />
       </div>
     );
   } else if (projects.length === 0) {
     gridContent = (
-      <div
-        className="flex flex-col items-center justify-center gap-5 py-20 rounded-card"
-        style={{ background: SURFACE, border: "1px dashed rgba(255,255,255,0.1)" }}
-      >
-        <div
-          className="flex items-center justify-center size-16 rounded-2xl"
-          style={{ background: "rgba(79,124,255,0.08)", border: "1px solid rgba(79,124,255,0.15)" }}
-        >
-          <FolderKanban className="size-7" style={{ color: PRIMARY }} />
+      <div className="flex flex-col items-center justify-center gap-5 py-20 rounded-card bg-surface border border-dashed border-border/40">
+        <div className="flex items-center justify-center size-16 rounded-2xl bg-primary/10 border border-primary/20">
+          <FolderKanban className="size-7 text-primary" />
         </div>
         <div className="text-center flex flex-col gap-2">
-          <h2 className="text-xl font-bold text-white">No projects yet</h2>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>
+          <h2 className="text-xl font-bold text-foreground">No projects yet</h2>
+          <p className="text-sm text-muted-foreground">
             Create your first project to organize your team&apos;s work
           </p>
         </div>
         <button
           type="button"
           onClick={open}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn"
-          style={{ background: "rgba(79,124,255,0.12)", color: PRIMARY, border: "1px solid rgba(79,124,255,0.25)" }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary/10 text-primary border border-primary/20"
         >
           <Plus className="size-4" />
           Create Project
@@ -87,14 +78,7 @@ export const ProjectsClient = () => {
                 href={`/workspace/${workspaceId}/project/${project.$id}`}
                 className="block h-full"
               >
-                <div
-                  className="project-card flex flex-col gap-4 p-5 h-full rounded-card transition-all duration-200"
-                  style={{
-                    background: SURFACE,
-                    border: "1px solid rgba(255,255,255,0.06)",
-                    boxShadow: "0 0 0 1px rgba(255,255,255,0.03)",
-                  }}
-                >
+                <div className="project-card flex flex-col gap-4 p-5 h-full rounded-card transition-all duration-200 bg-surface border border-border/40">
                   {/* Avatar + name */}
                   <div className="flex items-center gap-3">
                     <ProjectAvatar
@@ -103,8 +87,8 @@ export const ProjectsClient = () => {
                       className="size-10 rounded-md text-base"
                     />
                     <div className="flex flex-col gap-0.5 min-w-0">
-                      <p className="font-semibold text-white truncate">{project.name}</p>
-                      <p className="text-[12px]" style={{ color: "rgba(255,255,255,0.35)" }}>
+                      <p className="font-semibold text-foreground truncate">{project.name}</p>
+                      <p className="text-[12px] text-muted-foreground/70">
                         {openCount} open item{openCount === 1 ? "" : "s"}
                       </p>
                     </div>
@@ -118,18 +102,11 @@ export const ProjectsClient = () => {
                         <MemberAvatar
                           key={m.$id}
                           name={m.name ?? "M"}
-                          className="size-6 text-[10px] ring-2 ring-[#0F172A]"
+                          className="size-6 text-[10px] ring-2 ring-surface"
                         />
                       ))}
                       {members.length > 4 && (
-                        <div
-                          className="flex items-center justify-center size-6 rounded-full text-[10px] font-medium ring-2"
-                          style={{
-                            background: "rgba(255,255,255,0.08)",
-                            color: "rgba(255,255,255,0.5)",
-                            ringColor: SURFACE,
-                          } as React.CSSProperties}
-                        >
+                        <div className="flex items-center justify-center size-6 rounded-full text-[10px] font-medium ring-2 ring-surface bg-surface-2 text-muted-foreground">
                           +{members.length - 4}
                         </div>
                       )}
@@ -137,11 +114,12 @@ export const ProjectsClient = () => {
 
                     {/* Open items badge */}
                     <span
-                      className="text-[12px] px-2.5 py-1 rounded-full font-medium"
-                      style={{
-                        background: openCount > 0 ? "rgba(79,124,255,0.1)" : "rgba(255,255,255,0.05)",
-                        color: openCount > 0 ? PRIMARY : "rgba(255,255,255,0.3)",
-                      }}
+                      className={cn(
+                        "text-[12px] px-2.5 py-1 rounded-full font-medium",
+                        openCount > 0
+                          ? "bg-primary/10 text-primary"
+                          : "bg-surface-2 text-muted-foreground/60"
+                      )}
                     >
                       {openCount} open
                     </span>
@@ -160,22 +138,15 @@ export const ProjectsClient = () => {
       {/* ── Header ── */}
       <div className="flex items-start justify-between">
         <div className="flex flex-col gap-1">
-          <h1 className="text-2xl font-bold tracking-tight text-white">Projects</h1>
-          <p className="text-sm" style={{ color: "rgba(255,255,255,0.45)" }}>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">Projects</h1>
+          <p className="text-sm text-muted-foreground">
             {projects.length} project{projects.length === 1 ? "" : "s"} in your workspace
           </p>
         </div>
         <button
           type="button"
           onClick={open}
-          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all duration-150"
-          style={{
-            background: PRIMARY,
-            color: "#FFFFFF",
-            boxShadow: "0 0 0 1px rgba(79,124,255,0.3), 0 4px 12px rgba(79,124,255,0.25)",
-          }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = "#3d6ae8"; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = PRIMARY; }}
+          className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all duration-150 bg-primary text-white hover:bg-primary/90 shadow-glow-primary"
         >
           <Plus className="size-4" />
           New Project

--- a/src/app/(standalone)/settings/client.tsx
+++ b/src/app/(standalone)/settings/client.tsx
@@ -1,24 +1,22 @@
 "use client";
 
 import { useState } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { DottedSeperator } from "@/components/dotted-seperator";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Switch } from "@/components/ui/switch";
+import { SettingsLayout, SettingsCard } from "@/components/settings-components";
 import {
-	Trash2,
-	Plus,
-	Key,
-	AlertCircle,
-	Bell,
-	User,
-	Palette,
-	Shield,
-	ArrowLeft,
+  Trash2,
+  Plus,
+  Key,
+  AlertCircle,
+  Bell,
+  User,
+  Palette,
+  Shield,
 } from "lucide-react";
 import { useGenerateToken } from "@/features/tokens/api/use-generate-token";
 import { useGetUserTokens, Token } from "@/features/tokens/api/use-user-tokens";
@@ -26,299 +24,260 @@ import { useRevokeToken } from "@/features/tokens/api/use-user-tokens";
 import { useTheme } from "next-themes";
 import { formatDistanceToNow } from "date-fns";
 import { cn } from "@/lib/utils";
-import { useRouter } from "next/navigation";
 
 interface SettingsClientProps {
-	user: {
-		$id: string;
-		name: string | null;
-		email: string;
-		photoUrl: string;
-	};
+  user: {
+    $id: string;
+    name: string | null;
+    email: string;
+    photoUrl: string;
+  };
 }
 
+const ACCOUNT_TABS = [
+  { value: "profile",       icon: User,    label: "Profile" },
+  { value: "appearance",    icon: Palette, label: "Appearance" },
+  { value: "security",      icon: Shield,  label: "Security" },
+  { value: "notifications", icon: Bell,    label: "Notifications" },
+] as const;
+
 export const SettingsClient = ({ user }: SettingsClientProps) => {
-	const router = useRouter();
-	const { theme, resolvedTheme, setTheme } = useTheme();
-	const [displayName, setDisplayName] = useState(user.name || "");
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const [displayName, setDisplayName] = useState(user.name || "");
 
-	const { data: tokens, isLoading: tokensLoading, isError: tokensError, error: tokensErrorObj } = useGetUserTokens();
-	const { mutate: generateToken, isPending: isGenerating } = useGenerateToken();
-	const { mutate: revokeToken, isPending: isRevoking } = useRevokeToken();
+  const { data: tokens, isLoading: tokensLoading, isError: tokensError, error: tokensErrorObj } = useGetUserTokens();
+  const { mutate: generateToken, isPending: isGenerating } = useGenerateToken();
+  const { mutate: revokeToken, isPending: isRevoking } = useRevokeToken();
 
-	const avatarFallback =
-		(user.name?.charAt(0) || user.email?.charAt(0) || "U").toUpperCase();
+  const avatarFallback = (user.name?.charAt(0) || user.email?.charAt(0) || "U").toUpperCase();
 
-	return (
-		<div className="w-full lg:max-w-xl">
-			<Card className="w-full h-full border-none shadow-none">
-				<CardHeader className="flex flex-row items-center gap-x-4 p-7 space-y-0">
-					<Button
-						size="sm"
-						variant="secondary"
-						onClick={() => router.back()}
-					>
-						<ArrowLeft className="size-4 mr-2" />
-						Back
-					</Button>
-					<div>
-						<CardTitle className="text-xl font-bold">Settings</CardTitle>
-						<p className="text-sm text-muted-foreground mt-0.5">
-							Manage your account preferences
-						</p>
-					</div>
-				</CardHeader>
+  return (
+    <SettingsLayout title="Account Settings" description="Manage your profile, appearance, and security preferences">
+      <Tabs defaultValue="profile">
+        <TabsList className="flex items-center gap-1 p-1 rounded-xl w-fit bg-surface border border-border/40 mb-6">
+          {ACCOUNT_TABS.map(({ value, icon: Icon, label }) => (
+            <TabsTrigger
+              key={value}
+              value={value}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg transition-all data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground data-[state=active]:bg-surface-2 data-[state=inactive]:bg-transparent border-none shadow-none"
+            >
+              <Icon className="size-3.5" />
+              {label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
 
-				<DottedSeperator />
+        {/* ── Profile ── */}
+        <TabsContent value="profile" className="mt-0">
+          <SettingsCard title="Profile" description="Update your display name and avatar">
+            <div className="space-y-6">
+              <div className="flex items-center gap-4">
+                <Avatar className="size-16 border border-border">
+                  <AvatarImage src={user.photoUrl} alt={user.name || user.email} />
+                  <AvatarFallback className="text-xl font-semibold text-muted-foreground bg-muted">
+                    {avatarFallback}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="font-semibold text-foreground">{user.name || "User"}</p>
+                  <p className="text-xs text-muted-foreground">{user.email}</p>
+                </div>
+              </div>
 
-				<CardContent className="p-7">
-					<Tabs defaultValue="profile" className="w-full">
-						<TabsList className="w-full mb-4">
-							<TabsTrigger value="profile" className="flex-1 gap-1.5">
-								<User className="size-3.5" />
-								Profile
-							</TabsTrigger>
-							<TabsTrigger value="appearance" className="flex-1 gap-1.5">
-								<Palette className="size-3.5" />
-								Appearance
-							</TabsTrigger>
-							<TabsTrigger value="security" className="flex-1 gap-1.5">
-								<Shield className="size-3.5" />
-								Security
-							</TabsTrigger>
-							<TabsTrigger value="notifications" className="flex-1 gap-1.5">
-								<Bell className="size-3.5" />
-								Notifications
-							</TabsTrigger>
-						</TabsList>
+              <div className="h-px bg-border/40" />
 
-						{/* ── Profile ──────────────────────────────────────────── */}
-						<TabsContent value="profile" className="mt-0">
-							<div className="space-y-4 pt-2">
-								<div className="flex items-center gap-4">
-									<Avatar className="size-14">
-										<AvatarImage src={user.photoUrl} alt={user.name || user.email} />
-										<AvatarFallback className="text-lg font-semibold">
-											{avatarFallback}
-										</AvatarFallback>
-									</Avatar>
-									<div>
-										<p className="font-semibold text-sm">{user.name || "User"}</p>
-										<p className="text-xs text-muted-foreground">{user.email}</p>
-									</div>
-								</div>
-								<DottedSeperator />
-								<div className="space-y-3">
-									<div className="space-y-1.5">
-										<Label htmlFor="displayName">Display Name</Label>
-										<Input
-											id="displayName"
-											value={displayName}
-											onChange={(e) => setDisplayName(e.target.value)}
-											placeholder="Your display name"
-										/>
-									</div>
-									<div className="space-y-1.5">
-										<Label>Email</Label>
-										<Input value={user.email} disabled />
-										<p className="text-xs text-muted-foreground">
-											Email cannot be changed
-										</p>
-									</div>
-								</div>
-								<DottedSeperator />
-								<div className="space-y-1">
-									<Button
-										disabled
-										variant="primary"
-										size="sm"
-									>
-										Save Changes
-									</Button>
-									<p className="text-xs text-muted-foreground">Profile editing coming soon</p>
-								</div>
-							</div>
-						</TabsContent>
+              <div className="space-y-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="displayName">Display Name</Label>
+                  <Input
+                    id="displayName"
+                    value={displayName}
+                    onChange={(e) => setDisplayName(e.target.value)}
+                    placeholder="Your display name"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Email</Label>
+                  <Input value={user.email} disabled />
+                  <p className="text-xs text-muted-foreground">Email cannot be changed</p>
+                </div>
+              </div>
 
-						{/* ── Appearance ───────────────────────────────────────── */}
-						<TabsContent value="appearance" className="mt-0">
-							<div className="space-y-4 pt-2">
-								<div className="flex items-center justify-between">
-									<div>
-										<p className="font-medium text-sm">Dark Mode</p>
-										<p className="text-xs text-muted-foreground">
-											Switch between light and dark themes
-										</p>
-									</div>
-									<Switch
-										checked={resolvedTheme === "dark"}
-										onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
-									/>
-								</div>
-								<DottedSeperator />
-								<div className="space-y-2">
-									<p className="font-medium text-sm">Theme</p>
-									<div className="flex gap-2">
-										{["light", "dark", "system"].map((t) => (
-											<Button
-												key={t}
-												variant={theme === t ? "secondary" : "outline"}
-												size="sm"
-												onClick={() => setTheme(t)}
-											>
-												{t.charAt(0).toUpperCase() + t.slice(1)}
-											</Button>
-										))}
-									</div>
-								</div>
-							</div>
-						</TabsContent>
+              <div className="h-px bg-border/40" />
 
-						{/* ── Security ─────────────────────────────────────────── */}
-						<TabsContent value="security" className="mt-0">
-							<div className="space-y-4 pt-2">
-								<div className="flex items-center justify-between">
-									<div>
-										<p className="font-medium text-sm">Personal Access Tokens</p>
-										<p className="text-xs text-muted-foreground">
-											Used for API access. Max 5 active tokens.
-										</p>
-									</div>
-									<Button
-										size="sm"
-										variant="outline"
-										onClick={() => generateToken()}
-										disabled={isGenerating || !!((tokens?.filter((t: Token) => !t.isExpired) ?? []).length >= 5)}
-									>
-										<Plus className="size-3.5 mr-1" />
-										Generate
-									</Button>
-								</div>
-								<DottedSeperator />
-								{tokensLoading ? (
-									<p className="text-sm text-muted-foreground">Loading...</p>
-								) : tokensError ? (
-									<div className="flex flex-col items-center justify-center py-8 border border-dashed rounded-lg">
-										<AlertCircle className="size-8 text-destructive mb-2" />
-										<p className="text-sm text-destructive">
-											{tokensErrorObj?.message || "Failed to load tokens"}
-										</p>
-										<Button
-											size="sm"
-											variant="ghost"
-											onClick={() => location.reload()}
-											className="mt-2"
-										>
-											Retry
-										</Button>
-									</div>
-								) : !(tokens ?? []).length ? (
-									<div className="flex flex-col items-center justify-center py-8 border border-dashed rounded-lg">
-										<Key className="size-8 text-muted-foreground mb-2" />
-										<p className="text-sm text-muted-foreground">No active tokens</p>
-										<Button
-											size="sm"
-											variant="ghost"
-											onClick={() => generateToken()}
-											disabled={isGenerating}
-											className="mt-2"
-										>
-											Generate your first token
-										</Button>
-									</div>
-								) : (
-									<div className="space-y-2">
-										{(tokens ?? []).map((token: Token) => (
-											<div
-												key={token.$id}
-												className="flex items-center justify-between p-3 border rounded-lg"
-											>
-												<div className="flex items-center gap-3">
-													<Key className="size-4 text-muted-foreground shrink-0" />
-													<div>
-														<p className="text-sm font-medium">{token.name}</p>
-														<p className="text-xs text-muted-foreground">
-															Created{" "}
-															{token.$createdAt
-																? formatDistanceToNow(new Date(token.$createdAt), { addSuffix: true })
-																: "recently"}
-															{token.expiresAt && (
-																<span className={cn(
-																	"ml-2",
-																	token.isExpired ? "text-destructive" : "text-emerald-500"
-																)}>
-																	· {token.isExpired ? "Expired" : "Expires"}{" "}
-																	{formatDistanceToNow(new Date(token.expiresAt), { addSuffix: true })}
-																</span>
-															)}
-														</p>
-													</div>
-												</div>
-												<Button
-													size="sm"
-													variant="ghost"
-													className="text-destructive hover:text-destructive"
-													disabled={isRevoking}
-													aria-label={`Revoke token ${token.name}`}
-													title="Revoke token"
-													onClick={() => revokeToken(token.$id)}
-												>
-													<Trash2 className="size-4" />
-												</Button>
-											</div>
-										))}
-									</div>
-								)}
-							</div>
-						</TabsContent>
+              <div className="space-y-1">
+                <Button disabled variant="primary" size="sm">
+                  Save Changes
+                </Button>
+                <p className="text-xs text-muted-foreground">Profile editing coming soon</p>
+              </div>
+            </div>
+          </SettingsCard>
+        </TabsContent>
 
-						{/* ── Notifications ─────────────────────────────────────── */}
-						<TabsContent value="notifications" className="mt-0">
-							<div className="space-y-4 pt-2">
-								<div className="flex items-center justify-between">
-									<div>
-										<p className="font-medium text-sm">Email Notifications</p>
-										<p className="text-xs text-muted-foreground">
-											Receive email updates about task assignments
-										</p>
-									</div>
-									<Switch defaultChecked disabled />
-								</div>
-								<DottedSeperator />
-								<div className="flex items-center justify-between">
-									<div>
-										<p className="font-medium text-sm">Mention Alerts</p>
-										<p className="text-xs text-muted-foreground">
-											Get notified when someone mentions you in a comment
-										</p>
-									</div>
-									<Switch defaultChecked disabled />
-								</div>
-								<DottedSeperator />
-								<div className="flex items-center justify-between">
-									<div>
-										<p className="font-medium text-sm">Sprint Updates</p>
-										<p className="text-xs text-muted-foreground">
-											Notifications for sprint start, end, and summary
-										</p>
-									</div>
-									<Switch defaultChecked disabled />
-								</div>
-								<DottedSeperator />
-								<div className="rounded-lg border border-dashed p-4">
-									<div className="flex items-center gap-2 mb-1">
-										<AlertCircle className="size-4 text-muted-foreground" />
-										<p className="text-sm font-medium">More options coming soon</p>
-									</div>
-									<p className="text-xs text-muted-foreground">
-										Per-project notification preferences and digest settings will be available in a future update.
-									</p>
-								</div>
-							</div>
-						</TabsContent>
-					</Tabs>
-				</CardContent>
-			</Card>
-		</div>
-	);
+        {/* ── Appearance ── */}
+        <TabsContent value="appearance" className="mt-0">
+          <SettingsCard title="Appearance" description="Customize how Chronicle looks for you">
+            <div className="space-y-6">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium text-foreground text-sm">Dark Mode</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Switch between light and dark themes
+                  </p>
+                </div>
+                <Switch
+                  checked={resolvedTheme === "dark"}
+                  onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+                />
+              </div>
+
+              <div className="h-px bg-border/40" />
+
+              <div className="space-y-2">
+                <p className="font-medium text-foreground text-sm">Theme</p>
+                <div className="flex gap-2">
+                  {["light", "dark", "system"].map((t) => (
+                    <Button
+                      key={t}
+                      variant={theme === t ? "secondary" : "outline"}
+                      size="sm"
+                      onClick={() => setTheme(t)}
+                    >
+                      {t.charAt(0).toUpperCase() + t.slice(1)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </SettingsCard>
+        </TabsContent>
+
+        {/* ── Security ── */}
+        <TabsContent value="security" className="mt-0">
+          <SettingsCard title="Personal Access Tokens" description="Used for API access. Max 5 active tokens.">
+            <div className="space-y-4">
+              <div className="flex justify-end">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => generateToken()}
+                  disabled={isGenerating || !!((tokens?.filter((t: Token) => !t.isExpired) ?? []).length >= 5)}
+                >
+                  <Plus className="size-3.5 mr-1.5" />
+                  Generate
+                </Button>
+              </div>
+
+              {tokensLoading ? (
+                <p className="text-sm text-muted-foreground">Loading...</p>
+              ) : tokensError ? (
+                <div className="flex flex-col items-center justify-center py-8 border border-dashed border-border/40 rounded-lg">
+                  <AlertCircle className="size-8 text-destructive mb-2" />
+                  <p className="text-sm text-destructive">
+                    {tokensErrorObj?.message || "Failed to load tokens"}
+                  </p>
+                  <Button size="sm" variant="ghost" onClick={() => location.reload()} className="mt-2">
+                    Retry
+                  </Button>
+                </div>
+              ) : !(tokens ?? []).length ? (
+                <div className="flex flex-col items-center justify-center py-8 border border-dashed border-border/40 rounded-lg">
+                  <Key className="size-8 text-muted-foreground mb-2" />
+                  <p className="text-sm text-muted-foreground">No active tokens</p>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => generateToken()}
+                    disabled={isGenerating}
+                    className="mt-2"
+                  >
+                    Generate your first token
+                  </Button>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  {(tokens ?? []).map((token: Token) => (
+                    <div
+                      key={token.$id}
+                      className="flex items-center justify-between p-3 border border-border/40 rounded-lg bg-surface"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Key className="size-4 text-muted-foreground shrink-0" />
+                        <div>
+                          <p className="text-sm font-medium text-foreground">{token.name}</p>
+                          <p className="text-xs text-muted-foreground">
+                            Created{" "}
+                            {token.$createdAt
+                              ? formatDistanceToNow(new Date(token.$createdAt), { addSuffix: true })
+                              : "recently"}
+                            {token.expiresAt && (
+                              <span className={cn(
+                                "ml-2",
+                                token.isExpired ? "text-destructive" : "text-success"
+                              )}>
+                                · {token.isExpired ? "Expired" : "Expires"}{" "}
+                                {formatDistanceToNow(new Date(token.expiresAt), { addSuffix: true })}
+                              </span>
+                            )}
+                          </p>
+                        </div>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        disabled={isRevoking}
+                        aria-label={`Revoke token ${token.name}`}
+                        title="Revoke token"
+                        onClick={() => revokeToken(token.$id)}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </SettingsCard>
+        </TabsContent>
+
+        {/* ── Notifications ── */}
+        <TabsContent value="notifications" className="mt-0">
+          <SettingsCard title="Notifications" description="Control what you get notified about">
+            <div className="space-y-6">
+              {[
+                { label: "Email Notifications",  desc: "Receive email updates about task assignments" },
+                { label: "Mention Alerts",        desc: "Get notified when someone mentions you in a comment" },
+                { label: "Sprint Updates",         desc: "Notifications for sprint start, end, and summary" },
+              ].map(({ label, desc }, i, arr) => (
+                <div key={label}>
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="font-medium text-foreground text-sm">{label}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">{desc}</p>
+                    </div>
+                    <Switch defaultChecked disabled />
+                  </div>
+                  {i < arr.length - 1 && <div className="h-px bg-border/40 mt-6" />}
+                </div>
+              ))}
+
+              <div className="h-px bg-border/40" />
+
+              <div className="rounded-lg border border-dashed border-border/40 p-4 bg-surface">
+                <div className="flex items-center gap-2 mb-1">
+                  <AlertCircle className="size-4 text-muted-foreground" />
+                  <p className="text-sm font-medium text-foreground">More options coming soon</p>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  Per-project notification preferences and digest settings will be available in a future update.
+                </p>
+              </div>
+            </div>
+          </SettingsCard>
+        </TabsContent>
+      </Tabs>
+    </SettingsLayout>
+  );
 };

--- a/src/app/(standalone)/workspace/[workspaceId]/project/[projectId]/settings/client.tsx
+++ b/src/app/(standalone)/workspace/[workspaceId]/project/[projectId]/settings/client.tsx
@@ -85,18 +85,15 @@ export const ProjectIdSettingsClient = () => {
         <SettingsCard danger>
           <div className="flex items-center gap-2 mb-1">
             <TriangleAlert className="size-4 text-red-400" />
-            <h2 className="text-[15px] font-semibold text-white">Danger Zone</h2>
+            <h2 className="text-[15px] font-semibold text-foreground">Danger Zone</h2>
           </div>
-          <p className="text-[13px] mb-6" style={{ color: "rgba(255,255,255,0.4)" }}>
+          <p className="text-[13px] mb-6 text-muted-foreground">
             Irreversible actions that affect this project.
           </p>
-          <div
-            className="flex items-center justify-between p-4 rounded-xl"
-            style={{ background: "rgba(239,68,68,0.05)", border: "1px solid rgba(239,68,68,0.15)" }}
-          >
+          <div className="flex items-center justify-between p-4 rounded-xl bg-destructive/10 border border-destructive/20">
             <div>
-              <p className="text-[14px] font-medium text-white">Delete Project</p>
-              <p className="text-[13px] mt-0.5" style={{ color: "rgba(255,255,255,0.4)" }}>
+              <p className="text-[14px] font-medium text-foreground">Delete Project</p>
+              <p className="text-[13px] mt-0.5 text-muted-foreground">
                 Permanently deletes this project and all associated work items.
               </p>
             </div>
@@ -104,8 +101,7 @@ export const ProjectIdSettingsClient = () => {
               type="button"
               disabled={isDeleting || !isAdmin}
               onClick={handleDelete}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-50 shrink-0 ml-4"
-              style={{ background: "#EF4444", color: "#fff", boxShadow: "0 0 0 1px rgba(239,68,68,0.3), 0 4px 12px rgba(239,68,68,0.25)" }}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-50 shrink-0 ml-4 bg-destructive text-white hover:bg-destructive/90 shadow-glow-destructive"
             >
               <Trash2 className="size-3.5" />
               {isDeleting ? "Deleting…" : "Delete Project"}

--- a/src/app/(standalone)/workspace/[workspaceId]/settings/client.tsx
+++ b/src/app/(standalone)/workspace/[workspaceId]/settings/client.tsx
@@ -21,10 +21,6 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { ImageIcon, Copy, RefreshCw, Trash2, Save, Check, TriangleAlert } from "lucide-react";
 
-const BORDER = "1px solid rgba(255,255,255,0.08)";
-const BG_HOVER = "rgba(255,255,255,0.04)";
-const DANGER = "#EF4444";
-const TEXT_DIM = "rgba(255,255,255,0.4)";
 const SIZE_SM = "size-3.5";
 const BTN = "button";
 
@@ -151,17 +147,14 @@ export const WorkspaceIdSettingsClient = () => {
                 name="name"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="text-[12px] font-semibold uppercase tracking-widest" style={{ color: "rgba(255,255,255,0.35)" }}>
+                    <FormLabel className="text-[12px] font-semibold uppercase tracking-widest text-muted-foreground/70">
                       Workspace Name
                     </FormLabel>
                     <FormControl>
                       <input
                         {...field}
                         placeholder="Enter workspace name"
-                        className="w-full px-3 py-2.5 rounded-lg text-sm text-white outline-none transition-all"
-                        style={{ background: BG_HOVER, border: BORDER }}
-                        onFocus={e => { (e.currentTarget as HTMLInputElement).style.border = "1px solid rgba(79,124,255,0.4)"; }}
-                        onBlur={e => { (e.currentTarget as HTMLInputElement).style.border = BORDER; }}
+                        className="w-full px-3 py-2.5 rounded-lg text-sm text-foreground outline-none transition-all bg-surface-2 border border-border/40 focus:border-primary/40"
                       />
                     </FormControl>
                     <FormMessage className="text-red-400 text-xs mt-1" />
@@ -174,7 +167,7 @@ export const WorkspaceIdSettingsClient = () => {
                 name="imageUrl"
                 render={({ field }) => (
                   <div className="flex flex-col gap-2">
-                    <span className="text-[12px] font-semibold uppercase tracking-widest" style={{ color: "rgba(255,255,255,0.35)" }}>
+                    <span className="text-[12px] font-semibold uppercase tracking-widest text-muted-foreground/70">
                       Workspace Icon
                     </span>
                     <div className="flex items-center gap-4">
@@ -188,15 +181,12 @@ export const WorkspaceIdSettingsClient = () => {
                           />
                         </div>
                       ) : (
-                        <div
-                          className="flex items-center justify-center size-16 rounded-xl"
-                          style={{ background: BG_HOVER, border: "1px dashed rgba(255,255,255,0.12)" }}
-                        >
-                          <ImageIcon className="size-6" style={{ color: "rgba(255,255,255,0.2)" }} />
+                        <div className="flex items-center justify-center size-16 rounded-xl bg-surface-2 border border-dashed border-border/40">
+                          <ImageIcon className="size-6 text-muted-foreground/60" />
                         </div>
                       )}
                       <div className="flex flex-col gap-1.5">
-                        <p className="text-[13px] text-white/60">JPG, PNG, SVG or JPEG, max 1MB</p>
+                        <p className="text-[13px] text-muted-foreground/60">JPG, PNG, SVG or JPEG, max 1MB</p>
                         <input
                           className="hidden"
                           type="file"
@@ -210,8 +200,7 @@ export const WorkspaceIdSettingsClient = () => {
                             type={BTN}
                             disabled={isUpdating}
                             onClick={() => inputRef.current?.click()}
-                            className="px-3 py-1.5 text-[12px] font-medium rounded-lg transition-all"
-                            style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.6)", border: BORDER }}
+                            className="px-3 py-1.5 text-[12px] font-medium rounded-lg transition-all bg-surface-2 text-muted-foreground border border-border/40"
                           >
                             Upload Image
                           </button>
@@ -220,8 +209,7 @@ export const WorkspaceIdSettingsClient = () => {
                               type={BTN}
                               disabled={isUpdating}
                               onClick={() => { field.onChange(null); if (inputRef.current) inputRef.current.value = ""; }}
-                              className="px-3 py-1.5 text-[12px] font-medium rounded-lg transition-all"
-                              style={{ background: "rgba(239,68,68,0.1)", color: DANGER, border: "1px solid rgba(239,68,68,0.2)" }}
+                              className="px-3 py-1.5 text-[12px] font-medium rounded-lg transition-all bg-destructive/10 text-destructive border border-destructive/20"
                             >
                               Remove
                             </button>
@@ -237,8 +225,7 @@ export const WorkspaceIdSettingsClient = () => {
                 <button
                   type="submit"
                   disabled={isUpdating}
-                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-50"
-                  style={{ background: "#4F7CFF", color: "#fff", boxShadow: "0 0 0 1px rgba(79,124,255,0.3), 0 4px 12px rgba(79,124,255,0.25)" }}
+                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-50 bg-primary text-white hover:bg-primary/90 shadow-glow-primary"
                 >
                   <Save className={SIZE_SM} />
                   {isUpdating ? "Saving…" : "Save Changes"}
@@ -252,30 +239,26 @@ export const WorkspaceIdSettingsClient = () => {
       <TabsContent value="members" className="mt-6">
         <SettingsCard title="Invite Members" description="Share this link to invite people to your workspace.">
           <div className="flex items-center gap-2">
-            <div
-              className="flex-1 flex items-center px-3 py-2.5 rounded-lg overflow-hidden"
-              style={{ background: BG_HOVER, border: BORDER }}
-            >
-              <span className="text-[13px] truncate" style={{ color: "rgba(255,255,255,0.5)" }}>
+            <div className="flex-1 flex items-center px-3 py-2.5 rounded-lg overflow-hidden bg-surface-2 border border-border/40">
+              <span className="text-[13px] truncate text-muted-foreground">
                 {fullInviteLink}
               </span>
             </div>
             <button
               type={BTN}
               onClick={handleCopyInviteLink}
-              className="flex items-center gap-1.5 px-3 py-2.5 text-[13px] font-medium rounded-lg shrink-0 transition-all"
-              style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.7)", border: BORDER }}
+              className="flex items-center gap-1.5 px-3 py-2.5 text-[13px] font-medium rounded-lg shrink-0 transition-all bg-surface-2 text-muted-foreground border border-border/40"
             >
               {copied ? <Check className={`${SIZE_SM} text-green-400`} /> : <Copy className={SIZE_SM} />}
               {copied ? "Copied!" : "Copy"}
             </button>
           </div>
 
-          <div className="mt-6 pt-5" style={{ borderTop: "1px solid rgba(255,255,255,0.06)" }}>
+          <div className="mt-6 pt-5 border-t border-border/40">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-[14px] font-medium text-white">Reset Invite Link</p>
-                <p className="text-[13px] mt-0.5" style={{ color: TEXT_DIM }}>
+                <p className="text-[14px] font-medium text-foreground">Reset Invite Link</p>
+                <p className="text-[13px] mt-0.5 text-muted-foreground">
                   Invalidates the current link and generates a new one.
                 </p>
               </div>
@@ -283,8 +266,7 @@ export const WorkspaceIdSettingsClient = () => {
                 type={BTN}
                 disabled={isResetting}
                 onClick={handleResetInviteCode}
-                className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium rounded-lg transition-all disabled:opacity-50"
-                style={{ background: "rgba(239,68,68,0.1)", color: DANGER, border: "1px solid rgba(239,68,68,0.2)" }}
+                className="flex items-center gap-2 px-3 py-2 text-[13px] font-medium rounded-lg transition-all disabled:opacity-50 bg-destructive/10 text-destructive border border-destructive/20"
               >
                 <RefreshCw className={SIZE_SM} />
                 Reset Link
@@ -304,18 +286,15 @@ export const WorkspaceIdSettingsClient = () => {
         <SettingsCard danger>
           <div className="flex items-center gap-2 mb-1">
             <TriangleAlert className="size-4 text-red-400" />
-            <h2 className="text-[15px] font-semibold text-white">Danger Zone</h2>
+            <h2 className="text-[15px] font-semibold text-foreground">Danger Zone</h2>
           </div>
-          <p className="text-[13px] mb-6" style={{ color: TEXT_DIM }}>
+          <p className="text-[13px] mb-6 text-muted-foreground">
             Irreversible actions that affect the entire workspace.
           </p>
-          <div
-            className="flex items-center justify-between p-4 rounded-xl"
-            style={{ background: "rgba(239,68,68,0.05)", border: "1px solid rgba(239,68,68,0.15)" }}
-          >
+          <div className="flex items-center justify-between p-4 rounded-xl bg-destructive/10 border border-destructive/20">
             <div>
-              <p className="text-[14px] font-medium text-white">Delete Workspace</p>
-              <p className="text-[13px] mt-0.5" style={{ color: TEXT_DIM }}>
+              <p className="text-[14px] font-medium text-foreground">Delete Workspace</p>
+              <p className="text-[13px] mt-0.5 text-muted-foreground">
                 Permanently deletes this workspace and all associated data.
               </p>
             </div>
@@ -323,8 +302,7 @@ export const WorkspaceIdSettingsClient = () => {
               type={BTN}
               disabled={isDeleting}
               onClick={handleDelete}
-              className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-50 shrink-0 ml-4"
-              style={{ background: DANGER, color: "#fff", boxShadow: "0 0 0 1px rgba(239,68,68,0.3), 0 4px 12px rgba(239,68,68,0.25)" }}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all disabled:opacity-50 shrink-0 ml-4 bg-destructive text-white hover:bg-destructive/90 shadow-glow-destructive"
             >
               <Trash2 className={SIZE_SM} />
               {isDeleting ? "Deleting…" : "Delete Workspace"}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,9 +9,41 @@
 }
 
 @layer base {
+  /* ── Shared base tokens (theme-neutral) ────────────────────────── */
   :root {
-    /* Chronicle design tokens — always dark */
+    --radius: 0.75rem;
+    --radius-card: 1.125rem;   /* 18px */
+    --radius-btn: 0.75rem;     /* 12px */
+    --radius-panel: 1.5rem;    /* 24px */
+
+    --primary: 224 100% 65%;          /* Chronicle blue — same in both themes */
+    --primary-foreground: 0 0% 100%;
+
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 0 0% 100%;
+
+    --success: 142 71% 45%;
+    --warning: 38 92% 50%;
+    --purple: 258 89% 66%;
+
+    --ring: 224 100% 65%;
+
+    /* Chart palette */
+    --chart-1: 224 100% 65%;
+    --chart-2: 142 71% 45%;
+    --chart-3: 38 92% 50%;
+    --chart-4: 258 89% 66%;
+    --chart-5: 0 84% 60%;
+
+    /* Logo */
+    --logo-start: 224 100% 72%;
+    --logo-end: 224 84% 56%;
+  }
+
+  /* ── Dark theme — deep navy ────────────────────────────────────── */
+  .dark {
     --background: 222 47% 5%;           /* #070B14 */
+    --panel: 222 40% 9%;                /* #0C1220 — slightly lifted from bg */
     --surface-1: 222 40% 12%;           /* #0F172A */
     --surface-2: 222 38% 14%;           /* #121C31 */
     --surface-elevated: 222 40% 17%;    /* #16233F */
@@ -25,9 +57,6 @@
     --popover: 222 40% 12%;
     --popover-foreground: 0 0% 100%;
 
-    --primary: 224 100% 65%;            /* #4F7CFF */
-    --primary-foreground: 0 0% 100%;
-
     --secondary: 222 38% 14%;
     --secondary-foreground: 0 0% 100%;
 
@@ -36,78 +65,49 @@
 
     --accent: 222 40% 17%;
     --accent-foreground: 0 0% 100%;
-
-    --destructive: 0 84% 60%;           /* #EF4444 */
-    --destructive-foreground: 0 0% 100%;
-
-    --success: 142 71% 45%;             /* #22C55E */
-    --warning: 38 92% 50%;              /* #F59E0B */
-    --purple: 258 89% 66%;              /* #8B5CF6 */
 
     --border: 222 40% 20%;
     --border-subtle: 0 0% 100% / 0.05;
     --input: 222 38% 14%;
-    --ring: 224 100% 65%;
-
-    --radius: 0.75rem;
-    --radius-card: 1.125rem;            /* 18px */
-    --radius-btn: 0.75rem;              /* 12px */
-    --radius-panel: 1.5rem;             /* 24px */
 
     --shadow-sm: 0 0 0 1px rgba(255,255,255,.04), 0 4px 16px rgba(0,0,0,.2);
     --shadow-md: 0 0 0 1px rgba(255,255,255,.04), 0 8px 30px rgba(0,0,0,.25);
     --shadow-lg: 0 0 0 1px rgba(255,255,255,.06), 0 16px 48px rgba(0,0,0,.35);
-
-    /* Logo colors */
-    --logo-start: 224 100% 72%;
-    --logo-end: 224 84% 56%;
-
-    /* Chart colors */
-    --chart-1: 224 100% 65%;
-    --chart-2: 142 71% 45%;
-    --chart-3: 38 92% 50%;
-    --chart-4: 258 89% 66%;
-    --chart-5: 0 84% 60%;
   }
 
-  /* Chronicle is dark-first: no separate .dark override needed.
-     We always render in "dark" mode via the html class. */
-  .dark {
-    --background: 222 47% 5%;
-    --surface-1: 222 40% 12%;
-    --surface-2: 222 38% 14%;
-    --surface-elevated: 222 40% 17%;
-    --foreground: 0 0% 100%;
-    --foreground-secondary: 215 20% 72%;
-    --foreground-muted: 215 15% 52%;
-    --card: 222 40% 12%;
-    --card-foreground: 0 0% 100%;
-    --popover: 222 40% 12%;
-    --popover-foreground: 0 0% 100%;
-    --primary: 224 100% 65%;
-    --primary-foreground: 0 0% 100%;
-    --secondary: 222 38% 14%;
-    --secondary-foreground: 0 0% 100%;
-    --muted: 222 38% 14%;
-    --muted-foreground: 215 15% 52%;
-    --accent: 222 40% 17%;
-    --accent-foreground: 0 0% 100%;
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 100%;
-    --border: 222 40% 20%;
-    --input: 222 38% 14%;
-    --ring: 224 100% 65%;
-    --success: 142 71% 45%;
-    --warning: 38 92% 50%;
-    --purple: 258 89% 66%;
-    --logo-start: 224 100% 72%;
-    --logo-end: 224 84% 56%;
-    --radius: 0.75rem;
-    --chart-1: 224 100% 65%;
-    --chart-2: 142 71% 45%;
-    --chart-3: 38 92% 50%;
-    --chart-4: 258 89% 66%;
-    --chart-5: 0 84% 60%;
+  /* ── Light theme — warm white ──────────────────────────────────── */
+  .light {
+    --background: 40 30% 98%;           /* warm white */
+    --panel: 220 20% 96%;               /* soft cool white */
+    --surface-1: 220 16% 94%;           /* light surface */
+    --surface-2: 220 14% 90%;           /* slightly deeper */
+    --surface-elevated: 220 13% 87%;    /* elevated card */
+
+    --foreground: 222 47% 11%;          /* deep navy text */
+    --foreground-secondary: 220 20% 38%;
+    --foreground-muted: 220 15% 52%;
+
+    --card: 220 16% 94%;
+    --card-foreground: 222 47% 11%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 47% 11%;
+
+    --secondary: 220 14% 90%;
+    --secondary-foreground: 222 47% 11%;
+
+    --muted: 220 14% 90%;
+    --muted-foreground: 220 15% 45%;
+
+    --accent: 220 13% 87%;
+    --accent-foreground: 222 47% 11%;
+
+    --border: 220 16% 82%;
+    --border-subtle: 0 0% 0% / 0.06;
+    --input: 220 16% 94%;
+
+    --shadow-sm: 0 0 0 1px rgba(0,0,0,.06), 0 4px 16px rgba(0,0,0,.06);
+    --shadow-md: 0 0 0 1px rgba(0,0,0,.06), 0 8px 30px rgba(0,0,0,.08);
+    --shadow-lg: 0 0 0 1px rgba(0,0,0,.06), 0 16px 48px rgba(0,0,0,.10);
   }
 }
 
@@ -121,13 +121,12 @@
 
   body {
     @apply bg-background text-foreground;
-
     font-feature-settings: "cv11", "ss01";
     -webkit-font-smoothing: antialiased;
   }
 }
 
-/* Scrollbar */
+/* ── Scrollbar utilities ───────────────────────────────────────────── */
 .hide-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -136,10 +135,9 @@
   display: none;
 }
 
-/* Thin scrollbar for main content */
 .thin-scrollbar {
   scrollbar-width: thin;
-  scrollbar-color: rgba(255,255,255,0.08) transparent;
+  scrollbar-color: hsl(var(--border)) transparent;
 }
 .thin-scrollbar::-webkit-scrollbar {
   width: 4px;
@@ -148,50 +146,48 @@
   background: transparent;
 }
 .thin-scrollbar::-webkit-scrollbar-thumb {
-  background: rgba(255,255,255,0.08);
+  background: hsl(var(--border));
   border-radius: 2px;
 }
 
-/* Glass surface utility */
+/* ── Glass surface ─────────────────────────────────────────────────── */
 .glass {
-  background: rgba(15, 23, 42, 0.8);
+  background: hsl(var(--panel) / 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }
 
-/* Chronicle sidebar nav item */
+/* ── Chronicle nav item ────────────────────────────────────────────── */
 .nav-item {
   @apply flex items-center gap-2.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150 cursor-pointer select-none;
-
-  color: rgba(255,255,255,0.55);
+  color: hsl(var(--muted-foreground));
 }
 .nav-item:hover {
-  background: #0e1520;
-  color: #d9d9d9;
+  background: hsl(var(--surface-1));
+  color: hsl(var(--foreground));
 }
 .nav-item.active {
-  background: #1f2d4e;
-  color: #fff;
-  border-left: 2px solid #4F7CFF;
+  background: hsl(var(--surface-2));
+  color: hsl(var(--foreground));
+  border-left: 2px solid hsl(var(--primary));
   padding-left: calc(0.75rem - 2px);
 }
 
-/* Project card hover (avoids JS mouse handlers) */
+/* ── Project card hover ────────────────────────────────────────────── */
 .project-card:hover {
-  border-color: rgba(79,124,255,0.3) !important;
-  box-shadow: 0 0 0 1px rgba(79,124,255,0.15), 0 8px 24px rgba(79,124,255,0.08) !important;
+  border-color: hsl(var(--primary) / 0.3) !important;
+  box-shadow: 0 0 0 1px hsl(var(--primary) / 0.15), 0 8px 24px hsl(var(--primary) / 0.08) !important;
 }
 
-/* Section label */
+/* ── Sidebar section label ─────────────────────────────────────────── */
 .sidebar-section-label {
   @apply px-3 text-[10px] font-semibold uppercase tracking-widest;
-
-  color: rgba(255,255,255,0.3);
+  color: hsl(var(--muted-foreground) / 0.6);
 }
 
-/* Command palette backdrop */
+/* ── Command palette backdrop ──────────────────────────────────────── */
 .palette-backdrop {
-  background: rgba(7, 11, 20, 0.7);
+  background: hsl(var(--background) / 0.7);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -160,6 +160,7 @@
 /* ── Chronicle nav item ────────────────────────────────────────────── */
 .nav-item {
   @apply flex items-center gap-2.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-all duration-150 cursor-pointer select-none;
+
   color: hsl(var(--muted-foreground));
 }
 .nav-item:hover {
@@ -182,6 +183,7 @@
 /* ── Sidebar section label ─────────────────────────────────────────── */
 .sidebar-section-label {
   @apply px-3 text-[10px] font-semibold uppercase tracking-widest;
+
   color: hsl(var(--muted-foreground) / 0.6);
 }
 

--- a/src/components/chronicle/dashboard-card.tsx
+++ b/src/components/chronicle/dashboard-card.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { ResponsiveContainer, AreaChart, Area } from "recharts";
+
+const TREND_ICON = { up: TrendingUp, down: TrendingDown, neutral: Minus } as const;
+const TREND_COLOR_CLASS = {
+  up: "text-success",
+  down: "text-destructive",
+  neutral: "text-muted-foreground",
+} as const;
+
+interface DashboardCardProps {
+  readonly title: string;
+  readonly value: string | number;
+  readonly subtitle: string;
+  readonly icon: React.ElementType;
+  readonly iconBgClass: string;
+  readonly iconColorClass: string;
+  readonly trend?: "up" | "down" | "neutral";
+  readonly trendLabel?: string;
+  readonly accentColor?: string;
+  readonly chart?: { day: string; count: number }[];
+}
+
+export function DashboardCard({
+  title,
+  value,
+  subtitle,
+  icon: Icon,
+  iconBgClass,
+  iconColorClass,
+  trend = "neutral",
+  trendLabel,
+  accentColor,
+  chart,
+}: DashboardCardProps) {
+  const TrendIcon = TREND_ICON[trend];
+  const trendColorClass = TREND_COLOR_CLASS[trend];
+  const hasChartData = chart && chart.some((d) => d.count > 0);
+
+  return (
+    <div className="relative flex flex-col justify-between p-5 rounded-card overflow-hidden bg-surface border border-border/40 shadow-chronicle-sm min-h-[140px] hover:bg-surface-2 transition-colors duration-150">
+      {/* Top row */}
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/60">
+            {title}
+          </span>
+          <span className="text-3xl font-bold text-foreground leading-none">
+            {value}
+          </span>
+          <span className="text-[13px] text-muted-foreground">
+            {subtitle}
+          </span>
+        </div>
+        <div className={`flex items-center justify-center size-10 rounded-xl shrink-0 ${iconBgClass}`}>
+          <Icon className={`size-5 ${iconColorClass}`} />
+        </div>
+      </div>
+
+      {/* Bottom: trend label + optional mini chart */}
+      <div className="flex items-end justify-between mt-3">
+        {trendLabel && (
+          <div className={`flex items-center gap-1.5 ${trendColorClass}`}>
+            <TrendIcon className="size-3.5" />
+            <span className="text-[12px]">{trendLabel}</span>
+          </div>
+        )}
+        {hasChartData && accentColor && (
+          <div className="w-full h-10 -mb-1">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart
+                data={chart}
+                margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+              >
+                <defs>
+                  <linearGradient id={`grad-${title.replace(/\s+/g, "-")}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={accentColor} stopOpacity={0.3} />
+                    <stop offset="100%" stopColor={accentColor} stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <Area
+                  type="monotone"
+                  dataKey="count"
+                  stroke={accentColor}
+                  strokeWidth={1.5}
+                  fill={`url(#grad-${title.replace(/\s+/g, "-")})`}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/chronicle/work-item-detail-layout.tsx
+++ b/src/components/chronicle/work-item-detail-layout.tsx
@@ -16,7 +16,7 @@ export function WorkItemDetailLayout({
   return (
     <div className="flex flex-col gap-y-4">
       {header}
-      <div className="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-6">
+      <div className={sidebar ? "grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-6" : "grid grid-cols-1 gap-6"}>
         <div className="flex flex-col gap-y-4">
           {metadata}
           {mainContent}

--- a/src/components/chronicle/work-item-detail-layout.tsx
+++ b/src/components/chronicle/work-item-detail-layout.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+interface WorkItemDetailLayoutProps {
+  header: React.ReactNode;
+  metadata: React.ReactNode;
+  mainContent: React.ReactNode;
+  sidebar?: React.ReactNode;
+}
+
+export function WorkItemDetailLayout({
+  header,
+  metadata,
+  mainContent,
+  sidebar,
+}: WorkItemDetailLayoutProps) {
+  return (
+    <div className="flex flex-col gap-y-4">
+      {header}
+      <div className="grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-6">
+        <div className="flex flex-col gap-y-4">
+          {metadata}
+          {mainContent}
+        </div>
+        {sidebar && (
+          <div className="flex flex-col gap-y-4">
+            {sidebar}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/coming-soon-page.tsx
+++ b/src/components/coming-soon-page.tsx
@@ -16,24 +16,16 @@ export const ComingSoonPage = ({
   onCtaClick,
 }: ComingSoonPageProps) => {
   return (
-    <div
-      className="flex flex-col items-center justify-center min-h-[60vh] gap-6 text-center px-6"
-    >
-      <div
-        className="flex items-center justify-center size-20 rounded-2xl"
-        style={{
-          background: "rgba(79,124,255,0.08)",
-          border: "1px solid rgba(79,124,255,0.15)",
-        }}
-      >
-        <div style={{ color: "#4F7CFF" }} className="size-9">
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 text-center px-6">
+      <div className="flex items-center justify-center size-20 rounded-2xl bg-primary/10 border border-primary/20">
+        <div className="size-9 text-primary">
           {icon}
         </div>
       </div>
 
       <div className="flex flex-col gap-2 max-w-md">
-        <h2 className="text-2xl font-bold tracking-tight text-white">{title}</h2>
-        <p className="text-base leading-relaxed" style={{ color: "rgba(255,255,255,0.5)" }}>
+        <h2 className="text-2xl font-bold tracking-tight text-foreground">{title}</h2>
+        <p className="text-base leading-relaxed text-muted-foreground">
           {description}
         </p>
       </div>
@@ -43,18 +35,7 @@ export const ComingSoonPage = ({
         onClick={onCtaClick}
         disabled={!onCtaClick}
         aria-disabled={!onCtaClick}
-        className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium rounded-btn transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
-        style={{
-          background: "rgba(79,124,255,0.12)",
-          border: "1px solid rgba(79,124,255,0.25)",
-          color: "#4F7CFF",
-        }}
-        onMouseEnter={(e) => {
-          if (onCtaClick) e.currentTarget.style.background = "rgba(79,124,255,0.2)";
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.background = "rgba(79,124,255,0.12)";
-        }}
+        className="flex items-center gap-2 px-5 py-2.5 text-sm font-medium rounded-btn transition-all duration-150 disabled:opacity-40 disabled:cursor-not-allowed bg-primary/10 border border-primary/20 text-primary hover:bg-primary/20"
       >
         {cta}
       </button>

--- a/src/components/command-bar.tsx
+++ b/src/components/command-bar.tsx
@@ -50,7 +50,7 @@ export function CommandBar() {
   const pageLabel = PAGE_LABEL[lastSegment] ?? null;
 
   return (
-    <header className="sticky top-0 z-30 h-14 flex items-center gap-4 px-6 border-b border-white/5 bg-[#070B14]/90 backdrop-blur-sm shrink-0">
+    <header className="sticky top-0 z-30 h-14 flex items-center gap-4 px-6 border-b border-border/30 bg-background/90 backdrop-blur-sm shrink-0">
       {/* Mobile sidebar trigger */}
       <div className="lg:hidden">
         <MobileSidebar />
@@ -61,17 +61,17 @@ export function CommandBar() {
         {workspace && (
           <Link
             href={`/workspace/${workspaceId}`}
-            className="text-white/40 hover:text-white/70 transition-colors truncate max-w-[120px]"
+            className="text-muted-foreground hover:text-foreground transition-colors truncate max-w-[120px]"
           >
             {workspace.name}
           </Link>
         )}
         {project && (
           <>
-            <ChevronRight className="size-3 text-white/20 shrink-0" />
+            <ChevronRight className="size-3 text-muted-foreground/50 shrink-0" />
             <Link
               href={`/workspace/${workspaceId}/project/${projectId}`}
-              className="text-white/40 hover:text-white/70 transition-colors truncate max-w-[120px]"
+              className="text-muted-foreground hover:text-foreground transition-colors truncate max-w-[120px]"
             >
               {project.name}
             </Link>
@@ -79,8 +79,8 @@ export function CommandBar() {
         )}
         {pageLabel && (
           <>
-            <ChevronRight className="size-3 text-white/20 shrink-0" />
-            <span className="text-white/80 font-medium">{pageLabel}</span>
+            <ChevronRight className="size-3 text-muted-foreground/50 shrink-0" />
+            <span className="text-foreground font-medium">{pageLabel}</span>
           </>
         )}
       </nav>
@@ -90,11 +90,11 @@ export function CommandBar() {
         <button
           type="button"
           onClick={openCommandPalette}
-          className="flex items-center gap-3 w-full max-w-xl h-9 px-4 rounded-lg bg-white/[0.04] border border-white/[0.07] text-sm text-white/40 hover:bg-white/[0.06] hover:border-white/[0.12] hover:text-white/60 transition-all duration-150 group"
+          className="flex items-center gap-3 w-full max-w-xl h-9 px-4 rounded-lg bg-surface border border-border text-sm text-muted-foreground hover:bg-surface-2 hover:border-border hover:text-foreground transition-all duration-150 group"
         >
           <Search className="size-3.5 shrink-0" />
           <span className="flex-1 text-left">Search anything or type a command...</span>
-          <kbd className="hidden sm:flex items-center gap-0.5 text-[10px] bg-white/[0.06] px-1.5 py-0.5 rounded-md border border-white/[0.08] font-mono text-white/30">
+          <kbd className="hidden sm:flex items-center gap-0.5 text-[10px] bg-surface-2 px-1.5 py-0.5 rounded-md border border-border font-mono text-muted-foreground">
             ⌘K
           </kbd>
         </button>
@@ -103,13 +103,13 @@ export function CommandBar() {
       {/* Actions */}
       <div className="flex items-center gap-1 shrink-0">
         <button
-          className="p-2 rounded-lg text-white/40 hover:text-white/70 hover:bg-white/[0.05] transition-all"
+          className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-surface transition-all"
           aria-label="Notifications"
         >
           <Bell className="size-4" />
         </button>
         <button
-          className="p-2 rounded-lg text-white/40 hover:text-white/70 hover:bg-white/[0.05] transition-all"
+          className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-surface transition-all"
           aria-label="Help"
         >
           <HelpCircle className="size-4" />

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -36,10 +36,10 @@ import {
 import { IssueType, Task } from "@/features/tasks/types";
 import { cn } from "@/lib/utils";
 
-const GROUP_HEADING_CLS = "px-4 text-[10px] uppercase tracking-widest text-white/25 font-semibold";
-const ITEM_CLS = "flex items-center gap-3 px-4 py-2.5 rounded-lg mx-2 cursor-pointer hover:bg-white/[0.05] aria-selected:bg-white/[0.07] transition-colors";
+const GROUP_HEADING_CLS = "px-4 text-[10px] uppercase tracking-widest text-muted-foreground/60 font-semibold";
+const ITEM_CLS = "flex items-center gap-3 px-4 py-2.5 rounded-lg mx-2 cursor-pointer hover:bg-surface aria-selected:bg-surface-2 transition-colors";
 const ITEM_CONTENT_CLS = "flex-1 min-w-0";
-const ITEM_TITLE_CLS = "text-sm text-white/80 font-medium truncate";
+const ITEM_TITLE_CLS = "text-sm text-foreground/80 font-medium truncate";
 
 const ISSUE_ICON: Record<string, ElementType> = {
   EPIC: Target,
@@ -192,33 +192,26 @@ export function CommandPalette() {
             transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
             className="fixed left-1/2 top-[15vh] -translate-x-1/2 z-50 w-[760px] max-w-[calc(100vw-2rem)]"
           >
-            <div
-              className="rounded-[24px] overflow-hidden"
-              style={{
-                background: "#0F172A",
-                boxShadow:
-                  "0 0 0 1px rgba(255,255,255,0.06), 0 24px 64px rgba(0,0,0,0.5)",
-              }}
-            >
+            <div className="rounded-panel overflow-hidden bg-panel border border-border shadow-chronicle-lg">
               <Command
                 className="bg-transparent border-none"
                 shouldFilter={false}
               >
-                <div className="flex items-center gap-3 px-5 py-4 border-b border-white/[0.06]">
-                  <Search className="size-4 text-white/30 shrink-0" />
+                <div className="flex items-center gap-3 px-5 py-4 border-b border-border">
+                  <Search className="size-4 text-muted-foreground/60 shrink-0" />
                   <CommandInput
                     value={query}
                     onValueChange={setQuery}
                     placeholder="Search anything or type a command..."
-                    className="bg-transparent border-none text-white placeholder:text-white/30 text-sm h-auto p-0 focus:ring-0 focus:outline-none flex-1"
+                    className="bg-transparent border-none text-foreground placeholder:text-muted-foreground/50 text-sm h-auto p-0 focus:ring-0 focus:outline-none flex-1"
                   />
-                  <kbd className="text-[10px] bg-white/[0.06] px-1.5 py-0.5 rounded border border-white/[0.08] font-mono text-white/30 shrink-0">
+                  <kbd className="text-[10px] bg-surface px-1.5 py-0.5 rounded border border-border font-mono text-muted-foreground shrink-0">
                     ESC
                   </kbd>
                 </div>
 
                 <CommandList className="max-h-[480px] overflow-y-auto thin-scrollbar py-2">
-                  <CommandEmpty className="py-12 text-center text-white/30 text-sm">
+                  <CommandEmpty className="py-12 text-center text-muted-foreground text-sm">
                     No results for &ldquo;{query}&rdquo;
                   </CommandEmpty>
 
@@ -237,11 +230,11 @@ export function CommandPalette() {
                             <action.icon className="size-3.5 text-primary" />
                           </div>
                           <div className={ITEM_CONTENT_CLS}>
-                            <p className="text-sm text-white/80 font-medium">{action.label}</p>
-                            <p className="text-xs text-white/30">{action.description}</p>
+                            <p className="text-sm text-foreground/80 font-medium">{action.label}</p>
+                            <p className="text-xs text-muted-foreground">{action.description}</p>
                           </div>
                           {action.shortcut && (
-                            <kbd className="text-[10px] bg-white/[0.06] px-1.5 py-0.5 rounded border border-white/[0.08] font-mono text-white/30">
+                            <kbd className="text-[10px] bg-surface px-1.5 py-0.5 rounded border border-border font-mono text-muted-foreground">
                               {action.shortcut}
                             </kbd>
                           )}
@@ -261,13 +254,13 @@ export function CommandPalette() {
                           onSelect={() => handleSelectProject(project.$id)}
                           className={ITEM_CLS}
                         >
-                          <div className="flex items-center justify-center size-7 rounded-lg bg-white/[0.06] shrink-0">
-                            <FolderKanban className="size-3.5 text-white/50" />
+                          <div className="flex items-center justify-center size-7 rounded-lg bg-surface shrink-0">
+                            <FolderKanban className="size-3.5 text-muted-foreground" />
                           </div>
                           <div className={ITEM_CONTENT_CLS}>
                             <p className={ITEM_TITLE_CLS}>{project.name}</p>
                           </div>
-                          <ArrowRight className="size-3.5 text-white/20" />
+                          <ArrowRight className="size-3.5 text-muted-foreground/40" />
                         </CommandItem>
                       ))}
                     </CommandGroup>
@@ -288,12 +281,12 @@ export function CommandPalette() {
                             onSelect={() => handleSelectTask(task)}
                             className={ITEM_CLS}
                           >
-                            <div className={cn("flex items-center justify-center size-7 rounded-lg bg-white/[0.06] shrink-0")}>
+                            <div className={cn("flex items-center justify-center size-7 rounded-lg bg-surface shrink-0")}>
                               <Icon className={cn("size-3.5", colorClass)} />
                             </div>
                             <div className={ITEM_CONTENT_CLS}>
                               <p className={ITEM_TITLE_CLS}>{task.name}</p>
-                              <p className="text-xs text-white/30 capitalize">{type.toLowerCase()} · {task.status.replaceAll("_", " ").toLowerCase()}</p>
+                              <p className="text-xs text-muted-foreground capitalize">{type.toLowerCase()} · {task.status.replaceAll("_", " ").toLowerCase()}</p>
                             </div>
                           </CommandItem>
                         );
@@ -320,7 +313,7 @@ export function CommandPalette() {
                           </div>
                           <div className={ITEM_CONTENT_CLS}>
                             <p className={ITEM_TITLE_CLS}>{member.name ?? member.email}</p>
-                            <p className="text-xs text-white/30 capitalize">{member.role.toLowerCase()}</p>
+                            <p className="text-xs text-muted-foreground capitalize">{member.role.toLowerCase()}</p>
                           </div>
                         </CommandItem>
                       ))}

--- a/src/components/dashboard-shell.tsx
+++ b/src/components/dashboard-shell.tsx
@@ -11,9 +11,9 @@ interface DashboardShellProps {
 
 export function DashboardShell({ children, rightRail }: DashboardShellProps) {
   return (
-    <div className="flex w-full h-screen overflow-hidden bg-[#070B14]">
+    <div className="flex w-full h-screen overflow-hidden bg-background">
       {/* Fixed 280px sidebar */}
-      <aside className="fixed left-0 top-0 h-full w-[280px] hidden lg:flex flex-col z-40 bg-[#070B14] border-r border-white/5">
+      <aside className="fixed left-0 top-0 h-full w-[280px] hidden lg:flex flex-col z-40 bg-background border-r border-border/30">
         <Sidebar />
       </aside>
 
@@ -30,7 +30,7 @@ export function DashboardShell({ children, rightRail }: DashboardShellProps) {
 
         {/* Right intelligence rail — 340px, optional */}
         {rightRail && (
-          <aside className="hidden xl:flex flex-col w-[340px] shrink-0 border-l border-white/5 overflow-y-auto thin-scrollbar">
+          <aside className="hidden xl:flex flex-col w-[340px] shrink-0 border-l border-border/30 overflow-y-auto thin-scrollbar">
             {rightRail}
           </aside>
         )}

--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -42,7 +42,7 @@ export const DatePicker = ({
 					)}
 				</Button>
 			</PopoverTrigger>
-			<PopoverContent className="w-auto p-0" style={{ zIndex: 9999 }}>
+			<PopoverContent className="w-auto p-0 z-[9999]">
 				<Calendar
 					mode="single"
 					selected={value}

--- a/src/components/date-picker.tsx
+++ b/src/components/date-picker.tsx
@@ -21,7 +21,7 @@ export const DatePicker = ({
 	placeholder = "Select Date",
 }: DatePickerProps) => {
 	return (
-		<Popover>
+		<Popover modal={false}>
 			<PopoverTrigger asChild>
 				<Button
 					variant="outline"
@@ -42,7 +42,7 @@ export const DatePicker = ({
 					)}
 				</Button>
 			</PopoverTrigger>
-			<PopoverContent className="w-auto p-0">
+			<PopoverContent className="w-auto p-0" style={{ zIndex: 9999 }}>
 				<Calendar
 					mode="single"
 					selected={value}

--- a/src/components/intelligence-panel.tsx
+++ b/src/components/intelligence-panel.tsx
@@ -4,13 +4,20 @@ import { useGetTasks } from "@/features/tasks/api/use-get-tasks";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useGetDashboardSuggestions, DashboardSuggestion } from "@/features/ai/api/use-get-dashboard-suggestions";
 import { TaskStatus } from "@/features/tasks/types";
+import { cn } from "@/lib/utils";
 import { format, isAfter, isBefore, addDays } from "date-fns";
 import { Clock, AlertCircle, Bot, Loader, Sparkles } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 
 const SECTION_HEADER_CLS = "flex items-center gap-2 mb-3";
-const SECTION_LABEL_CLS = "text-xs font-semibold uppercase tracking-widest text-white/30";
-const EMPTY_CLS = "text-[13px] text-white/25 text-center py-4";
+const SECTION_LABEL_CLS = "text-xs font-semibold uppercase tracking-widest text-muted-foreground/40";
+const EMPTY_CLS = "text-[13px] text-muted-foreground/30 text-center py-4";
+
+const SUGGESTION_CLASSES: Record<string, { wrapper: string; titleCls: string; dot: string }> = {
+  warning: { wrapper: "bg-destructive/8 border border-destructive/20",   titleCls: "text-destructive",  dot: "bg-destructive" },
+  info:    { wrapper: "bg-primary/8 border border-primary/20",            titleCls: "text-primary",      dot: "bg-primary" },
+  success: { wrapper: "bg-success/8 border border-success/20",            titleCls: "text-success",      dot: "bg-success" },
+};
 
 interface IntelligencePanelProps {
   readonly embedded?: boolean;
@@ -31,20 +38,17 @@ export function IntelligencePanel({ embedded: _embedded }: IntelligencePanelProp
     [tasks]
   );
 
-  const upcoming = useMemo(
-    () => {
-      const now = new Date();
-      return tasks
-        .filter((t) => {
-          if (!t.dueDate || t.status === TaskStatus.DONE) return false;
-          const due = new Date(t.dueDate);
-          return isAfter(due, now) && isBefore(due, addDays(now, 7));
-        })
-        .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
-        .slice(0, 5);
-    },
-    [tasks]
-  );
+  const upcoming = useMemo(() => {
+    const now = new Date();
+    return tasks
+      .filter((t) => {
+        if (!t.dueDate || t.status === TaskStatus.DONE) return false;
+        const due = new Date(t.dueDate);
+        return isAfter(due, now) && isBefore(due, addDays(now, 7));
+      })
+      .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())
+      .slice(0, 5);
+  }, [tasks]);
 
   useEffect(() => {
     hasFetched.current = false;
@@ -54,27 +58,15 @@ export function IntelligencePanel({ embedded: _embedded }: IntelligencePanelProp
     if (hasFetched.current || tasks.length === 0 || !workspaceId) return;
     hasFetched.current = true;
     const now = new Date();
-
     const doneTasks = tasks.filter((t) => t.status === TaskStatus.DONE).length;
     const overdueCount = tasks.filter(
       (t) => t.dueDate && isBefore(new Date(t.dueDate), now) && t.status !== TaskStatus.DONE
     ).length;
     const blockedCount = tasks.filter((t) => t.blockedBy && t.blockedBy.length > 0).length;
-
-    fetchRef.current({
-      workspaceName: workspaceId,
-      totalTasks: tasks.length,
-      doneTasks,
-      overdueCount,
-      blockedCount,
-    });
+    fetchRef.current({ workspaceName: workspaceId, totalTasks: tasks.length, doneTasks, overdueCount, blockedCount });
   }, [tasks, workspaceId]);
 
-  const suggestionColors: Record<string, { bg: string; border: string; text: string; dot: string }> = {
-    warning: { bg: "rgba(239,68,68,0.08)", border: "rgba(239,68,68,0.2)", text: "#EF4444", dot: "bg-red-400" },
-    info: { bg: "rgba(79,124,255,0.08)", border: "rgba(79,124,255,0.2)", text: "#4F7CFF", dot: "bg-blue-400" },
-    success: { bg: "rgba(34,197,94,0.08)", border: "rgba(34,197,94,0.2)", text: "#22C55E", dot: "bg-green-400" },
-  };
+  const displaySuggestions: DashboardSuggestion[] = aiSuggestions ?? [];
 
   const statusLabel: Record<string, string> = {
     BACKLOG: "backlog",
@@ -84,47 +76,41 @@ export function IntelligencePanel({ embedded: _embedded }: IntelligencePanelProp
     DONE: "done",
   };
 
-  const displaySuggestions: DashboardSuggestion[] = aiSuggestions ?? [];
-
   return (
     <div className="flex flex-col h-full px-4 py-5 gap-6">
       {/* AI Suggestions */}
       <div>
         <div className={SECTION_HEADER_CLS}>
-          <div className="flex items-center justify-center size-6 rounded-md" style={{ background: "rgba(139,92,246,0.1)" }}>
-            <Bot className="size-3.5" style={{ color: "#8B5CF6" }} />
+          <div className="flex items-center justify-center size-6 rounded-md bg-purple/10">
+            <Bot className="size-3.5 text-purple" />
           </div>
           <h3 className={SECTION_LABEL_CLS}>AI Insights</h3>
-          {aiLoading && <Loader className="size-3 animate-spin text-white/20 ml-auto" />}
+          {aiLoading && <Loader className="size-3 animate-spin text-muted-foreground/20 ml-auto" />}
           {!aiLoading && aiSuggestions && (
-            <Sparkles className="size-3 ml-auto" style={{ color: "rgba(139,92,246,0.5)" }} />
+            <Sparkles className="size-3 ml-auto text-purple/50" />
           )}
         </div>
         <div className="space-y-2">
           {aiLoading && (
-            <div
-              className="flex items-center gap-2.5 p-3 rounded-xl text-[13px]"
-              style={{ background: "rgba(139,92,246,0.06)", border: "1px solid rgba(139,92,246,0.15)" }}
-            >
-              <Loader className="size-3.5 animate-spin shrink-0" style={{ color: "rgba(139,92,246,0.6)" }} />
-              <span style={{ color: "rgba(255,255,255,0.35)" }}>Generating insights with Claude…</span>
+            <div className="flex items-center gap-2.5 p-3 rounded-xl text-[13px] bg-purple/6 border border-purple/15">
+              <Loader className="size-3.5 animate-spin shrink-0 text-purple/60" />
+              <span className="text-muted-foreground/50">Generating insights with Claude…</span>
             </div>
           )}
           {!aiLoading && displaySuggestions.length === 0 && !aiSuggestions && (
             <p className={EMPTY_CLS}>No data yet</p>
           )}
           {!aiLoading && displaySuggestions.map((s) => {
-            const c = suggestionColors[s.type] ?? suggestionColors.info;
+            const c = SUGGESTION_CLASSES[s.type] ?? SUGGESTION_CLASSES.info;
             return (
               <div
                 key={`${s.title}-${s.type}`}
-                className="flex items-start gap-2.5 p-3 rounded-xl text-[13px] leading-snug"
-                style={{ background: c.bg, border: `1px solid ${c.border}` }}
+                className={cn("flex items-start gap-2.5 p-3 rounded-xl text-[13px] leading-snug", c.wrapper)}
               >
-                <span className={`size-1.5 rounded-full shrink-0 mt-1 ${c.dot}`} />
+                <span className={cn("size-1.5 rounded-full shrink-0 mt-1", c.dot)} />
                 <div className="flex flex-col gap-0.5">
-                  <span className="font-semibold" style={{ color: c.text }}>{s.title}</span>
-                  <span style={{ color: "rgba(255,255,255,0.55)" }}>{s.body}</span>
+                  <span className={cn("font-semibold", c.titleCls)}>{s.title}</span>
+                  <span className="text-foreground/60">{s.body}</span>
                 </div>
               </div>
             );
@@ -135,34 +121,32 @@ export function IntelligencePanel({ embedded: _embedded }: IntelligencePanelProp
       {/* Recent Activity */}
       <div>
         <div className={SECTION_HEADER_CLS}>
-          <div className="flex items-center justify-center size-6 rounded-md bg-white/[0.05]">
-            <Clock className="size-3.5 text-white/40" />
+          <div className="flex items-center justify-center size-6 rounded-md bg-surface-2">
+            <Clock className="size-3.5 text-muted-foreground/50" />
           </div>
           <h3 className={SECTION_LABEL_CLS}>Recent Activity</h3>
         </div>
         {isLoading ? (
           <div className="flex items-center justify-center py-6">
-            <Loader className="size-4 animate-spin text-white/20" />
+            <Loader className="size-4 animate-spin text-muted-foreground/20" />
           </div>
         ) : (
           <div className="space-y-1">
             {recent.map((task) => (
               <div
                 key={task.$id}
-                className="flex items-start gap-2.5 px-2 py-2 rounded-lg hover:bg-white/[0.03] transition-colors cursor-pointer"
+                className="flex items-start gap-2.5 px-2 py-2 rounded-lg hover:bg-surface-2 transition-colors cursor-pointer"
               >
                 <div className="size-1.5 rounded-full bg-primary/60 shrink-0 mt-1.5" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-[13px] text-white/70 truncate font-medium">{task.name}</p>
-                  <p className="text-[11px] text-white/30 mt-0.5">
+                  <p className="text-[13px] text-foreground/70 truncate font-medium">{task.name}</p>
+                  <p className="text-[11px] text-muted-foreground/40 mt-0.5">
                     {statusLabel[task.status] ?? task.status.toLowerCase()}
                   </p>
                 </div>
               </div>
             ))}
-            {recent.length === 0 && (
-              <p className={EMPTY_CLS}>No recent activity</p>
-            )}
+            {recent.length === 0 && <p className={EMPTY_CLS}>No recent activity</p>}
           </div>
         )}
       </div>
@@ -170,8 +154,8 @@ export function IntelligencePanel({ embedded: _embedded }: IntelligencePanelProp
       {/* Upcoming Deadlines */}
       <div>
         <div className={SECTION_HEADER_CLS}>
-          <div className="flex items-center justify-center size-6 rounded-md" style={{ background: "rgba(245,158,11,0.1)" }}>
-            <AlertCircle className="size-3.5" style={{ color: "#F59E0B" }} />
+          <div className="flex items-center justify-center size-6 rounded-md bg-warning/10">
+            <AlertCircle className="size-3.5 text-warning" />
           </div>
           <h3 className={SECTION_LABEL_CLS}>Upcoming Deadlines</h3>
         </div>
@@ -179,22 +163,17 @@ export function IntelligencePanel({ embedded: _embedded }: IntelligencePanelProp
           {upcoming.map((task) => (
             <div
               key={task.$id}
-              className="flex items-center gap-2 px-2 py-2 rounded-lg hover:bg-white/[0.03] transition-colors cursor-pointer"
+              className="flex items-center gap-2 px-2 py-2 rounded-lg hover:bg-surface-2 transition-colors cursor-pointer"
             >
               <div className="flex-1 min-w-0">
-                <p className="text-[13px] text-white/70 truncate font-medium">{task.name}</p>
+                <p className="text-[13px] text-foreground/70 truncate font-medium">{task.name}</p>
               </div>
-              <span
-                className="text-[11px] font-medium px-2 py-0.5 rounded-full shrink-0"
-                style={{ background: "rgba(245,158,11,0.12)", color: "#F59E0B" }}
-              >
+              <span className="text-[11px] font-medium px-2 py-0.5 rounded-full shrink-0 bg-warning/10 text-warning">
                 {format(new Date(task.dueDate), "MMM d")}
               </span>
             </div>
           ))}
-          {upcoming.length === 0 && (
-            <p className={EMPTY_CLS}>No upcoming deadlines</p>
-          )}
+          {upcoming.length === 0 && <p className={EMPTY_CLS}>No upcoming deadlines</p>}
         </div>
       </div>
     </div>

--- a/src/components/project-nav.tsx
+++ b/src/components/project-nav.tsx
@@ -11,6 +11,7 @@ import { useCreateTaskModal } from "@/features/tasks/hooks/use-create-task-modal
 import { useCreateSprintModal } from "@/features/sprints/hooks/use-create-sprint-modal";
 import { useCreateVersionModal } from "@/features/versions/hooks/use-create-version-modal";
 import { ProjectAvatar } from "@/features/projects/components/project-avatar";
+import { IssueType } from "@/features/tasks/types";
 import { cn } from "@/lib/utils";
 import {
   ChevronDown,
@@ -40,6 +41,7 @@ interface NavItem {
   icon: ElementType;
   soon?: boolean;
   onCreate?: "task" | "sprint" | "release";
+  issueType?: IssueType;
 }
 
 const TASK = "task" as const;
@@ -60,7 +62,6 @@ const PROJECT_SECTIONS: NavSection[] = [
   {
     group: "Work Items",
     items: [
-      { label: "Epics", hrefSuffix: "/epics", icon: Target, onCreate: TASK },
       { label: "Work Items", hrefSuffix: "/work-items", icon: ListTodo, onCreate: TASK },
     ],
   },
@@ -108,7 +109,7 @@ function ProjectNavItem({ item, projectHref, projectId }: ProjectItemProps) {
     e.stopPropagation();
     if (item.onCreate === SPRINT) openSprintModal({ projectId });
     else if (item.onCreate === RELEASE) openVersionModal({ projectId });
-    else if (item.onCreate === TASK) openTaskModal({ projectId });
+    else if (item.onCreate === TASK) openTaskModal({ projectId, issueType: item.issueType });
   };
 
   return (

--- a/src/components/settings-components.tsx
+++ b/src/components/settings-components.tsx
@@ -3,12 +3,13 @@
 import { ReactNode } from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Settings, Users, Plug, TriangleAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 const SETTINGS_TABS = [
-  { value: "general", icon: Settings, label: "General" },
-  { value: "members", icon: Users, label: "Members" },
-  { value: "integrations", icon: Plug, label: "Integrations" },
-  { value: "danger", icon: TriangleAlert, label: "Danger Zone" },
+  { value: "general",      icon: Settings,      label: "General" },
+  { value: "members",      icon: Users,         label: "Members" },
+  { value: "integrations", icon: Plug,          label: "Integrations" },
+  { value: "danger",       icon: TriangleAlert, label: "Danger Zone" },
 ] as const;
 
 interface SettingsLayoutProps {
@@ -26,28 +27,20 @@ export const SettingsLayout = ({
 }: SettingsLayoutProps) => (
   <div className="flex flex-col gap-6 w-full max-w-2xl">
     <div>
-      <h1 className="text-2xl font-bold text-white">{title}</h1>
-      <p className="text-[14px] mt-1" style={{ color: "rgba(255,255,255,0.45)" }}>
-        {description}
-      </p>
+      <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+      <p className="text-[14px] mt-1 text-muted-foreground">{description}</p>
     </div>
     <Tabs defaultValue={defaultTab}>{children}</Tabs>
   </div>
 );
 
 export const SettingsTabsList = () => (
-  <TabsList
-    className="flex items-center gap-1 p-1 rounded-xl w-fit"
-    style={{
-      background: "rgba(255,255,255,0.04)",
-      border: "1px solid rgba(255,255,255,0.07)",
-    }}
-  >
+  <TabsList className="flex items-center gap-1 p-1 rounded-xl w-fit bg-surface border border-border/40">
     {SETTINGS_TABS.map(({ value, icon: Icon, label }) => (
       <TabsTrigger
         key={value}
         value={value}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg transition-all data-[state=active]:text-white data-[state=inactive]:text-white/40 data-[state=active]:bg-white/[0.08] data-[state=inactive]:bg-transparent border-none shadow-none"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium rounded-lg transition-all data-[state=active]:text-foreground data-[state=inactive]:text-muted-foreground data-[state=active]:bg-surface-2 data-[state=inactive]:bg-transparent border-none shadow-none"
       >
         <Icon className="size-3.5" />
         {label}
@@ -65,37 +58,27 @@ interface SettingsCardProps {
 
 export const SettingsCard = ({ title, description, danger = false, children }: SettingsCardProps) => (
   <div
-    className="rounded-card p-6"
-    style={{
-      background: "#0F172A",
-      border: `1px solid ${danger ? "rgba(239,68,68,0.2)" : "rgba(255,255,255,0.06)"}`,
-      boxShadow: "0 0 0 1px rgba(255,255,255,0.04), 0 8px 30px rgba(0,0,0,0.25)",
-    }}
+    className={cn(
+      "rounded-card p-6 bg-surface shadow-chronicle-sm",
+      danger ? "border border-destructive/20" : "border border-border/40"
+    )}
   >
-    {title && <h2 className="text-[15px] font-semibold text-white mb-1">{title}</h2>}
+    {title && <h2 className="text-[15px] font-semibold text-foreground mb-1">{title}</h2>}
     {description && (
-      <p className="text-[13px] mb-6" style={{ color: "rgba(255,255,255,0.4)" }}>
-        {description}
-      </p>
+      <p className="text-[13px] mb-6 text-muted-foreground">{description}</p>
     )}
     {children}
   </div>
 );
 
 export const IntegrationsPlaceholder = () => (
-  <div
-    className="flex flex-col items-center justify-center py-12 rounded-xl gap-3"
-    style={{ background: "rgba(255,255,255,0.02)", border: "1px dashed rgba(255,255,255,0.08)" }}
-  >
-    <div
-      className="flex items-center justify-center size-12 rounded-2xl"
-      style={{ background: "rgba(79,124,255,0.08)", border: "1px solid rgba(79,124,255,0.15)" }}
-    >
-      <Plug className="size-5" style={{ color: "#4F7CFF" }} />
+  <div className="flex flex-col items-center justify-center py-12 rounded-xl gap-3 bg-surface border border-dashed border-border/40">
+    <div className="flex items-center justify-center size-12 rounded-2xl bg-primary/8 border border-primary/15">
+      <Plug className="size-5 text-primary" />
     </div>
     <div className="text-center">
-      <p className="text-[14px] font-medium text-white">No integrations yet</p>
-      <p className="text-[13px] mt-1" style={{ color: "rgba(255,255,255,0.35)" }}>
+      <p className="text-[14px] font-medium text-foreground">No integrations yet</p>
+      <p className="text-[13px] mt-1 text-muted-foreground">
         Integrations will be available soon.
       </p>
     </div>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -14,7 +14,7 @@ export const Sidebar = () => {
   return (
     <div className="flex flex-col h-full w-full select-none">
       {/* Logo */}
-      <div className="flex items-center h-14 px-5 border-b border-white/5 shrink-0">
+      <div className="flex items-center h-14 px-5 border-b border-border/30 shrink-0">
         <ChronicleLogoFull />
       </div>
 
@@ -30,10 +30,10 @@ export const Sidebar = () => {
       </div>
 
       {/* Bottom bar: theme + profile */}
-      <div className="shrink-0 border-t border-white/5 px-3 py-3 flex items-center justify-between">
+      <div className="shrink-0 border-t border-border/30 px-3 py-3 flex items-center justify-between">
         <button
           onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-          className="p-2 rounded-lg text-white/30 hover:text-white/60 hover:bg-white/[0.05] transition-all"
+          className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-surface transition-all"
           aria-label="Toggle theme"
         >
           {theme === "dark" ? <Sun className="size-4" /> : <Moon className="size-4" />}

--- a/src/features/auth/components/user-button.tsx
+++ b/src/features/auth/components/user-button.tsx
@@ -1,107 +1,126 @@
 "use client";
 
 import { useCurrent } from "../api/use-current";
-import { Loader, LogOut, Key, Moon, Sun, Settings } from "lucide-react";
+import { Loader, LogOut, Moon, Sun, Settings, Link2, Shield, Monitor } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { DottedSeperator } from "@/components/dotted-seperator";
 import { useLogout } from "../api/use-logout";
-import { useGenerateToken } from "@/features/tokens/api/use-generate-token";
 import { useTheme } from "next-themes";
 import { useRouter } from "next/navigation";
-import { cn } from "@/lib/utils";
 
 export const UserButton = () => {
-	const { data: user, isLoading } = useCurrent();
-	const { mutate: logout } = useLogout();
-	const { mutate: generateToken } = useGenerateToken();
-	const { resolvedTheme, setTheme } = useTheme();
-	const router = useRouter();
+  const { data: user, isLoading } = useCurrent();
+  const { mutate: logout } = useLogout();
+  const { resolvedTheme, setTheme } = useTheme();
+  const router = useRouter();
 
-	if (isLoading) {
-		return (
-			<div className="size-10 rounded-full flex items-center justify-center bg-muted border border-border">
-				<Loader className="size-4 animate-spin text-muted-foreground" />
-			</div>
-		);
-	}
+  if (isLoading) {
+    return (
+      <div className="size-10 rounded-full flex items-center justify-center bg-muted border border-border">
+        <Loader className="size-4 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
 
-	if (!user) {
-		return null;
-	}
+  if (!user) return null;
 
-	const { name, email, photoUrl } = user;
+  const { name, email, photoUrl } = user;
+  const avatarFallback = (name?.charAt(0) || email?.charAt(0) || "U").toUpperCase();
 
-	const avatarFallback =
-		(name?.charAt(0) || email?.charAt(0) || "U").toUpperCase();
+  return (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger className="outline-none">
+        <Avatar className="size-10 hover:opacity-75 transition border border-border">
+          <AvatarImage src={photoUrl} alt={name || email} />
+          <AvatarFallback className="bg-muted font-medium text-muted-foreground">
+            {avatarFallback}
+          </AvatarFallback>
+        </Avatar>
+      </DropdownMenuTrigger>
 
-	return (
-		<DropdownMenu modal={false}>
-			<DropdownMenuTrigger className="outline-none relative">
-				<Avatar className="size-10 hover:opacity-75 transition border border-border">
-					<AvatarImage src={photoUrl} alt={name || email} />
-					<AvatarFallback className="bg-muted font-medium text-muted-foreground flex items-center justify-center">
-						{avatarFallback}
-					</AvatarFallback>
-				</Avatar>
-			</DropdownMenuTrigger>
-			<DropdownMenuContent
-				align="end"
-				side="bottom"
-				className="w-60"
-				sideOffset={10}
-			>
-				<div className="flex flex-col items-center justify-center gap-2 px-2.5 py-4">
-					<Avatar className="size-[52px] border border-border">
-						<AvatarImage src={photoUrl} alt={name || email} />
-						<AvatarFallback className="bg-muted text-xl font-medium text-muted-foreground flex items-center justify-center">
-							{avatarFallback}
-						</AvatarFallback>
-					</Avatar>
-					<div className="flex flex-col items-center justify-center">
-						<p className="text-sm font-medium text-foreground">
-							{name || "User"}
-						</p>
-						<p className="text-xs text-muted-foreground">{email}</p>
-					</div>
-				</div>
-				<DottedSeperator className="mb-1" />
-				<DropdownMenuItem
-					onClick={() => router.push("/settings")}
-					className="h-10 flex items-center justify-center font-medium cursor-pointer"
-				>
-					<Settings className="size-4 mr-2" />
-					Settings
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
-					className="h-10 flex items-center justify-center font-medium cursor-pointer"
-				>
-					<Sun className={cn("size-4 mr-2", resolvedTheme === "dark" ? "hidden" : "")} />
-					<Moon className={cn("size-4 mr-2", resolvedTheme !== "dark" ? "hidden" : "")} />
-					{resolvedTheme === "dark" ? "Light Mode" : "Dark Mode"}
-				</DropdownMenuItem>
-				<DottedSeperator className="mb-1" />
-				<DropdownMenuItem
-					onClick={() => generateToken()}
-					className="h-10 flex items-center justify-center font-medium cursor-pointer"
-				>
-					<Key className="size-4 mr-2" />
-					Generate Agent Token
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onClick={() => logout()}
-					className="h-10 flex items-center justify-center text-destructive font-medium cursor-pointer"
-				>
-					<LogOut className="size-4 mr-2" />
-					Log out
-				</DropdownMenuItem>
-			</DropdownMenuContent>
-		</DropdownMenu>
-	);
+      <DropdownMenuContent
+        align="end"
+        side="bottom"
+        className="w-72 p-0 overflow-hidden"
+        sideOffset={10}
+      >
+        {/* User card */}
+        <div className="flex items-center gap-3 px-4 py-5">
+          <Avatar className="size-16 shrink-0 border border-border">
+            <AvatarImage src={photoUrl} alt={name || email} />
+            <AvatarFallback className="bg-muted text-2xl font-semibold text-muted-foreground">
+              {avatarFallback}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col min-w-0">
+            <p className="text-[15px] font-semibold text-foreground truncate">{name || "User"}</p>
+            <p className="text-[12px] text-muted-foreground truncate">{email}</p>
+          </div>
+        </div>
+
+        <div className="h-px bg-border/40" />
+
+        {/* Account section */}
+        <div className="p-2 space-y-0.5">
+          <DropdownMenuItem
+            onClick={() => router.push("/settings")}
+            className="h-11 px-3 rounded-lg text-[13px] cursor-pointer"
+          >
+            <Settings className="size-4 mr-2.5 text-muted-foreground" />
+            Settings
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => router.push("/settings")}
+            className="h-11 px-3 rounded-lg text-[13px] cursor-pointer"
+          >
+            <Link2 className="size-4 mr-2.5 text-muted-foreground" />
+            Connected Accounts
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => router.push("/settings")}
+            className="h-11 px-3 rounded-lg text-[13px] cursor-pointer"
+          >
+            <Shield className="size-4 mr-2.5 text-muted-foreground" />
+            OAuth Access
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => router.push("/settings")}
+            className="h-11 px-3 rounded-lg text-[13px] cursor-pointer"
+          >
+            <Monitor className="size-4 mr-2.5 text-muted-foreground" />
+            Sessions
+          </DropdownMenuItem>
+        </div>
+
+        <div className="h-px bg-border/40" />
+
+        {/* Preferences + logout */}
+        <div className="p-2 space-y-0.5">
+          <DropdownMenuItem
+            onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+            className="h-11 px-3 rounded-lg text-[13px] cursor-pointer"
+          >
+            {resolvedTheme === "dark" ? (
+              <Sun className="size-4 mr-2.5 text-muted-foreground" />
+            ) : (
+              <Moon className="size-4 mr-2.5 text-muted-foreground" />
+            )}
+            {resolvedTheme === "dark" ? "Switch to Light" : "Switch to Dark"}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => logout()}
+            className="h-11 px-3 rounded-lg text-[13px] text-destructive cursor-pointer focus:text-destructive"
+          >
+            <LogOut className="size-4 mr-2.5" />
+            Log out
+          </DropdownMenuItem>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 };

--- a/src/features/auth/components/user-button.tsx
+++ b/src/features/auth/components/user-button.tsx
@@ -34,7 +34,7 @@ export const UserButton = () => {
 
   return (
     <DropdownMenu modal={false}>
-      <DropdownMenuTrigger className="outline-none">
+      <DropdownMenuTrigger className="outline-none focus-visible:ring-2 focus-visible:ring-primary/40 rounded-full">
         <Avatar className="size-10 hover:opacity-75 transition border border-border">
           <AvatarImage src={photoUrl} alt={name || email} />
           <AvatarFallback className="bg-muted font-medium text-muted-foreground">

--- a/src/features/tasks/api/use-bulk-update-tasks.ts
+++ b/src/features/tasks/api/use-bulk-update-tasks.ts
@@ -33,6 +33,7 @@ export const useBulkUpdateTasks = () => {
 		},
 		onError: () => {
 			toast.error("Failed to update tasks");
+			queryClient.invalidateQueries({ queryKey: ["tasks"] });
 		},
 	});
 	return mutation;

--- a/src/features/tasks/components/data-kanban.tsx
+++ b/src/features/tasks/components/data-kanban.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Task, TaskStatus } from "../types";
 
 import {
@@ -22,64 +22,50 @@ type TaskState = {
 	[key in TaskStatus]: Task[];
 };
 
+function buildTaskState(data: Task[]): TaskState {
+	const state: TaskState = {
+		[TaskStatus.BACKLOG]: [],
+		[TaskStatus.TODO]: [],
+		[TaskStatus.IN_PROGRESS]: [],
+		[TaskStatus.UNDER_REVIEW]: [],
+		[TaskStatus.DONE]: [],
+	};
+	data.forEach((task) => {
+		state[task.status].push(task);
+	});
+	Object.keys(state).forEach((status) => {
+		state[status as TaskStatus].sort((a, b) => a.position - b.position);
+	});
+	return state;
+}
+
 interface DataKanbanProps {
 	data: Task[];
+	isPending?: boolean;
 	onChange: (
 		tasks: { $id: string; status: TaskStatus; position: number }[]
 	) => void;
 }
 
-export const DataKanban = ({ data, onChange }: DataKanbanProps) => {
-	const [tasks, setTasks] = useState<TaskState>(() => {
-		const initialTasks: TaskState = {
-			[TaskStatus.BACKLOG]: [],
-			[TaskStatus.TODO]: [],
-			[TaskStatus.IN_PROGRESS]: [],
-			[TaskStatus.UNDER_REVIEW]: [],
-			[TaskStatus.DONE]: [],
-		};
-		data.forEach((task) => {
-			initialTasks[task.status].push(task);
-		});
-		Object.keys(initialTasks).forEach((status) => {
-			initialTasks[status as TaskStatus].sort(
-				(a, b) => a.position - b.position
-			);
-		});
-		return initialTasks;
-	});
+export const DataKanban = ({ data, isPending = false, onChange }: DataKanbanProps) => {
+	const [tasks, setTasks] = useState<TaskState>(() => buildTaskState(data));
+	const prevTasksRef = useRef<TaskState | null>(null);
 
 	useEffect(() => {
-		const newTasks: TaskState = {
-			[TaskStatus.BACKLOG]: [],
-			[TaskStatus.TODO]: [],
-			[TaskStatus.IN_PROGRESS]: [],
-			[TaskStatus.UNDER_REVIEW]: [],
-			[TaskStatus.DONE]: [],
-		};
-		data.forEach((task) => {
-			newTasks[task.status].push(task);
-		});
-		Object.keys(newTasks).forEach((status) => {
-			newTasks[status as TaskStatus].sort(
-				(a, b) => a.position - b.position
-			);
-		});
-		setTasks(newTasks);
+		setTasks(buildTaskState(data));
 	}, [data]);
 
 	const onDragEnd = useCallback(
 		(result: DropResult) => {
-			if (!result.destination) return;
+			if (!result.destination || isPending) return;
 			const { source, destination } = result;
 			const sourceStatus = source.droppableId as TaskStatus;
 			const destStatus = destination.droppableId as TaskStatus;
-			let updatesPayload: {
-				$id: string;
-				status: TaskStatus;
-				position: number;
-			}[] = [];
+			let updatesPayload: { $id: string; status: TaskStatus; position: number }[] = [];
+
 			setTasks((prevTasks) => {
+				prevTasksRef.current = prevTasks;
+
 				const newTasks = { ...prevTasks };
 				const sourceColumn = [...newTasks[sourceStatus]];
 				const [movedTask] = sourceColumn.splice(source.index, 1);
@@ -100,39 +86,22 @@ export const DataKanban = ({ data, onChange }: DataKanbanProps) => {
 				updatesPayload.push({
 					$id: updatedMovedTask.$id,
 					status: destStatus,
-					position: Math.min(
-						(destination.index + 1) * 1000,
-						1_000_000
-					),
+					position: Math.min((destination.index + 1) * 1000, 1_000_000),
 				});
 				newTasks[destStatus].forEach((task, index) => {
 					if (task && task.$id !== updatedMovedTask.$id) {
-						const newPosition = Math.min(
-							(index + 1) * 1000,
-							1_000_000
-						);
+						const newPosition = Math.min((index + 1) * 1000, 1_000_000);
 						if (task.position !== newPosition) {
-							updatesPayload.push({
-								$id: task.$id,
-								status: destStatus,
-								position: newPosition,
-							});
+							updatesPayload.push({ $id: task.$id, status: destStatus, position: newPosition });
 						}
 					}
 				});
 				if (sourceStatus !== destStatus) {
 					newTasks[sourceStatus].forEach((task, index) => {
 						if (task) {
-							const newPosition = Math.min(
-								(index + 1) * 1000,
-								1_000_000
-							);
+							const newPosition = Math.min((index + 1) * 1000, 1_000_000);
 							if (task.position !== newPosition) {
-								updatesPayload.push({
-									$id: task.$id,
-									status: sourceStatus,
-									position: newPosition,
-								});
+								updatesPayload.push({ $id: task.$id, status: sourceStatus, position: newPosition });
 							}
 						}
 					});
@@ -141,55 +110,57 @@ export const DataKanban = ({ data, onChange }: DataKanbanProps) => {
 			});
 			onChange(updatesPayload);
 		},
-		[onChange]
+		[onChange, isPending]
 	);
 
 	return (
 		<DragDropContext onDragEnd={onDragEnd}>
-			<div className="flex overflow-x-auto">
-				{boards.map((board) => {
-					return (
-						<div
-							key={board}
-							className="flex-1 mx-2 bg-muted p-1.5 rounded-md min-w-[200px]"
-						>
-							<KanbanColumnHeader
-								board={board}
-								taskCount={tasks[board].length}
-							/>
-							<Droppable droppableId={board}>
-								{(provided) => (
-									<div
-										className="min-h-[200px] py-1.5"
-										{...provided.droppableProps}
-										ref={provided.innerRef}
-									>
-										{tasks[board].map((task, index) => (
-											<Draggable
-												key={task.$id}
-												draggableId={task.$id}
-												index={index}
-											>
-												{(provided) => (
-													<div
-														ref={provided.innerRef}
-														{...provided.draggableProps}
-														{...provided.dragHandleProps}
-													>
-														<KanbanCard
-															task={task}
-														/>
-													</div>
-												)}
-											</Draggable>
-										))}
-										{provided.placeholder}
-									</div>
-								)}
-							</Droppable>
-						</div>
-					);
-				})}
+			<div className="flex overflow-x-auto gap-2 pb-2">
+				{boards.map((board) => (
+					<div
+						key={board}
+						className="flex-1 min-w-[220px] rounded-card bg-surface border border-border/30 p-2"
+					>
+						<KanbanColumnHeader
+							board={board}
+							taskCount={tasks[board].length}
+						/>
+						<Droppable droppableId={board}>
+							{(provided, snapshot) => (
+								<div
+									className={`min-h-[200px] py-1 rounded-lg transition-colors duration-150 ${
+										snapshot.isDraggingOver ? "bg-surface-2" : ""
+									}`}
+									{...provided.droppableProps}
+									ref={provided.innerRef}
+								>
+									{tasks[board].map((task, index) => (
+										<Draggable
+											key={task.$id}
+											draggableId={task.$id}
+											index={index}
+											isDragDisabled={isPending}
+										>
+											{(provided, snapshot) => (
+												<div
+													ref={provided.innerRef}
+													{...provided.draggableProps}
+													{...provided.dragHandleProps}
+													className={`transition-opacity duration-150 ${
+														isPending ? "opacity-50 cursor-not-allowed" : ""
+													} ${snapshot.isDragging ? "opacity-90 rotate-1" : ""}`}
+												>
+													<KanbanCard task={task} />
+												</div>
+											)}
+										</Draggable>
+									))}
+									{provided.placeholder}
+								</div>
+							)}
+						</Droppable>
+					</div>
+				))}
 			</div>
 		</DragDropContext>
 	);

--- a/src/features/tasks/components/data-kanban.tsx
+++ b/src/features/tasks/components/data-kanban.tsx
@@ -59,6 +59,7 @@ export const DataKanban = ({ data, isPending = false, onChange }: DataKanbanProp
 		(result: DropResult) => {
 			if (!result.destination || isPending) return;
 			const { source, destination } = result;
+			if (source.droppableId === destination.droppableId && source.index === destination.index) return;
 			const sourceStatus = source.droppableId as TaskStatus;
 			const destStatus = destination.droppableId as TaskStatus;
 			let updatesPayload: { $id: string; status: TaskStatus; position: number }[] = [];

--- a/src/features/tasks/components/data-table.tsx
+++ b/src/features/tasks/components/data-table.tsx
@@ -1,130 +1,125 @@
 "use client";
 
 import * as React from "react";
-
 import {
-	ColumnDef,
-	flexRender,
-	getCoreRowModel,
-	useReactTable,
-	getPaginationRowModel,
-	SortingState,
-	getSortedRowModel,
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  getPaginationRowModel,
+  SortingState,
+  getSortedRowModel,
 } from "@tanstack/react-table";
-
 import { Button } from "@/components/ui/button";
-
 import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
+import { cn } from "@/lib/utils";
 
-interface DataTableProps<TData, TValue> {
-	columns: ColumnDef<TData, TValue>[];
-	data: TData[];
-	onRowClick?: (row: TData) => void;
+interface ChronicleDataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  onRowClick?: (row: TData) => void;
 }
 
-export function DataTable<TData, TValue>({
-	columns,
-	data,
-	onRowClick,
-}: DataTableProps<TData, TValue>) {
-	const [sorting, setSorting] = React.useState<SortingState>([]);
-	const table = useReactTable({
-		data,
-		columns,
-		getCoreRowModel: getCoreRowModel(),
-		getPaginationRowModel: getPaginationRowModel(),
-		onSortingChange: setSorting,
-		getSortedRowModel: getSortedRowModel(),
-		state: {
-			sorting,
-		},
-	});
+export function ChronicleDataTable<TData, TValue>({
+  columns,
+  data,
+  onRowClick,
+}: ChronicleDataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    state: { sorting },
+  });
 
-	return (
-		<div className="">
-			<div className="rounded-md border">
-				<Table>
-					<TableHeader>
-						{table.getHeaderGroups().map((headerGroup) => (
-							<TableRow key={headerGroup.id}>
-								{headerGroup.headers.map((header) => {
-									return (
-										<TableHead key={header.id}>
-											{header.isPlaceholder
-												? null
-												: flexRender(
-														header.column.columnDef
-															.header,
-														header.getContext()
-												  )}
-										</TableHead>
-									);
-								})}
-							</TableRow>
-						))}
-					</TableHeader>
-					<TableBody>
-						{table.getRowModel().rows?.length ? (
-							table.getRowModel().rows.map((row) => (
-								<TableRow
-									key={row.id}
-									data-state={
-										row.getIsSelected() && "selected"
-									}
-									onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-									onKeyDown={onRowClick ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onRowClick(row.original); } } : undefined}
-									tabIndex={onRowClick ? 0 : undefined}
-									role={onRowClick ? "button" : undefined}
-									className={onRowClick ? "cursor-pointer" : ""}
-								>
-									{row.getVisibleCells().map((cell) => (
-										<TableCell key={cell.id}>
-											{flexRender(
-												cell.column.columnDef.cell,
-												cell.getContext()
-											)}
-										</TableCell>
-									))}
-								</TableRow>
-							))
-						) : (
-							<TableRow>
-								<TableCell
-									colSpan={columns.length}
-									className="h-24 text-center"
-								>
-									No results.
-								</TableCell>
-							</TableRow>
-						)}
-					</TableBody>
-				</Table>
-			</div>
-			<div className="flex items-center justify-end space-x-2 py-4">
-				<Button
-					variant="secondary"
-					size="sm"
-					onClick={() => table.previousPage()}
-					disabled={!table.getCanPreviousPage()}
-				>
-					Previous
-				</Button>
-				<Button
-					variant="secondary"
-					size="sm"
-					onClick={() => table.nextPage()}
-					disabled={!table.getCanNextPage()}
-				>
-					Next
-				</Button>
-			</div>
-		</div>
-	);
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id} className="border-border/40">
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id} className="text-muted-foreground">
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                onKeyDown={
+                  onRowClick
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRowClick(row.original);
+                        }
+                      }
+                    : undefined
+                }
+                tabIndex={onRowClick ? 0 : undefined}
+                role={onRowClick ? "button" : undefined}
+                className={cn(
+                  "h-12 border-border/40",
+                  onRowClick && "cursor-pointer hover:bg-surface"
+                )}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+      <div className="flex items-center justify-end gap-2 px-4 py-3 border-t border-border/40">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
 }
+
+/* Backward-compat alias — prefer ChronicleDataTable in new code */
+export const DataTable = ChronicleDataTable;

--- a/src/features/tasks/components/kanban-card.tsx
+++ b/src/features/tasks/components/kanban-card.tsx
@@ -6,25 +6,21 @@ import { MemberAvatar } from "@/features/members/components/member-avatar";
 import { cn } from "@/lib/utils";
 import { MoreHorizontal, AlertCircle, GitPullRequest } from "lucide-react";
 
-const PRIMARY = "#4F7CFF";
-const DANGER = "#EF4444";
-const BORDER_SUBTLE = "rgba(255,255,255,0.06)";
-
-const TYPE_CONFIG: Record<string, { label: string; bg: string; color: string }> = {
-  EPIC: { label: "Epic", bg: "rgba(245,158,11,0.12)", color: "#F59E0B" },
-  STORY: { label: "Story", bg: "rgba(34,197,94,0.12)", color: "#22C55E" },
-  BUG: { label: "Bug", bg: "rgba(239,68,68,0.12)", color: DANGER },
-  SPIKE: { label: "Spike", bg: "rgba(139,92,246,0.12)", color: "#8B5CF6" },
-  TASK: { label: "Task", bg: "rgba(79,124,255,0.12)", color: PRIMARY },
+const TYPE_CONFIG: Record<string, { label: string; bgClass: string; colorClass: string }> = {
+  EPIC: { label: "Epic", bgClass: "bg-warning/10", colorClass: "text-warning" },
+  STORY: { label: "Story", bgClass: "bg-success/10", colorClass: "text-success" },
+  BUG: { label: "Bug", bgClass: "bg-destructive/10", colorClass: "text-destructive" },
+  SPIKE: { label: "Spike", bgClass: "bg-purple/15", colorClass: "text-purple" },
+  TASK: { label: "Task", bgClass: "bg-primary/10", colorClass: "text-primary" },
 };
 
-const PRIORITY_CONFIG: Record<string, { label: string; color: string; dot: string }> = {
-  CRITICAL: { label: "Critical", color: DANGER, dot: "bg-red-400" },
-  HIGH: { label: "High", color: "#F59E0B", dot: "bg-yellow-400" },
-  MEDIUM: { label: "Medium", color: PRIMARY, dot: "bg-blue-400" },
-  LOW: { label: "Low", color: "rgba(255,255,255,0.3)", dot: "bg-white/20" },
-  BLOCKER: { label: "Blocker", color: DANGER, dot: "bg-red-400" },
-  TRIVIAL: { label: "Trivial", color: "rgba(255,255,255,0.2)", dot: "bg-white/10" },
+const PRIORITY_CONFIG: Record<string, { label: string; colorClass: string; dot: string }> = {
+  CRITICAL: { label: "Critical", colorClass: "text-destructive", dot: "bg-red-400" },
+  HIGH: { label: "High", colorClass: "text-warning", dot: "bg-yellow-400" },
+  MEDIUM: { label: "Medium", colorClass: "text-primary", dot: "bg-blue-400" },
+  LOW: { label: "Low", colorClass: "text-muted-foreground/60", dot: "bg-white/20" },
+  BLOCKER: { label: "Blocker", colorClass: "text-destructive", dot: "bg-red-400" },
+  TRIVIAL: { label: "Trivial", colorClass: "text-muted-foreground/60", dot: "bg-white/10" },
 };
 
 interface KanbanCardProps {
@@ -40,75 +36,59 @@ export const KanbanCard = ({ task }: KanbanCardProps) => {
   return (
     <button
       type="button"
-      className="group relative flex flex-col gap-3 p-3.5 mb-2 rounded-xl cursor-pointer transition-all duration-150 w-full text-left"
-      style={{
-        background: "#0F172A",
-        border: `1px solid ${isBlocked ? "rgba(239,68,68,0.25)" : BORDER_SUBTLE}`,
-        boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
-      }}
-      onMouseEnter={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.border = `1px solid ${isBlocked ? "rgba(239,68,68,0.4)" : "rgba(79,124,255,0.25)"}`;
-        (e.currentTarget as HTMLButtonElement).style.transform = "translateY(-1px)";
-        (e.currentTarget as HTMLButtonElement).style.boxShadow = "0 4px 12px rgba(0,0,0,0.3)";
-      }}
-      onMouseLeave={(e) => {
-        (e.currentTarget as HTMLButtonElement).style.border = `1px solid ${isBlocked ? "rgba(239,68,68,0.25)" : BORDER_SUBTLE}`;
-        (e.currentTarget as HTMLButtonElement).style.transform = "translateY(0)";
-        (e.currentTarget as HTMLButtonElement).style.boxShadow = "0 1px 3px rgba(0,0,0,0.2)";
-      }}
+      className={cn(
+        "group relative flex flex-col gap-3 p-3.5 mb-2 rounded-xl cursor-pointer transition-all duration-150 w-full text-left bg-surface shadow-sm hover:-translate-y-px hover:shadow-md",
+        isBlocked
+          ? "border border-destructive/25 hover:border-destructive/40"
+          : "border border-border/40 hover:border-primary/25"
+      )}
     >
       {/* Top row: type + priority badges + menu */}
       <div className="flex items-center gap-1.5 justify-between">
         <div className="flex items-center gap-1.5 flex-wrap">
           {typeConfig && (
             <span
-              className="text-[10px] font-semibold px-1.5 py-0.5 rounded-md"
-              style={{ background: typeConfig.bg, color: typeConfig.color }}
+              className={cn(
+                "text-[10px] font-semibold px-1.5 py-0.5 rounded-md",
+                typeConfig.bgClass,
+                typeConfig.colorClass
+              )}
             >
               {typeConfig.label}
             </span>
           )}
           {priorityConfig && (
-            <span className="flex items-center gap-1 text-[10px] font-medium" style={{ color: priorityConfig.color }}>
+            <span className={cn("flex items-center gap-1 text-[10px] font-medium", priorityConfig.colorClass)}>
               <span className={cn("size-1.5 rounded-full", priorityConfig.dot)} />
               {priorityConfig.label}
             </span>
           )}
         </div>
         <TaskActions id={task.$id}>
-          <MoreHorizontal className="size-4 text-white/20 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+          <MoreHorizontal className="size-4 text-muted-foreground/60 opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
         </TaskActions>
       </div>
 
       {/* Title */}
-      <p className="text-[13px] font-medium leading-snug text-white/85 line-clamp-2">
+      <p className="text-[13px] font-medium leading-snug text-foreground line-clamp-2">
         {task.name}
       </p>
 
       {/* Meta row: sprint, story points, PR, blocker */}
       <div className="flex items-center gap-2 flex-wrap">
         {task.storyPoints != null && (
-          <span
-            className="text-[10px] font-medium px-1.5 py-0.5 rounded-md"
-            style={{ background: BORDER_SUBTLE, color: "rgba(255,255,255,0.4)" }}
-          >
+          <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-md bg-border/40 text-muted-foreground">
             {task.storyPoints} SP
           </span>
         )}
         {hasLinkedPR && (
-          <span
-            className="flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-md"
-            style={{ background: "rgba(79,124,255,0.1)", color: PRIMARY }}
-          >
+          <span className="flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-md bg-primary/10 text-primary">
             <GitPullRequest className="size-3" />
             PR
           </span>
         )}
         {isBlocked && (
-          <span
-            className="flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-md"
-            style={{ background: "rgba(239,68,68,0.12)", color: DANGER }}
-          >
+          <span className="flex items-center gap-1 text-[10px] font-semibold px-1.5 py-0.5 rounded-md bg-destructive/10 text-destructive">
             <AlertCircle className="size-3" />
             Blocked
           </span>
@@ -122,12 +102,12 @@ export const KanbanCard = ({ task }: KanbanCardProps) => {
             <MemberAvatar
               name={task.assignee.name ?? "?"}
               imageUrl={task.assignee.email}
-              className="size-5 ring-1 ring-[#0F172A]"
+              className="size-5 ring-1 ring-surface"
             />
           )}
         </div>
         {task.dueDate && (
-          <span className="text-[11px]" style={{ color: "rgba(255,255,255,0.3)" }}>
+          <span className="text-[11px] text-muted-foreground/60">
             {new Date(task.dueDate).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
           </span>
         )}

--- a/src/features/tasks/components/kanban-column-header.tsx
+++ b/src/features/tasks/components/kanban-column-header.tsx
@@ -10,12 +10,12 @@ interface KanbanColumnHeaderProps {
   taskCount: number;
 }
 
-const STATUS_CONFIG: Record<TaskStatus, { label: string; color: string; dot: string }> = {
-  [TaskStatus.BACKLOG]: { label: "Backlog", color: "rgba(255,255,255,0.3)", dot: "bg-white/20" },
-  [TaskStatus.TODO]: { label: "To Do", color: "#F59E0B", dot: "bg-yellow-400" },
-  [TaskStatus.IN_PROGRESS]: { label: "In Progress", color: "#4F7CFF", dot: "bg-blue-400" },
-  [TaskStatus.UNDER_REVIEW]: { label: "Review", color: "#8B5CF6", dot: "bg-purple-400" },
-  [TaskStatus.DONE]: { label: "Done", color: "#22C55E", dot: "bg-green-400" },
+const STATUS_CONFIG: Record<TaskStatus, { label: string; colorClass: string; dot: string }> = {
+  [TaskStatus.BACKLOG]: { label: "Backlog", colorClass: "text-muted-foreground/60", dot: "bg-white/20" },
+  [TaskStatus.TODO]: { label: "To Do", colorClass: "text-warning", dot: "bg-yellow-400" },
+  [TaskStatus.IN_PROGRESS]: { label: "In Progress", colorClass: "text-primary", dot: "bg-blue-400" },
+  [TaskStatus.UNDER_REVIEW]: { label: "Review", colorClass: "text-purple", dot: "bg-purple-400" },
+  [TaskStatus.DONE]: { label: "Done", colorClass: "text-success", dot: "bg-green-400" },
 };
 
 export const KanbanColumnHeader = ({ board, taskCount }: KanbanColumnHeaderProps) => {
@@ -26,19 +26,16 @@ export const KanbanColumnHeader = ({ board, taskCount }: KanbanColumnHeaderProps
     <div className="flex items-center justify-between px-1 py-2 mb-2">
       <div className="flex items-center gap-2">
         <span className={cn("size-2 rounded-full shrink-0", config.dot)} />
-        <span className="text-[13px] font-semibold" style={{ color: config.color }}>
+        <span className={cn("text-[13px] font-semibold", config.colorClass)}>
           {config.label}
         </span>
-        <span
-          className="text-[11px] font-medium px-1.5 py-0.5 rounded-md min-w-[20px] text-center"
-          style={{ background: "rgba(255,255,255,0.06)", color: "rgba(255,255,255,0.35)" }}
-        >
+        <span className="text-[11px] font-medium px-1.5 py-0.5 rounded-md min-w-[20px] text-center bg-surface-2 text-muted-foreground/70">
           {taskCount}
         </span>
       </div>
       <button
         onClick={() => open()}
-        className="p-1 rounded-md text-white/25 hover:text-white/60 hover:bg-white/[0.06] transition-all"
+        className="p-1 rounded-md text-muted-foreground/60 hover:text-muted-foreground hover:bg-surface-2 transition-all"
         aria-label="Add work item"
       >
         <Plus className="size-3.5" />

--- a/src/features/workspaces/components/members-list.tsx
+++ b/src/features/workspaces/components/members-list.tsx
@@ -7,6 +7,7 @@ import { useUpdateMember } from "@/features/members/api/use-update-member";
 import { MemberRole } from "@/features/members/types";
 import { MemberAvatar } from "@/features/members/components/member-avatar";
 import { useConfirm } from "@/hooks/use-confirm";
+import { cn } from "@/lib/utils";
 import {
   MoreHorizontal,
   ShieldCheck,
@@ -26,11 +27,6 @@ import {
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { formatDistanceToNow } from "date-fns";
-
-const PRIMARY = "#4F7CFF";
-const BORDER_SUBTLE = "rgba(255,255,255,0.06)";
-const BG_HOVER = "rgba(255,255,255,0.04)";
-const TEXT_DIM = "rgba(255,255,255,0.3)";
 
 export const MembersList = () => {
   const workspaceId = useWorkspaceId();
@@ -54,58 +50,47 @@ export const MembersList = () => {
   const handleDelete = async (memberId: string) => {
     const ok = await confirm();
     if (!ok) return;
-    deleteMember(
-      { param: { memberId } },
-      {
-        onSuccess: () => {
-          window.location.reload();
-        },
-      }
-    );
+    deleteMember({ param: { memberId } }, { onSuccess: () => window.location.reload() });
   };
 
   let rowContent: React.ReactNode;
   if (isLoading) {
     rowContent = (
       <div className="flex items-center justify-center py-16">
-        <Loader className="size-5 animate-spin" style={{ color: "rgba(255,255,255,0.2)" }} />
+        <Loader className="size-5 animate-spin text-muted-foreground/30" />
       </div>
     );
   } else if (members.length === 0) {
     rowContent = (
       <div className="flex flex-col items-center justify-center py-16 gap-2">
-        <UserCircle2 className="size-8" style={{ color: "rgba(255,255,255,0.1)" }} />
-        <p className="text-sm text-white/30">No members found</p>
+        <UserCircle2 className="size-8 text-muted-foreground/20" />
+        <p className="text-sm text-muted-foreground/40">No members found</p>
       </div>
     );
   } else {
     rowContent = members.map((member) => (
       <div
         key={member.$id}
-        className="group grid grid-cols-[2fr_1fr_1fr_1fr_48px] gap-4 items-center px-6 py-4 hover:bg-white/[0.02] transition-colors"
-        style={{ borderBottom: `1px solid ${BG_HOVER}` }}
+        className="group grid grid-cols-[2fr_1fr_1fr_1fr_48px] gap-4 items-center px-6 py-4 hover:bg-surface-2 transition-colors border-b border-border/30"
       >
         {/* Avatar + Name */}
         <div className="flex items-center gap-3 min-w-0">
-          <MemberAvatar
-            name={member.name ?? member.email ?? "?"}
-            className="size-8 shrink-0"
-          />
+          <MemberAvatar name={member.name ?? member.email ?? "?"} className="size-8 shrink-0" />
           <div className="min-w-0">
-            <p className="text-[14px] font-medium text-white truncate">{member.name ?? "Unknown"}</p>
-            <p className="text-[12px] truncate" style={{ color: "rgba(255,255,255,0.35)" }}>{member.email}</p>
+            <p className="text-[14px] font-medium text-foreground truncate">{member.name ?? "Unknown"}</p>
+            <p className="text-[12px] text-muted-foreground/60 truncate">{member.email}</p>
           </div>
         </div>
 
         {/* Role badge */}
         <div>
           <span
-            className="inline-flex items-center gap-1.5 text-[11px] font-semibold px-2 py-1 rounded-md"
-            style={
+            className={cn(
+              "inline-flex items-center gap-1.5 text-[11px] font-semibold px-2 py-1 rounded-md",
               member.role === MemberRole.ADMIN
-                ? { background: "rgba(79,124,255,0.12)", color: PRIMARY }
-                : { background: BORDER_SUBTLE, color: "rgba(255,255,255,0.45)" }
-            }
+                ? "bg-primary/10 text-primary"
+                : "bg-border/40 text-muted-foreground"
+            )}
           >
             {member.role === MemberRole.ADMIN && <ShieldCheck className="size-3" />}
             {member.role === MemberRole.ADMIN ? "Admin" : "Member"}
@@ -113,16 +98,16 @@ export const MembersList = () => {
         </div>
 
         {/* Joined */}
-        <p className="text-[13px]" style={{ color: "rgba(255,255,255,0.35)" }}>
+        <p className="text-[13px] text-muted-foreground/60">
           {formatDistanceToNow(new Date(member.$createdAt ?? Date.now()), { addSuffix: true })}
         </p>
 
         {/* Workload placeholder */}
         <div className="flex items-center gap-2">
-          <div className="flex-1 h-1 rounded-full" style={{ background: "rgba(255,255,255,0.08)" }}>
-            <div className="h-1 rounded-full w-1/3" style={{ background: PRIMARY }} />
+          <div className="flex-1 h-1 rounded-full bg-border/40">
+            <div className="h-1 rounded-full w-1/3 bg-primary" />
           </div>
-          <span className="text-[11px]" style={{ color: TEXT_DIM }}>33%</span>
+          <span className="text-[11px] text-muted-foreground/40">33%</span>
         </div>
 
         {/* Actions */}
@@ -130,34 +115,30 @@ export const MembersList = () => {
           <DropdownMenuTrigger asChild>
             <button
               aria-label={`Member actions for ${member.name ?? member.email ?? "member"}`}
-              className="flex items-center justify-center size-8 rounded-lg opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:bg-white/[0.06] hover:bg-white/[0.06] transition-all"
+              className="flex items-center justify-center size-8 rounded-lg opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-surface-2 transition-all"
             >
-              <MoreHorizontal className="size-4 text-white/40" />
+              <MoreHorizontal className="size-4 text-muted-foreground" />
             </button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            style={{ background: "#16233F", border: "1px solid rgba(255,255,255,0.08)" }}
-            className="min-w-[180px] rounded-xl p-1"
-          >
+          <DropdownMenuContent align="end" className="min-w-[180px] rounded-xl p-1">
             <DropdownMenuItem
               onClick={() => updateMember({ param: { memberId: member.$id }, json: { role: MemberRole.ADMIN } })}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-white/70 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm cursor-pointer"
             >
-              <ShieldCheck className="size-4 text-blue-400" />
+              <ShieldCheck className="size-4 text-primary" />
               Make Admin
             </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => updateMember({ param: { memberId: member.$id }, json: { role: MemberRole.MEMBER } })}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-white/70 hover:text-white hover:bg-white/[0.06] cursor-pointer"
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm cursor-pointer"
             >
-              <UserCircle2 className="size-4 text-white/40" />
+              <UserCircle2 className="size-4 text-muted-foreground" />
               Set as Member
             </DropdownMenuItem>
-            <DropdownMenuSeparator className="my-1 bg-white/[0.06]" />
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => handleDelete(member.$id)}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-red-400 hover:bg-red-500/10 cursor-pointer"
+              className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-destructive cursor-pointer"
             >
               <UserMinus className="size-4" />
               Remove Member
@@ -175,39 +156,29 @@ export const MembersList = () => {
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-white">Members</h1>
-          <p className="text-[14px] mt-1" style={{ color: "rgba(255,255,255,0.45)" }}>
+          <h1 className="text-2xl font-bold text-foreground">Members</h1>
+          <p className="text-[14px] mt-1 text-muted-foreground">
             {members.length} member{members.length === 1 ? "" : "s"} in this workspace
           </p>
         </div>
         <div className="flex items-center gap-3">
           {/* Search */}
-          <div
-            className="flex items-center gap-2 px-3 h-9 rounded-btn"
-            style={{ background: BG_HOVER, border: "1px solid rgba(255,255,255,0.07)" }}
-          >
-            <Search className="size-3.5 shrink-0" style={{ color: TEXT_DIM }} />
+          <div className="flex items-center gap-2 px-3 h-9 rounded-btn bg-surface border border-border/40">
+            <Search className="size-3.5 shrink-0 text-muted-foreground/40" />
             <input
               type="text"
               aria-label="Search members"
               placeholder="Search members..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="bg-transparent text-sm outline-none placeholder:text-white/30 text-white w-48"
+              className="bg-transparent text-sm outline-none placeholder:text-muted-foreground/40 text-foreground w-48"
             />
           </div>
           {/* Invite button */}
           <button
             type="button"
             onClick={() => router.push(`/workspace/${workspaceId}/settings`)}
-            className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn transition-all"
-            style={{
-              background: PRIMARY,
-              color: "#fff",
-              boxShadow: "0 0 0 1px rgba(79,124,255,0.3), 0 4px 12px rgba(79,124,255,0.25)",
-            }}
-            onMouseEnter={e => { (e.currentTarget as HTMLButtonElement).style.background = "#3d6ae8"; }}
-            onMouseLeave={e => { (e.currentTarget as HTMLButtonElement).style.background = PRIMARY; }}
+            className="flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-btn bg-primary text-white hover:bg-primary/90 transition-all shadow-glow-primary"
           >
             <UserPlus className="size-4" />
             Invite Member
@@ -216,19 +187,9 @@ export const MembersList = () => {
       </div>
 
       {/* Table */}
-      <div
-        className="rounded-card overflow-hidden"
-        style={{
-          background: "#0F172A",
-          border: `1px solid ${BORDER_SUBTLE}`,
-          boxShadow: `0 0 0 1px ${BG_HOVER}, 0 8px 30px rgba(0,0,0,0.25)`,
-        }}
-      >
+      <div className="rounded-card overflow-hidden bg-surface border border-border/40 shadow-chronicle-sm">
         {/* Table header */}
-        <div
-          className="grid grid-cols-[2fr_1fr_1fr_1fr_48px] gap-4 px-6 py-3 text-[11px] font-semibold uppercase tracking-widest"
-          style={{ color: TEXT_DIM, borderBottom: `1px solid ${BORDER_SUBTLE}` }}
-        >
+        <div className="grid grid-cols-[2fr_1fr_1fr_1fr_48px] gap-4 px-6 py-3 text-[11px] font-semibold uppercase tracking-widest text-muted-foreground/40 border-b border-border/40">
           <span>Member</span>
           <span>Role</span>
           <span>Joined</span>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
+        panel: "hsl(var(--panel))",
         surface: {
           DEFAULT: "hsl(var(--surface-1))",
           "2": "hsl(var(--surface-2))",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Token foundation**: Restructured `globals.css` with `:root` (shared), `.dark` (deep navy), `.light` (warm white) — eliminates all hardcoded `#0F172A`, `rgba(255,255,255,...)` across 25+ files
- **Shared primitives**: Added `DashboardCard` and `WorkItemDetailLayout` in `src/components/chronicle/`
- **Dashboard greeting**: Fixed to use authenticated user's first name via `useCurrent()`, not workspace name
- **Kanban DnD**: Full behavioral fix — optimistic update, `isPending` drag-lock during in-flight requests, server-state rollback on failure via `queryClient.invalidateQueries` in `onError`
- **Date picker**: Fixed Radix Popover blocked by Dialog focus trap (`modal={false}` + `zIndex: 9999`)
- **Issue structure**: Removed "Epics" from sidebar nav; Epic is now a filter pill on Work Items page (All | Epic | Story | Bug | Spike)
- **Create modal auto-select**: Extended `NavItem` with `issueType?: IssueType`; nav actions pass it through to `openTaskModal({ projectId, issueType })`; generic Work Items action leaves type unset
- **ChronicleDataTable**: Renamed `DataTable` export; backward-compat alias preserved; `h-12` rows, `border-border/40`, `hover:bg-surface`
- **Settings unification**: `SettingsLayout` + `SettingsCard` now use token classes; user account settings migrated to `SettingsLayout`; `DottedSeperator` replaced with `h-px bg-border/40`
- **Profile dropdown redesign**: Removed "Generate Agent Token"; added Connected Accounts, OAuth Access, Sessions; Chronicle styling (`w-72`, `size-16` avatar, no dotted separators, `h-11` menu items)
- **Intelligence panel, members list, sprints, projects**: All inline styles replaced with Tailwind tokens

## Test plan

- [ ] Dashboard greeting shows authenticated user's first name
- [ ] Dark theme: deep navy environment; Light theme: warm white environment
- [ ] Sprint board: drag card → status persists after page refresh; metrics update
- [ ] Sprint board: dragging is disabled while bulk-update is in-flight
- [ ] Release modal: click date → calendar opens, date is selectable
- [ ] Work Items page has All | Epic | Story | Bug | Spike filter pills; no "Epics" in sidebar
- [ ] Profile dropdown: no "Generate Agent Token"; OAuth Access / Sessions items present
- [ ] Settings pages (workspace, project, account) share identical card/tab styling
- [ ] `grep -r "#0F172A\|rgba(255,255,255" src/` returns only dashboard SVG constants

https://claude.ai/code/session_01LRXdJp5YFxMZFzNCiu6Crs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRXdJp5YFxMZFzNCiu6Crs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced dashboard card components with improved visual styling and consistency.
  * New layout components for better work item organization and display.

* **Improvements**
  * Updated theme system with improved dark and light mode support across all dashboards and detail views.
  * Refreshed visual design with consistent color palette and styling throughout the application.
  * Improved settings pages with reorganized layout and better visual hierarchy.

* **Bug Fixes**
  * Fixed query invalidation during bulk task updates to ensure data consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->