### PR TITLE
Fix docs, activity buttons, Knowledge Dashboard dummy data, and Firestore index policy

### DIFF
--- a/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
@@ -189,9 +189,9 @@ function EventCard({ event, idx }: Readonly<{ event: ActivityEvent; idx: number 
   const handleCopyLink = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     if (event.url) {
-      navigator.clipboard.writeText(window.location.origin + event.url).then(() => {
-        toast.success("Link copied to clipboard");
-      });
+      navigator.clipboard.writeText(window.location.origin + event.url)
+        .then(() => toast.success("Link copied to clipboard"))
+        .catch(() => toast.error("Failed to copy link"));
     }
   };
 
@@ -496,7 +496,9 @@ export function ActivityClient() {
       const proj = projects.find((p) => p.$id === task.projectId)?.name ?? "";
       const createdAt = new Date(task.$createdAt);
 
-      const taskUrl = `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`;
+      const taskUrl = task.projectId
+        ? `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`
+        : undefined;
       events.push({
         id: `task-${task.$id}`,
         type: "issue_created",
@@ -575,7 +577,7 @@ export function ActivityClient() {
     }
 
     return events.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
-  }, [tasks, members, docs, projects, getMemberName]);
+  }, [tasks, members, docs, projects, getMemberName, workspaceId]);
 
   const newCount = useMemo(
     () => allEvents.filter((e) => e.isNew).length,

--- a/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
@@ -17,7 +17,10 @@ import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetProjects } from "@/features/projects/api/use-get-projects";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useDocuments } from "@/features/docs/hooks/use-documents";
-import { IssueType, TaskStatus } from "@/features/tasks/types";
+import { IssueType, TaskStatus, type Task } from "@/features/tasks/types";
+import type { Project } from "@/features/projects/types";
+import type { Member } from "@/features/members/types";
+import type { ChronicleDocument } from "@/lib/docs-firestore";
 import { toast } from "sonner";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -189,7 +192,7 @@ function EventCard({ event, idx }: Readonly<{ event: ActivityEvent; idx: number 
   const handleCopyLink = (e: { stopPropagation: () => void }) => {
     e.stopPropagation();
     if (event.url) {
-      navigator.clipboard.writeText(window.location.origin + event.url)
+      navigator.clipboard.writeText(globalThis.location.origin + event.url)
         .then(() => toast.success("Link copied to clipboard"))
         .catch(() => toast.error("Failed to copy link"));
     }
@@ -463,6 +466,74 @@ function CollaborationActivity({ items }: Readonly<{ items: CollabItem[] }>) {
 
 // ─── Main component ────────────────────────────────────────────────────────────
 
+// ─── Event builders ───────────────────────────────────────────────────────────
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function taskUrl(task: Task, workspaceId: string): string | undefined {
+  if (!task.projectId) return undefined;
+  return `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`;
+}
+
+function initial(name: string): string {
+  return (name[0] ?? "?").toUpperCase();
+}
+
+function buildTaskEvents(
+  tasks: Task[],
+  workspaceId: string,
+  projects: Project[],
+  getMemberName: (id: string) => string,
+  now: number,
+): ActivityEvent[] {
+  const events: ActivityEvent[] = [];
+  for (const task of tasks) {
+    const name = getMemberName(task.assigneeId);
+    const color = actorColor(name);
+    const proj = projects.find((p) => p.$id === task.projectId)?.name ?? "";
+    const createdAt = new Date(task.$createdAt);
+    const url = taskUrl(task, workspaceId);
+    events.push({ id: `task-${task.$id}`, type: "issue_created", actor: name, actorInitial: initial(name), actorColor: color, action: "created", target: task.name, project: proj, timestamp: createdAt, isNew: now - createdAt.getTime() < ONE_DAY_MS, url });
+    if (task.status === TaskStatus.DONE) {
+      const updatedAtStr = (task as { $updatedAt?: string }).$updatedAt;
+      if (updatedAtStr && updatedAtStr !== task.$createdAt) {
+        const doneAt = new Date(updatedAtStr);
+        events.push({ id: `done-${task.$id}`, type: "task_complete", actor: name, actorInitial: initial(name), actorColor: color, action: "completed", target: task.name, project: proj, timestamp: doneAt, isNew: now - doneAt.getTime() < ONE_DAY_MS, url });
+      }
+    }
+  }
+  return events;
+}
+
+function buildMemberEvents(members: Member[], workspaceId: string, now: number): ActivityEvent[] {
+  return members.map((member) => {
+    const name = member.name ?? "Someone";
+    const joinedAt = new Date(member.$createdAt);
+    return { id: `member-${member.$id}`, type: "member_joined" as const, actor: name, actorInitial: initial(name), actorColor: actorColor(name), action: "joined", target: "workspace", project: "", timestamp: joinedAt, isNew: now - joinedAt.getTime() < ONE_DAY_MS, url: `/workspace/${workspaceId}/members` };
+  });
+}
+
+function buildDocEvents(
+  docs: ChronicleDocument[],
+  workspaceId: string,
+  projects: Project[],
+  getMemberName: (id: string) => string,
+  now: number,
+): ActivityEvent[] {
+  return docs.map((docItem) => {
+    const name = getMemberName(docItem.createdBy);
+    const proj = docItem.projectId ? (projects.find((p) => p.$id === docItem.projectId)?.name ?? "") : "";
+    const docAt = new Date(docItem.updatedAt);
+    const url = docItem.projectId
+      ? `/workspace/${workspaceId}/project/${docItem.projectId}/docs?docId=${docItem.id}`
+      : `/workspace/${workspaceId}/docs?docId=${docItem.id}`;
+    const action = docItem.updatedAt === docItem.createdAt ? "created" : "updated";
+    return { id: `doc-${docItem.id}`, type: "doc_edit" as const, actor: name, actorInitial: initial(name), actorColor: actorColor(name), action, target: docItem.title, project: proj, timestamp: docAt, isNew: now - docAt.getTime() < ONE_DAY_MS, url };
+  });
+}
+
+// ─── Main component ────────────────────────────────────────────────────────────
+
 export function ActivityClient() {
   const workspaceId = useWorkspaceId();
   const [dateRange, setDateRange] = useState<DateRange>("7d");
@@ -487,96 +558,11 @@ export function ActivityClient() {
 
   const allEvents = useMemo((): ActivityEvent[] => {
     const now = Date.now();
-    const oneDayMs = 24 * 60 * 60 * 1000;
-    const events: ActivityEvent[] = [];
-
-    for (const task of tasks) {
-      const name = getMemberName(task.assigneeId);
-      const color = actorColor(name);
-      const proj = projects.find((p) => p.$id === task.projectId)?.name ?? "";
-      const createdAt = new Date(task.$createdAt);
-
-      const taskUrl = task.projectId
-        ? `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`
-        : undefined;
-      events.push({
-        id: `task-${task.$id}`,
-        type: "issue_created",
-        actor: name,
-        actorInitial: (name[0] ?? "?").toUpperCase(),
-        actorColor: color,
-        action: "created",
-        target: task.name,
-        project: proj,
-        timestamp: createdAt,
-        isNew: now - createdAt.getTime() < oneDayMs,
-        url: taskUrl,
-      });
-
-      if (task.status === TaskStatus.DONE) {
-        const updatedAtStr = (task as { $updatedAt?: string }).$updatedAt;
-        if (updatedAtStr && updatedAtStr !== task.$createdAt) {
-          const doneAt = new Date(updatedAtStr);
-          events.push({
-            id: `done-${task.$id}`,
-            type: "task_complete",
-            actor: name,
-            actorInitial: (name[0] ?? "?").toUpperCase(),
-            actorColor: color,
-            action: "completed",
-            target: task.name,
-            project: proj,
-            timestamp: doneAt,
-            isNew: now - doneAt.getTime() < oneDayMs,
-            url: taskUrl,
-          });
-        }
-      }
-    }
-
-    for (const member of members) {
-      const name = member.name ?? "Someone";
-      const joinedAt = new Date(member.$createdAt);
-      events.push({
-        id: `member-${member.$id}`,
-        type: "member_joined",
-        actor: name,
-        actorInitial: (name[0] ?? "?").toUpperCase(),
-        actorColor: actorColor(name),
-        action: "joined",
-        target: "workspace",
-        project: "",
-        timestamp: joinedAt,
-        isNew: now - joinedAt.getTime() < oneDayMs,
-        url: `/workspace/${workspaceId}/members`,
-      });
-    }
-
-    for (const docItem of docs) {
-      const name = getMemberName(docItem.createdBy);
-      const proj = docItem.projectId
-        ? projects.find((p) => p.$id === docItem.projectId)?.name ?? ""
-        : "";
-      const docAt = new Date(docItem.updatedAt);
-      const docUrl = docItem.projectId
-        ? `/workspace/${workspaceId}/project/${docItem.projectId}/docs?docId=${docItem.id}`
-        : `/workspace/${workspaceId}/docs?docId=${docItem.id}`;
-      events.push({
-        id: `doc-${docItem.id}`,
-        type: "doc_edit",
-        actor: name,
-        actorInitial: (name[0] ?? "?").toUpperCase(),
-        actorColor: actorColor(name),
-        action: docItem.updatedAt === docItem.createdAt ? "created" : "updated",
-        target: docItem.title,
-        project: proj,
-        timestamp: docAt,
-        isNew: now - docAt.getTime() < oneDayMs,
-        url: docUrl,
-      });
-    }
-
-    return events.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
+    return [
+      ...buildTaskEvents(tasks, workspaceId, projects, getMemberName, now),
+      ...buildMemberEvents(members, workspaceId, now),
+      ...buildDocEvents(docs, workspaceId, projects, getMemberName, now),
+    ].sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime());
   }, [tasks, members, docs, projects, getMemberName, workspaceId]);
 
   const newCount = useMemo(

--- a/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
@@ -11,12 +11,14 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow, format } from "date-fns";
+import { useRouter } from "next/navigation";
 import { useGetTasks } from "@/features/tasks/api/use-get-tasks";
 import { useGetMembers } from "@/features/members/api/use-get-members";
 import { useGetProjects } from "@/features/projects/api/use-get-projects";
 import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
 import { useDocuments } from "@/features/docs/hooks/use-documents";
-import { TaskStatus } from "@/features/tasks/types";
+import { IssueType, TaskStatus } from "@/features/tasks/types";
+import { toast } from "sonner";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -37,6 +39,7 @@ interface ActivityEvent {
   timestamp: Date;
   isNew?: boolean;
   meta?: string;
+  url?: string;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -52,6 +55,15 @@ const EVENT_TYPE_LABELS: Record<EventType, string> = {
 };
 
 const ACTOR_COLORS = ["#4F7CFF", "#22c55e", "#a855f7", "#f59e0b", "#ef4444", "#06b6d4", "#f97316"];
+
+function taskTypeSegment(issueType?: IssueType): string {
+  switch (issueType) {
+    case IssueType.EPIC: return "epic";
+    case IssueType.SPIKE: return "spike";
+    case IssueType.BUG: return "bug";
+    default: return "story";
+  }
+}
 
 function actorColor(name: string): string {
   let hash = 0;
@@ -164,9 +176,24 @@ function WorkspaceSummary({ stats }: Readonly<{ stats: SummaryStats }>) {
 
 function EventCard({ event, idx }: Readonly<{ event: ActivityEvent; idx: number }>) {
   const [showActions, setShowActions] = useState(false);
+  const router = useRouter();
   const cfg = EVENT_CONFIG[event.type];
   const Icon = cfg.icon;
   const timeAgo = formatDistanceToNow(event.timestamp, { addSuffix: true });
+
+  const handleOpen = (e: { stopPropagation: () => void }) => {
+    e.stopPropagation();
+    if (event.url) router.push(event.url);
+  };
+
+  const handleCopyLink = (e: { stopPropagation: () => void }) => {
+    e.stopPropagation();
+    if (event.url) {
+      navigator.clipboard.writeText(window.location.origin + event.url).then(() => {
+        toast.success("Link copied to clipboard");
+      });
+    }
+  };
 
   return (
     <motion.div
@@ -224,14 +251,20 @@ function EventCard({ event, idx }: Readonly<{ event: ActivityEvent; idx: number 
               transition={{ duration: 0.12 }}
               className="flex items-center gap-1"
             >
-              {["Open", "Copy link"].map((label) => (
-                <button
-                  key={label}
-                  className="text-[10px] px-2 py-1 rounded-md bg-surface border border-border/50 text-muted-foreground hover:text-foreground hover:border-border transition-all"
-                >
-                  {label}
-                </button>
-              ))}
+              <button
+                onClick={handleOpen}
+                disabled={!event.url}
+                className="text-[10px] px-2 py-1 rounded-md bg-surface border border-border/50 text-muted-foreground hover:text-foreground hover:border-border transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Open
+              </button>
+              <button
+                onClick={handleCopyLink}
+                disabled={!event.url}
+                className="text-[10px] px-2 py-1 rounded-md bg-surface border border-border/50 text-muted-foreground hover:text-foreground hover:border-border transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Copy link
+              </button>
             </motion.div>
           ) : (
             <motion.span
@@ -463,6 +496,7 @@ export function ActivityClient() {
       const proj = projects.find((p) => p.$id === task.projectId)?.name ?? "";
       const createdAt = new Date(task.$createdAt);
 
+      const taskUrl = `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`;
       events.push({
         id: `task-${task.$id}`,
         type: "issue_created",
@@ -474,6 +508,7 @@ export function ActivityClient() {
         project: proj,
         timestamp: createdAt,
         isNew: now - createdAt.getTime() < oneDayMs,
+        url: taskUrl,
       });
 
       if (task.status === TaskStatus.DONE) {
@@ -491,6 +526,7 @@ export function ActivityClient() {
             project: proj,
             timestamp: doneAt,
             isNew: now - doneAt.getTime() < oneDayMs,
+            url: taskUrl,
           });
         }
       }
@@ -510,6 +546,7 @@ export function ActivityClient() {
         project: "",
         timestamp: joinedAt,
         isNew: now - joinedAt.getTime() < oneDayMs,
+        url: `/workspace/${workspaceId}/members`,
       });
     }
 
@@ -519,6 +556,9 @@ export function ActivityClient() {
         ? projects.find((p) => p.$id === docItem.projectId)?.name ?? ""
         : "";
       const docAt = new Date(docItem.updatedAt);
+      const docUrl = docItem.projectId
+        ? `/workspace/${workspaceId}/project/${docItem.projectId}/docs?docId=${docItem.id}`
+        : `/workspace/${workspaceId}/docs?docId=${docItem.id}`;
       events.push({
         id: `doc-${docItem.id}`,
         type: "doc_edit",
@@ -530,6 +570,7 @@ export function ActivityClient() {
         project: proj,
         timestamp: docAt,
         isNew: now - docAt.getTime() < oneDayMs,
+        url: docUrl,
       });
     }
 

--- a/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/activity/client.tsx
@@ -471,8 +471,10 @@ function CollaborationActivity({ items }: Readonly<{ items: CollabItem[] }>) {
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 function taskUrl(task: Task, workspaceId: string): string | undefined {
-  if (!task.projectId) return undefined;
-  return `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`;
+  if (task.projectId) {
+    return `/workspace/${workspaceId}/project/${task.projectId}/${taskTypeSegment(task.issueType)}/${task.$id}`;
+  }
+  return undefined;
 }
 
 function initial(name: string): string {

--- a/src/app/(dashboard)/workspace/[workspaceId]/knowledge/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/knowledge/client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import {
   AreaChart, Area, BarChart, Bar, XAxis, YAxis,
@@ -8,113 +8,93 @@ import {
 } from "recharts";
 import {
   AlertTriangle, ArrowRight, BookOpen, CheckCircle2,
-  Clock, Eye, FileText, Link2, RefreshCw,
-  Sparkles, TrendingDown, TrendingUp, XCircle, Activity,
-  Zap, Shield,
+  Clock, Eye, FileText,
+  RefreshCw, Sparkles, TrendingUp, TrendingDown, XCircle,
+  Activity, Zap, Shield, FolderKanban,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { format, formatDistanceToNow } from "date-fns";
+import { useWorkspaceId } from "@/features/workspaces/hooks/use-workspace-id";
+import { useDocuments } from "@/features/docs/hooks/use-documents";
+import { useGetProjects } from "@/features/projects/api/use-get-projects";
+import { useGetMembers } from "@/features/members/api/use-get-members";
+import { useGetTasks } from "@/features/tasks/api/use-get-tasks";
+import { TaskStatus } from "@/features/tasks/types";
+import type { ChronicleDocument } from "@/lib/docs-firestore";
+import type { Project } from "@/features/projects/types";
+import type { Member } from "@/features/members/types";
+import type { Task } from "@/features/tasks/types";
 
-// ─── Seed data ────────────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const DATE_RANGES = ["Today", "7d", "30d", "All time"] as const;
 type DateRange = (typeof DATE_RANGES)[number];
 
-const growthData = [
-  { month: "Jan", docs: 12, decisions: 3, notes: 8 },
-  { month: "Feb", docs: 18, decisions: 5, notes: 14 },
-  { month: "Mar", docs: 22, decisions: 4, notes: 19 },
-  { month: "Apr", docs: 28, decisions: 6, notes: 24 },
-  { month: "May", docs: 34, decisions: 8, notes: 31 },
-];
+const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
 
-const recentDocs = [
-  { id: "1", title: "Authentication Flow v2", project: "Chronicle", editor: "Matrim", time: "18 min ago", views: 234, icon: "🔐", tags: ["Auth", "Firebase"] },
-  { id: "2", title: "MCP Integration Notes", project: "Spendwise", editor: "Matrim", time: "2 hours ago", views: 127, icon: "🔌", tags: ["MCP", "API"] },
-  { id: "3", title: "Firebase Rules Reference", project: "Jarvis", editor: "System", time: "1 day ago", views: 180, icon: "🔥", tags: ["Firebase", "Security"] },
-  { id: "4", title: "API Architecture Guide", project: "Chronicle", editor: "Matrim", time: "3 days ago", views: 312, icon: "📐", tags: ["API", "Architecture"] },
-  { id: "5", title: "Sprint Retrospective Template", project: "Spendwise", editor: "Matrim", time: "5 days ago", views: 89, icon: "📋", tags: ["Process"] },
-];
-
-const topDocs = [
-  { title: "API Architecture Guide", views: 312, trend: 12, icon: "📐", desc: "End-to-end API design patterns and conventions" },
-  { title: "Authentication Flow v2", views: 234, trend: 23, icon: "🔐", desc: "OAuth and session management implementation" },
-  { title: "Firebase Rules Reference", views: 180, trend: 8, icon: "🔥", desc: "Security rules for Firestore collections" },
-  { title: "MCP Integration Notes", views: 127, trend: -3, icon: "🔌", desc: "Model Context Protocol setup and usage" },
-  { title: "Sprint Retro Template", views: 89, trend: 4, icon: "📋", desc: "Structured retrospective format for teams" },
-];
-
-const activeTopics = [
-  { tag: "Authentication", count: 24 },
-  { tag: "Firebase", count: 18 },
-  { tag: "AI", count: 11 },
-  { tag: "Payments", count: 8 },
-  { tag: "MCP", count: 6 },
-  { tag: "Sessions", count: 5 },
-];
-
-const decisions = [
-  { id: "1", title: "Switched auth provider to Firebase", reason: "Lower complexity, native OAuth support, better SDK", status: "accepted" as const, date: "Apr 2026", owner: "Matrim", project: "Chronicle", tags: ["Auth", "Firebase"] },
-  { id: "2", title: "Rejected Prisma ORM migration", reason: "Firestore already established across all projects", status: "rejected" as const, date: "Mar 2026", owner: "Matrim", project: "Chronicle", tags: ["Database"] },
-  { id: "3", title: "Adopted Chronicle design system", reason: "Consistency across all product surfaces", status: "accepted" as const, date: "Feb 2026", owner: "Matrim", project: "All projects", tags: ["Design", "UI"] },
-  { id: "4", title: "Migrated from Appwrite to Firebase", reason: "Better OAuth support and unified auth/db stack", status: "accepted" as const, date: "Jan 2026", owner: "Matrim", project: "Chronicle", tags: ["Auth", "Migration"] },
-];
-
-const timeline = [
-  { month: "Jan 2026", event: "Project initialized", detail: "Repository setup, base architecture defined", icon: "🚀" },
-  { month: "Feb 2026", event: "Chronicle design system", detail: "Unified design tokens and component library", icon: "🎨" },
-  { month: "Mar 2026", event: "Knowledge module added", detail: "Docs, decisions, and architecture tracking", icon: "📚" },
-  { month: "Apr 2026", event: "MCP support integrated", detail: "Model Context Protocol for AI tool connectivity", icon: "🔌" },
-  { month: "May 2026", event: "Docs indexing launched", detail: "Cross-project knowledge linking and search", icon: "🔍" },
-];
-
-const crossProjects = [
-  { from: "Chronicle", to: "Spendwise", shared: ["Auth package", "Design system", "Session utilities"], strength: "high" as const },
-  { from: "Chronicle", to: "Jarvis", shared: ["API utilities", "Firebase config", "Error handlers"], strength: "medium" as const },
-  { from: "Spendwise", to: "Jarvis", shared: ["MCP integration", "Workspace types"], strength: "low" as const },
-];
-
-const alerts = [
-  { type: "warning" as const, message: "3 docs haven't been updated in over 90 days", action: "Review stale docs" },
-  { type: "error" as const, message: "Duplicate authentication implementation found across 2 projects", action: "Merge logic" },
-  { type: "info" as const, message: "Decision record 'Rejected Prisma' is missing an owner", action: "Assign owner" },
-];
-
-const evolutionData = [
-  { month: "Jan", commits: 45, docs: 8, notes: 12, decisions: 2 },
-  { month: "Feb", commits: 62, docs: 14, notes: 18, decisions: 4 },
-  { month: "Mar", commits: 78, docs: 19, notes: 24, decisions: 3 },
-  { month: "Apr", commits: 91, docs: 26, notes: 31, decisions: 6 },
-  { month: "May", commits: 84, docs: 34, notes: 38, decisions: 8 },
-];
-
-// ─── Graph ────────────────────────────────────────────────────────────────────
-
-interface GraphNode {
-  id: string;
-  label: string;
-  x: number;
-  y: number;
-  color: string;
-  r: number;
-  connections: string[];
+function getLastNMonths(n: number): string[] {
+  const months: string[] = [];
+  const now = new Date();
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    months.push(format(d, "MMM"));
+  }
+  return months;
 }
 
-const GRAPH_NODES: GraphNode[] = [
-  { id: "auth",        label: "Auth",        x: 210, y: 180, color: "#4F7CFF", r: 30, connections: ["firebase", "sessions", "permissions", "api"] },
-  { id: "firebase",   label: "Firebase",    x: 78,  y: 128, color: "#f59e0b", r: 22, connections: ["auth", "permissions"] },
-  { id: "sessions",   label: "Sessions",    x: 78,  y: 240, color: "#4F7CFF", r: 18, connections: ["auth", "api"] },
-  { id: "permissions",label: "Permissions", x: 238, y: 58,  color: "#f59e0b", r: 18, connections: ["auth", "firebase"] },
-  { id: "api",        label: "API",         x: 380, y: 180, color: "#22c55e", r: 26, connections: ["auth", "mcp", "chronicle", "billing", "sessions"] },
-  { id: "mcp",        label: "MCP",         x: 476, y: 108, color: "#a855f7", r: 20, connections: ["api", "chronicle"] },
-  { id: "billing",    label: "Billing",     x: 476, y: 258, color: "#22c55e", r: 18, connections: ["api"] },
-  { id: "chronicle",  label: "Chronicle",   x: 308, y: 292, color: "#4F7CFF", r: 22, connections: ["api", "mcp"] },
-];
+function buildMonthlyGrowth(docs: ChronicleDocument[]) {
+  const months = getLastNMonths(5);
+  const counts: Record<string, number> = Object.fromEntries(months.map((m) => [m, 0]));
+  for (const doc of docs) {
+    const key = format(new Date(doc.createdAt), "MMM");
+    if (key in counts) counts[key]++;
+  }
+  let cumulative = 0;
+  return months.map((month) => {
+    cumulative += counts[month];
+    return { month, docs: cumulative, added: counts[month] };
+  });
+}
 
-const GRAPH_EDGES: [string, string][] = [
-  ["auth", "firebase"], ["auth", "sessions"], ["auth", "permissions"], ["auth", "api"],
-  ["api", "mcp"], ["api", "chronicle"], ["api", "billing"], ["api", "sessions"],
-  ["mcp", "chronicle"], ["firebase", "permissions"],
-];
+function buildEvolutionData(docs: ChronicleDocument[], tasks: Task[]) {
+  const months = getLastNMonths(5);
+  const data: Record<string, { month: string; docs: number; tasks: number; done: number }> = Object.fromEntries(
+    months.map((m) => [m, { month: m, docs: 0, tasks: 0, done: 0 }])
+  );
+  for (const doc of docs) {
+    const key = format(new Date(doc.createdAt), "MMM");
+    if (key in data) data[key].docs++;
+  }
+  for (const task of tasks) {
+    const key = format(new Date(task.$createdAt), "MMM");
+    if (key in data) {
+      data[key].tasks++;
+      if (task.status === TaskStatus.DONE) data[key].done++;
+    }
+  }
+  return months.map((m) => data[m]);
+}
+
+function buildActiveTopics(tasks: Task[]): { tag: string; count: number }[] {
+  const freq: Record<string, number> = {};
+  for (const task of tasks) {
+    for (const label of task.labels ?? []) {
+      freq[label] = (freq[label] ?? 0) + 1;
+    }
+  }
+  return Object.entries(freq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6)
+    .map(([tag, count]) => ({ tag, count }));
+}
+
+function computeHealthScore(docs: ChronicleDocument[], staleDocs: ChronicleDocument[]): number {
+  if (docs.length === 0) return 100;
+  const staleRatio = staleDocs.length / docs.length;
+  const unlinked = docs.filter((d) => (d.linkedWorkItems?.length ?? 0) === 0).length;
+  const unlinkedRatio = unlinked / docs.length;
+  return Math.max(0, Math.round(100 - staleRatio * 40 - unlinkedRatio * 20));
+}
 
 // ─── Primitives ───────────────────────────────────────────────────────────────
 
@@ -154,9 +134,26 @@ function Pill({ children, className }: Readonly<{ children: React.ReactNode; cla
   );
 }
 
+function EmptyState({ icon: Icon, message }: Readonly<{ icon: React.ElementType; message: string }>) {
+  return (
+    <div className="flex flex-col items-center justify-center py-10 gap-3">
+      <Icon className="size-7 text-muted-foreground/20" />
+      <p className="text-[12px] text-muted-foreground text-center">{message}</p>
+    </div>
+  );
+}
+
 // ─── Section 1: Intelligence Overview ─────────────────────────────────────────
 
-function KnowledgeHealthCard() {
+interface HealthStats {
+  score: number;
+  staleDocs: number;
+  linkedProjects: number;
+  contributors: number;
+  totalDocs: number;
+}
+
+function KnowledgeHealthCard({ stats }: Readonly<{ stats: HealthStats }>) {
   return (
     <Card className="p-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -164,26 +161,26 @@ function KnowledgeHealthCard() {
         <Shield className="size-3.5 text-success" />
       </div>
       <div className="flex flex-col gap-1">
-        <span className="text-4xl font-bold text-foreground">84%</span>
-        <div className="flex items-center gap-1.5 text-[11px] text-success">
-          <TrendingUp className="size-3" />
-          <span>+6% this month</span>
+        <span className="text-4xl font-bold text-foreground">{stats.score}%</span>
+        <div className={cn("flex items-center gap-1.5 text-[11px]", stats.score >= 70 ? "text-success" : "text-warning")}>
+          {stats.score >= 70 ? <TrendingUp className="size-3" /> : <TrendingDown className="size-3" />}
+          <span>{stats.staleDocs > 0 ? `${stats.staleDocs} stale doc${stats.staleDocs > 1 ? "s" : ""}` : "All docs current"}</span>
         </div>
       </div>
       <div className="h-1.5 rounded-full overflow-hidden bg-border/40">
         <motion.div
-          className="h-full rounded-full bg-success"
+          className={cn("h-full rounded-full", stats.score >= 70 ? "bg-success" : "bg-warning")}
           initial={{ width: 0 }}
-          animate={{ width: "84%" }}
+          animate={{ width: `${stats.score}%` }}
           transition={{ duration: 1, ease: "easeOut", delay: 0.3 }}
         />
       </div>
       <div className="grid grid-cols-2 gap-2 pt-1 border-t border-border/30">
         {[
-          { label: "Stale docs", value: "7", cls: "text-warning" },
-          { label: "Active ADRs", value: "12", cls: "text-primary" },
-          { label: "Linked projects", value: "4", cls: "text-foreground" },
-          { label: "Contributors", value: "6", cls: "text-foreground" },
+          { label: "Stale docs", value: String(stats.staleDocs), cls: stats.staleDocs > 0 ? "text-warning" : "text-foreground" },
+          { label: "Projects with docs", value: String(stats.linkedProjects), cls: "text-primary" },
+          { label: "Total docs", value: String(stats.totalDocs), cls: "text-foreground" },
+          { label: "Contributors", value: String(stats.contributors), cls: "text-foreground" },
         ].map(({ label, value, cls }) => (
           <div key={label}>
             <span className={cn("text-[13px] font-semibold", cls)}>{value}</span>
@@ -195,35 +192,43 @@ function KnowledgeHealthCard() {
   );
 }
 
-function ActiveTopicsCard() {
-  const max = activeTopics[0].count;
+function ActiveTopicsCard({ topics }: Readonly<{ topics: { tag: string; count: number }[] }>) {
+  const max = topics[0]?.count ?? 1;
   return (
     <Card className="p-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <SectionLabel>Most Active Topics</SectionLabel>
         <Activity className="size-3.5 text-primary" />
       </div>
-      <div className="flex flex-col gap-2.5">
-        {activeTopics.map(({ tag, count }) => (
-          <div key={tag} className="flex items-center gap-2.5">
-            <span className="text-[12px] text-foreground/80 w-24 shrink-0 truncate">{tag}</span>
-            <div className="flex-1 h-1 rounded-full bg-border/40 overflow-hidden">
-              <motion.div
-                className="h-full rounded-full bg-primary"
-                initial={{ width: 0 }}
-                animate={{ width: `${(count / max) * 100}%` }}
-                transition={{ duration: 0.8, ease: "easeOut", delay: 0.2 }}
-              />
+      {topics.length === 0 ? (
+        <EmptyState icon={Activity} message="Add labels to tasks to see active topics" />
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {topics.map(({ tag, count }) => (
+            <div key={tag} className="flex items-center gap-2.5">
+              <span className="text-[12px] text-foreground/80 w-24 shrink-0 truncate">{tag}</span>
+              <div className="flex-1 h-1 rounded-full bg-border/40 overflow-hidden">
+                <motion.div
+                  className="h-full rounded-full bg-primary"
+                  initial={{ width: 0 }}
+                  animate={{ width: `${(count / max) * 100}%` }}
+                  transition={{ duration: 0.8, ease: "easeOut", delay: 0.2 }}
+                />
+              </div>
+              <span className="text-[11px] text-muted-foreground w-5 text-right shrink-0">{count}</span>
             </div>
-            <span className="text-[11px] text-muted-foreground w-5 text-right shrink-0">{count}</span>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
     </Card>
   );
 }
 
-function KnowledgeGrowthCard() {
+function KnowledgeGrowthCard({ docs, monthlyData }: Readonly<{ docs: number; monthlyData: { month: string; docs: number }[] }>) {
+  const prev = monthlyData.at(-2)?.docs ?? 0;
+  const curr = monthlyData.at(-1)?.docs ?? 0;
+  const added = curr - prev;
+
   return (
     <Card className="p-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -231,64 +236,58 @@ function KnowledgeGrowthCard() {
         <TrendingUp className="size-3.5 text-success" />
       </div>
       <div className="flex items-end gap-3">
-        <span className="text-4xl font-bold text-foreground">74</span>
+        <span className="text-4xl font-bold text-foreground">{docs}</span>
         <div className="mb-1">
           <p className="text-[11px] text-muted-foreground">total documents</p>
-          <div className="flex items-center gap-1 text-[11px] text-success">
-            <TrendingUp className="size-3" />
-            <span>+19 this month</span>
-          </div>
+          {added > 0 && (
+            <div className="flex items-center gap-1 text-[11px] text-success">
+              <TrendingUp className="size-3" />
+              <span>+{added} this month</span>
+            </div>
+          )}
         </div>
       </div>
       <div className="h-24">
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={growthData} margin={{ top: 2, right: 2, bottom: 0, left: 0 }}>
+          <AreaChart data={monthlyData} margin={{ top: 2, right: 2, bottom: 0, left: 0 }}>
             <defs>
               <linearGradient id="docsGrad" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="5%" stopColor="#4F7CFF" stopOpacity={0.25} />
                 <stop offset="95%" stopColor="#4F7CFF" stopOpacity={0} />
-              </linearGradient>
-              <linearGradient id="decsGrad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#a855f7" stopOpacity={0.2} />
-                <stop offset="95%" stopColor="#a855f7" stopOpacity={0} />
               </linearGradient>
             </defs>
             <Tooltip
               contentStyle={{ background: "hsl(222 40% 12%)", border: "1px solid hsl(222 40% 20%)", borderRadius: 8, fontSize: 11 }}
               labelStyle={{ color: "rgba(255,255,255,0.6)" }}
             />
-            <Area type="monotone" dataKey="docs" stroke="#4F7CFF" strokeWidth={1.5} fill="url(#docsGrad)" dot={false} />
-            <Area type="monotone" dataKey="decisions" stroke="#a855f7" strokeWidth={1.5} fill="url(#decsGrad)" dot={false} />
+            <Area type="monotone" dataKey="docs" name="Docs" stroke="#4F7CFF" strokeWidth={1.5} fill="url(#docsGrad)" dot={false} />
           </AreaChart>
         </ResponsiveContainer>
-      </div>
-      <div className="flex gap-3">
-        {[{ label: "Docs", color: "bg-primary" }, { label: "Decisions", color: "bg-purple" }].map(({ label, color }) => (
-          <div key={label} className="flex items-center gap-1.5">
-            <span className={cn("size-1.5 rounded-full shrink-0", color)} />
-            <span className="text-[10px] text-muted-foreground">{label}</span>
-          </div>
-        ))}
       </div>
     </Card>
   );
 }
 
-function AiInsightCard() {
-  const [loading, setLoading] = useState(false);
-  const insights = [
-    "Authentication logic appears across 4 projects — 3 share session management patterns",
-    "Firebase configuration is duplicated in Chronicle and Spendwise — consider a shared package",
-    "MCP integration docs are the fastest-growing topic this month (+40%)",
-  ];
+function AiInsightCard({ staleDocs, blockedTasks, totalDocs }: Readonly<{ staleDocs: number; blockedTasks: number; totalDocs: number }>) {
+  const insights = useMemo(() => {
+    const list: string[] = [];
+    if (staleDocs > 0) list.push(`${staleDocs} doc${staleDocs > 1 ? "s" : ""} haven't been updated in over 30 days — consider a review`);
+    if (blockedTasks > 0) list.push(`${blockedTasks} task${blockedTasks > 1 ? "s are" : " is"} blocked — check your backlog for dependencies`);
+    if (totalDocs === 0) list.push("No documents yet — start by creating your first doc to build your knowledge base");
+    else if (totalDocs < 5) list.push(`You have ${totalDocs} doc${totalDocs > 1 ? "s" : ""} — keep building your knowledge base`);
+    if (list.length === 0) list.push("Knowledge base looks healthy. Keep up the good work!");
+    return list;
+  }, [staleDocs, blockedTasks, totalDocs]);
+
   const [idx, setIdx] = useState(0);
+  const [loading, setLoading] = useState(false);
 
   const rotate = () => {
     setLoading(true);
     setTimeout(() => {
       setIdx((i) => (i + 1) % insights.length);
       setLoading(false);
-    }, 600);
+    }, 400);
   };
 
   return (
@@ -315,8 +314,8 @@ function AiInsightCard() {
       <div className="flex items-center justify-between pt-3 border-t border-border/30 relative">
         <button
           onClick={rotate}
-          disabled={loading}
-          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+          disabled={loading || insights.length <= 1}
+          className="flex items-center gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
         >
           <RefreshCw className={cn("size-3", loading && "animate-spin")} />
           {loading ? "Analyzing..." : "Next insight"}
@@ -332,127 +331,213 @@ function AiInsightCard() {
 
 // ─── Section 2: Recently Updated ──────────────────────────────────────────────
 
-function RecentlyUpdated() {
+function RecentlyUpdated({
+  docs,
+  projects,
+  members,
+}: Readonly<{
+  docs: ChronicleDocument[];
+  projects: Project[];
+  members: Member[];
+}>) {
+  const recent = useMemo(
+    () => [...docs].sort((a, b) => b.updatedAt - a.updatedAt).slice(0, 5),
+    [docs]
+  );
+
+  const projectName = (id?: string) => projects.find((p) => p.$id === id)?.name ?? "Workspace";
+  const memberName = (uid: string) => members.find((m) => m.userId === uid)?.name ?? "Unknown";
+
   return (
     <Card className="p-5">
-      <SectionHeader
-        title="Recently Updated"
-        description="Latest changes across all projects"
-        action={
-          <button className="text-[11px] text-primary hover:text-primary/80 transition-colors">
-            View all
-          </button>
-        }
-      />
-      <div className="flex flex-col divide-y divide-border/30">
-        {recentDocs.map((doc, i) => (
-          <motion.button
-            key={doc.id}
-            initial={{ opacity: 0, x: -8 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ delay: i * 0.06, duration: 0.3 }}
-            className="flex items-center gap-3 py-3 text-left group hover:bg-surface-2 -mx-5 px-5 transition-colors"
-          >
-            <span className="text-[18px] shrink-0 w-7 text-center">{doc.icon}</span>
-            <div className="flex-1 min-w-0">
-              <p className="text-[13px] font-medium text-foreground/90 truncate group-hover:text-foreground transition-colors">
-                {doc.title}
-              </p>
-              <div className="flex items-center gap-2 mt-0.5">
-                <span className="text-[11px] text-primary/70">{doc.project}</span>
-                <span className="text-[11px] text-muted-foreground">by {doc.editor}</span>
+      <SectionHeader title="Recently Updated" description="Latest changes across all projects" />
+      {recent.length === 0 ? (
+        <EmptyState icon={FileText} message="No documents yet — create one to get started" />
+      ) : (
+        <div className="flex flex-col divide-y divide-border/30">
+          {recent.map((doc, i) => (
+            <motion.div
+              key={doc.id}
+              initial={{ opacity: 0, x: -8 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: i * 0.06, duration: 0.3 }}
+              className="flex items-center gap-3 py-3 group hover:bg-surface-2 -mx-5 px-5 transition-colors"
+            >
+              <span className="text-[18px] shrink-0 w-7 text-center">{doc.icon ?? "📄"}</span>
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-medium text-foreground/90 truncate group-hover:text-foreground transition-colors">
+                  {doc.title}
+                </p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <span className="text-[11px] text-primary/70">{projectName(doc.projectId)}</span>
+                  <span className="text-[11px] text-muted-foreground">by {memberName(doc.createdBy)}</span>
+                </div>
               </div>
-            </div>
-            <div className="flex flex-col items-end gap-1 shrink-0">
-              <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
-                <Clock className="size-2.5" />
-                {doc.time}
+              <div className="flex flex-col items-end gap-1 shrink-0">
+                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <Clock className="size-2.5" />
+                  {formatDistanceToNow(new Date(doc.updatedAt), { addSuffix: true })}
+                </div>
+                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <Eye className="size-2.5" />
+                  {doc.linkedWorkItems?.length ?? 0} links
+                </div>
               </div>
-              <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
-                <Eye className="size-2.5" />
-                {doc.views}
-              </div>
-            </div>
-          </motion.button>
-        ))}
-      </div>
+            </motion.div>
+          ))}
+        </div>
+      )}
     </Card>
   );
 }
 
-// ─── Section 3: Most Viewed ────────────────────────────────────────────────────
+// ─── Section 3: Project Docs Overview ─────────────────────────────────────────
 
-function MostViewedDocs() {
+function ProjectDocsOverview({
+  projects,
+  docs,
+  tasks,
+}: Readonly<{
+  projects: Project[];
+  docs: ChronicleDocument[];
+  tasks: Task[];
+}>) {
+  const rows = useMemo(() =>
+    projects.map((proj) => ({
+      name: proj.name,
+      docCount: docs.filter((d) => d.projectId === proj.$id).length,
+      taskCount: tasks.filter((t) => t.projectId === proj.$id).length,
+      doneCount: tasks.filter((t) => t.projectId === proj.$id && t.status === TaskStatus.DONE).length,
+    })).sort((a, b) => b.docCount - a.docCount),
+    [projects, docs, tasks]
+  );
+
   return (
     <Card className="p-5">
-      <SectionHeader
-        title="Most Viewed"
-        description="Top documents by read count"
-      />
-      <div className="flex flex-col gap-2">
-        {topDocs.map((doc, i) => (
-          <motion.div
-            key={doc.title}
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: i * 0.07, duration: 0.3 }}
-            className="flex items-center gap-3 p-3 rounded-xl border border-border/30 hover:border-border/60 hover:bg-surface-2 cursor-pointer transition-all group"
-          >
-            <span className="text-[16px] shrink-0">{doc.icon}</span>
-            <div className="flex-1 min-w-0">
-              <p className="text-[12px] font-medium text-foreground/90 truncate group-hover:text-foreground transition-colors">
-                {doc.title}
-              </p>
-              <p className="text-[11px] text-muted-foreground truncate mt-0.5">{doc.desc}</p>
-            </div>
-            <div className="flex flex-col items-end gap-1 shrink-0">
-              <div className="flex items-center gap-1 text-[11px] text-foreground/70">
-                <Eye className="size-3" />
-                {doc.views}
+      <SectionHeader title="Project Overview" description="Docs and tasks per project" />
+      {rows.length === 0 ? (
+        <EmptyState icon={FolderKanban} message="No projects yet" />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {rows.map((row, i) => (
+            <motion.div
+              key={row.name}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: i * 0.07, duration: 0.3 }}
+              className="flex items-center gap-3 p-3 rounded-xl border border-border/30 hover:border-border/60 hover:bg-surface-2 transition-all group"
+            >
+              <div className="flex items-center justify-center size-7 rounded-lg bg-primary/10 shrink-0">
+                <FolderKanban className="size-3.5 text-primary" />
               </div>
-              <div className={cn("flex items-center gap-0.5 text-[10px]", doc.trend >= 0 ? "text-success" : "text-destructive")}>
-                {doc.trend >= 0 ? <TrendingUp className="size-2.5" /> : <TrendingDown className="size-2.5" />}
-                {Math.abs(doc.trend)}%
+              <div className="flex-1 min-w-0">
+                <p className="text-[12px] font-semibold text-foreground/90 group-hover:text-foreground transition-colors truncate">
+                  {row.name}
+                </p>
+                <p className="text-[10px] text-muted-foreground">
+                  {row.docCount} doc{row.docCount !== 1 ? "s" : ""} · {row.taskCount} task{row.taskCount !== 1 ? "s" : ""}
+                </p>
               </div>
-            </div>
-          </motion.div>
-        ))}
-      </div>
+              {row.taskCount > 0 && (
+                <div className="shrink-0 text-right">
+                  <p className="text-[11px] font-medium text-success">{Math.round((row.doneCount / row.taskCount) * 100)}%</p>
+                  <p className="text-[9px] text-muted-foreground">done</p>
+                </div>
+              )}
+            </motion.div>
+          ))}
+        </div>
+      )}
     </Card>
   );
 }
 
 // ─── Section 4: Knowledge Graph ───────────────────────────────────────────────
 
-function KnowledgeGraph() {
+interface GraphNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  color: string;
+  r: number;
+  connections: string[];
+}
+
+const NODE_COLORS = ["#4F7CFF", "#22c55e", "#a855f7", "#f59e0b", "#ef4444", "#06b6d4", "#f97316"];
+
+function buildGraph(projects: Project[], topics: { tag: string; count: number }[]): { nodes: GraphNode[]; edges: [string, string][] } {
+  const nodes: GraphNode[] = [];
+  const edges: [string, string][] = [];
+
+  const cx = 280, cy = 180;
+  const projectR = 110;
+  const topicR = 180;
+
+  // Project nodes in a circle
+  projects.slice(0, 6).forEach((proj, i) => {
+    const angle = (2 * Math.PI * i) / Math.max(projects.length, 1) - Math.PI / 2;
+    nodes.push({
+      id: `proj-${proj.$id}`,
+      label: proj.name.slice(0, 8),
+      x: cx + projectR * Math.cos(angle),
+      y: cy + projectR * Math.sin(angle),
+      color: NODE_COLORS[i % NODE_COLORS.length],
+      r: 26,
+      connections: [],
+    });
+  });
+
+  // Topic nodes outer ring
+  topics.slice(0, 5).forEach((topic, i) => {
+    const angle = (2 * Math.PI * i) / Math.max(topics.length, 1);
+    nodes.push({
+      id: `topic-${topic.tag}`,
+      label: topic.tag.slice(0, 8),
+      x: cx + topicR * Math.cos(angle),
+      y: cy + topicR * Math.sin(angle),
+      color: NODE_COLORS[(i + 2) % NODE_COLORS.length],
+      r: 18,
+      connections: [],
+    });
+    // Connect each topic to all projects
+    for (const proj of projects.slice(0, 6)) {
+      edges.push([`proj-${proj.$id}`, `topic-${topic.tag}`]);
+    }
+  });
+
+  // Connect adjacent projects
+  for (let i = 0; i < Math.min(projects.length, 6); i++) {
+    const next = (i + 1) % projects.length;
+    if (next !== i) edges.push([`proj-${projects[i].$id}`, `proj-${projects[next].$id}`]);
+  }
+
+  return { nodes, edges };
+}
+
+function KnowledgeGraph({ projects, topics }: Readonly<{ projects: Project[]; topics: { tag: string; count: number }[] }>) {
   const [hovered, setHovered] = useState<string | null>(null);
+  const { nodes, edges } = useMemo(() => buildGraph(projects, topics), [projects, topics]);
 
-  const getNode = (id: string) => GRAPH_NODES.find((n) => n.id === id)!;
-
-  const isNodeActive = (id: string) => {
-    if (!hovered) return true;
-    return hovered === id || getNode(hovered)?.connections.includes(id);
-  };
-
-  const isEdgeActive = (a: string, b: string) => {
-    if (!hovered) return true;
-    return hovered === a || hovered === b;
-  };
-
+  const getNode = (id: string) => nodes.find((n) => n.id === id)!;
+  const isNodeActive = (id: string) => !hovered || hovered === id || getNode(hovered)?.connections.includes(id) || edges.some(([a, b]) => (a === hovered && b === id) || (b === hovered && a === id));
+  const isEdgeActive = (a: string, b: string) => !hovered || hovered === a || hovered === b;
   const hoveredNode = hovered ? getNode(hovered) : null;
+
+  if (projects.length === 0) {
+    return (
+      <Card className="p-5">
+        <SectionHeader title="Knowledge Graph" description="Relationships between projects and topics" />
+        <EmptyState icon={Zap} message="Create projects and add task labels to see the knowledge graph" />
+      </Card>
+    );
+  }
 
   return (
     <Card className="p-5">
-      <SectionHeader
-        title="Knowledge Graph"
-        description="Relationships between concepts across the workspace"
-      />
+      <SectionHeader title="Knowledge Graph" description="Relationships between projects and topics across the workspace" />
       <div className="relative">
-        <svg
-          viewBox="0 0 560 360"
-          className="w-full"
-          style={{ height: "280px" }}
-        >
+        <svg viewBox="0 0 560 360" className="w-full" style={{ height: "280px" }}>
           <defs>
             <filter id="nodeGlow" x="-50%" y="-50%" width="200%" height="200%">
               <feGaussianBlur stdDeviation="4" result="blur" />
@@ -462,17 +547,12 @@ function KnowledgeGraph() {
               </feMerge>
             </filter>
           </defs>
-
-          {/* Edges */}
-          {GRAPH_EDGES.map(([a, b]) => {
-            const na = getNode(a);
-            const nb = getNode(b);
+          {edges.map(([a, b]) => {
+            const na = getNode(a); const nb = getNode(b);
             if (!na || !nb) return null;
             const active = isEdgeActive(a, b);
             return (
-              <line
-                key={`${a}-${b}`}
-                x1={na.x} y1={na.y} x2={nb.x} y2={nb.y}
+              <line key={`${a}-${b}`} x1={na.x} y1={na.y} x2={nb.x} y2={nb.y}
                 stroke={active ? na.color : "rgba(255,255,255,0.06)"}
                 strokeOpacity={active ? 0.35 : 1}
                 strokeWidth={active ? 1.5 : 0.8}
@@ -480,100 +560,43 @@ function KnowledgeGraph() {
               />
             );
           })}
-
-          {/* Nodes */}
-          {GRAPH_NODES.map((node) => {
+          {nodes.map((node) => {
             const active = isNodeActive(node.id);
-            const isHovered = hovered === node.id;
-            const hoveredFillOpacity = isHovered ? 0.22 : 0.12;
-            const circleFillOpacity = active ? hoveredFillOpacity : 0.04;
-            const hoveredStrokeOpacity = isHovered ? 1 : 0.6;
-            const circleStrokeOpacity = active ? hoveredStrokeOpacity : 0.15;
+            const isH = hovered === node.id;
             return (
-              <g
-                key={node.id}
-                role="button"
-                tabIndex={0}
-                aria-label={`${node.label} node`}
+              <g key={node.id} role="button" tabIndex={0} aria-label={`${node.label} node`}
                 transform={`translate(${node.x}, ${node.y})`}
-                onMouseEnter={() => setHovered(node.id)}
-                onMouseLeave={() => setHovered(null)}
-                onFocus={() => setHovered(node.id)}
-                onBlur={() => setHovered(null)}
-                onKeyDown={(e) => { if (e.key === "Escape") setHovered(null); }}
+                onMouseEnter={() => setHovered(node.id)} onMouseLeave={() => setHovered(null)}
+                onFocus={() => setHovered(node.id)} onBlur={() => setHovered(null)}
                 style={{ cursor: "pointer" }}
               >
-                {/* Glow ring when hovered */}
-                {isHovered && (
-                  <circle
-                    r={node.r + 10}
-                    fill={node.color}
-                    fillOpacity={0.08}
-                    filter="url(#nodeGlow)"
-                    style={{ transition: "all 0.2s" }}
-                  />
-                )}
-                {/* Main circle */}
-                <circle
-                  r={isHovered ? node.r + 2 : node.r}
-                  fill={node.color}
-                  fillOpacity={circleFillOpacity}
-                  stroke={node.color}
-                  strokeOpacity={circleStrokeOpacity}
-                  strokeWidth={isHovered ? 2 : 1.5}
-                  style={{ transition: "all 0.2s" }}
+                {isH && <circle r={node.r + 10} fill={node.color} fillOpacity={0.08} filter="url(#nodeGlow)" />}
+                <circle r={isH ? node.r + 2 : node.r}
+                  fill={node.color} fillOpacity={active ? (isH ? 0.22 : 0.12) : 0.04}
+                  stroke={node.color} strokeOpacity={active ? (isH ? 1 : 0.6) : 0.15}
+                  strokeWidth={isH ? 2 : 1.5} style={{ transition: "all 0.2s" }}
                 />
-                {/* Label */}
-                <text
-                  textAnchor="middle"
-                  dy={node.r + 13}
-                  fill="white"
-                  fillOpacity={active ? 0.85 : 0.2}
-                  fontSize="9"
-                  fontWeight="500"
-                  fontFamily="Inter, system-ui, sans-serif"
-                  style={{ pointerEvents: "none", transition: "all 0.2s" }}
-                >
-                  {node.label}
-                </text>
-                {/* Icon text inside */}
-                <text
-                  textAnchor="middle"
-                  dy="0.35em"
-                  fill={node.color}
-                  fillOpacity={active ? 1 : 0.2}
-                  fontSize={node.r * 0.7}
-                  fontWeight="700"
-                  fontFamily="Inter, system-ui, sans-serif"
-                  style={{ pointerEvents: "none", transition: "all 0.2s" }}
-                >
-                  {node.label[0]}
-                </text>
+                <text textAnchor="middle" dy={node.r + 13} fill="white"
+                  fillOpacity={active ? 0.85 : 0.2} fontSize="9" fontWeight="500"
+                  fontFamily="Inter, system-ui, sans-serif" style={{ pointerEvents: "none", transition: "all 0.2s" }}
+                >{node.label}</text>
+                <text textAnchor="middle" dy="0.35em" fill={node.color}
+                  fillOpacity={active ? 1 : 0.2} fontSize={node.r * 0.65} fontWeight="700"
+                  fontFamily="Inter, system-ui, sans-serif" style={{ pointerEvents: "none", transition: "all 0.2s" }}
+                >{node.label[0]}</text>
               </g>
             );
           })}
         </svg>
-
-        {/* Tooltip */}
-        <div
-          className={cn(
-            "absolute bottom-0 left-0 right-0 p-3 rounded-xl bg-surface-2 border border-border/40 transition-all duration-200",
-            hoveredNode ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none"
-          )}
-        >
+        <div className={cn(
+          "absolute bottom-0 left-0 right-0 p-3 rounded-xl bg-surface-2 border border-border/40 transition-all duration-200",
+          hoveredNode ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none"
+        )}>
           {hoveredNode && (
             <div className="flex items-center gap-3">
-              <span
-                className="text-[11px] font-semibold px-2 py-0.5 rounded-md border"
-                style={{ color: hoveredNode.color, borderColor: hoveredNode.color + "40", background: hoveredNode.color + "18" }}
-              >
+              <span className="text-[11px] font-semibold px-2 py-0.5 rounded-md border"
+                style={{ color: hoveredNode.color, borderColor: hoveredNode.color + "40", background: hoveredNode.color + "18" }}>
                 {hoveredNode.label}
-              </span>
-              <span className="text-[11px] text-muted-foreground">
-                Connected to:{" "}
-                <span className="text-foreground/70">
-                  {hoveredNode.connections.map((id) => getNode(id)?.label).filter(Boolean).join(", ")}
-                </span>
               </span>
             </div>
           )}
@@ -583,56 +606,55 @@ function KnowledgeGraph() {
   );
 }
 
-// ─── Section 5: Architecture Timeline ─────────────────────────────────────────
+// ─── Section 5: Project Timeline ──────────────────────────────────────────────
 
-function ArchitectureTimeline() {
+const TIMELINE_ICONS = ["🚀", "📁", "⚡", "🔧", "📊", "🎯", "🔌", "🔍"];
+
+function ProjectTimeline({ projects }: Readonly<{ projects: Project[] }>) {
+  const sorted = useMemo(
+    () => [...projects].sort((a, b) => new Date(a.$createdAt).getTime() - new Date(b.$createdAt).getTime()),
+    [projects]
+  );
+
   return (
     <Card className="p-5">
-      <SectionHeader
-        title="Architecture Timeline"
-        description="Chronological evolution of the system"
-      />
-      <div className="relative">
-        {/* Vertical line */}
-        <div className="absolute left-[22px] top-3 bottom-3 w-px bg-border/40" />
-
-        <div className="flex flex-col gap-1">
-          {timeline.map((item, i) => (
-            <motion.div
-              key={item.month}
-              initial={{ opacity: 0, x: -12 }}
-              animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: i * 0.1, duration: 0.35 }}
-              className="flex gap-4 items-start py-3 group"
-            >
-              {/* Node */}
-              <div className="relative z-10 flex items-center justify-center size-[44px] shrink-0 rounded-full bg-surface-2 border border-border/50 text-[18px] group-hover:border-primary/40 transition-colors">
-                {item.icon}
-              </div>
-              {/* Content */}
-              <div className="flex-1 min-w-0 pt-1.5">
-                <div className="flex items-center gap-2">
-                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">{item.month}</span>
+      <SectionHeader title="Project Timeline" description="Chronological order of project creation" />
+      {sorted.length === 0 ? (
+        <EmptyState icon={Clock} message="No projects yet" />
+      ) : (
+        <div className="relative">
+          <div className="absolute left-[22px] top-3 bottom-3 w-px bg-border/40" />
+          <div className="flex flex-col gap-1">
+            {sorted.map((proj, i) => (
+              <motion.div
+                key={proj.$id}
+                initial={{ opacity: 0, x: -12 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: i * 0.1, duration: 0.35 }}
+                className="flex gap-4 items-start py-3 group"
+              >
+                <div className="relative z-10 flex items-center justify-center size-[44px] shrink-0 rounded-full bg-surface-2 border border-border/50 text-[18px] group-hover:border-primary/40 transition-colors">
+                  {TIMELINE_ICONS[i % TIMELINE_ICONS.length]}
                 </div>
-                <p className="text-[13px] font-semibold text-foreground mt-0.5">{item.event}</p>
-                <p className="text-[11px] text-muted-foreground mt-0.5 leading-relaxed">{item.detail}</p>
-              </div>
-            </motion.div>
-          ))}
+                <div className="flex-1 min-w-0 pt-1.5">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    {format(new Date(proj.$createdAt), "MMM yyyy")}
+                  </span>
+                  <p className="text-[13px] font-semibold text-foreground mt-0.5">{proj.name}</p>
+                  <p className="text-[11px] text-muted-foreground mt-0.5">Project created</p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
     </Card>
   );
 }
 
-// ─── Section 6: Decision Records ──────────────────────────────────────────────
+// ─── Section 6: Decision Records (no data source) ─────────────────────────────
 
 function DecisionRecords() {
-  const STATUS = {
-    accepted: { label: "Accepted", cls: "text-success bg-success/10 border-success/25", icon: CheckCircle2 },
-    rejected: { label: "Rejected", cls: "text-destructive bg-destructive/10 border-destructive/25", icon: XCircle },
-  };
-
   return (
     <Card className="p-5">
       <SectionHeader
@@ -645,51 +667,7 @@ function DecisionRecords() {
           </button>
         }
       />
-      <div className="flex flex-col gap-3">
-        {decisions.map((dec, i) => {
-          const { label, cls, icon: Icon } = STATUS[dec.status];
-          return (
-            <motion.div
-              key={dec.id}
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: i * 0.08, duration: 0.3 }}
-              className="p-4 rounded-xl border border-border/30 hover:border-border/60 hover:bg-surface-2 cursor-pointer transition-all group"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="flex-1 min-w-0">
-                  <p className="text-[13px] font-semibold text-foreground/90 group-hover:text-foreground transition-colors">
-                    {dec.title}
-                  </p>
-                  <p className="text-[11px] text-muted-foreground mt-1 leading-relaxed">{dec.reason}</p>
-                  <div className="flex items-center gap-2 mt-2.5 flex-wrap">
-                    <Pill className={cls}>
-                      <span className="flex items-center gap-1">
-                        <Icon className="size-2.5" />
-                        {label}
-                      </span>
-                    </Pill>
-                    <span className="text-[10px] text-muted-foreground">{dec.project}</span>
-                    <span className="text-[10px] text-muted-foreground">·</span>
-                    <span className="text-[10px] text-muted-foreground">{dec.date}</span>
-                    <span className="text-[10px] text-muted-foreground">·</span>
-                    <span className="text-[10px] text-muted-foreground">{dec.owner}</span>
-                  </div>
-                </div>
-              </div>
-              {dec.tags.length > 0 && (
-                <div className="flex flex-wrap gap-1.5 mt-3 pt-3 border-t border-border/25">
-                  {dec.tags.map((tag) => (
-                    <Pill key={tag} className="text-muted-foreground bg-surface-2 border-border/40">
-                      {tag}
-                    </Pill>
-                  ))}
-                </div>
-              )}
-            </motion.div>
-          );
-        })}
-      </div>
+      <EmptyState icon={BookOpen} message="No decision records yet. Use the ADR format to document architecture decisions." />
     </Card>
   );
 }
@@ -715,41 +693,27 @@ const CustomTooltip = ({ active, payload, label }: {
   );
 };
 
-function ProjectEvolution() {
+function ProjectEvolution({ data }: Readonly<{ data: { month: string; docs: number; tasks: number; done: number }[] }>) {
   return (
     <Card className="p-5">
-      <SectionHeader
-        title="Project Evolution"
-        description="Activity breakdown across all contribution types"
-      />
+      <SectionHeader title="Project Evolution" description="Docs and task activity over the last 5 months" />
       <div className="h-48">
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart data={evolutionData} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
-            <XAxis
-              dataKey="month"
-              tick={{ fill: "rgba(255,255,255,0.35)", fontSize: 10 }}
-              axisLine={false}
-              tickLine={false}
-            />
-            <YAxis
-              tick={{ fill: "rgba(255,255,255,0.35)", fontSize: 10 }}
-              axisLine={false}
-              tickLine={false}
-            />
+          <BarChart data={data} margin={{ top: 4, right: 4, bottom: 0, left: -20 }}>
+            <XAxis dataKey="month" tick={{ fill: "rgba(255,255,255,0.35)", fontSize: 10 }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fill: "rgba(255,255,255,0.35)", fontSize: 10 }} axisLine={false} tickLine={false} />
             <Tooltip content={<CustomTooltip />} cursor={{ fill: "rgba(255,255,255,0.03)" }} />
-            <Bar dataKey="commits" name="Commits" fill="#4F7CFF" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
-            <Bar dataKey="docs" name="Docs" fill="#22c55e" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
-            <Bar dataKey="notes" name="Notes" fill="#a855f7" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
-            <Bar dataKey="decisions" name="Decisions" fill="#f59e0b" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
+            <Bar dataKey="docs" name="Docs" fill="#4F7CFF" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
+            <Bar dataKey="tasks" name="Tasks" fill="#22c55e" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
+            <Bar dataKey="done" name="Completed" fill="#a855f7" fillOpacity={0.7} radius={[3, 3, 0, 0]} />
           </BarChart>
         </ResponsiveContainer>
       </div>
       <div className="flex flex-wrap gap-3 mt-3 pt-3 border-t border-border/30">
         {[
-          { label: "Commits", color: "bg-primary" },
-          { label: "Docs", color: "bg-success" },
-          { label: "Notes", color: "bg-purple" },
-          { label: "Decisions", color: "bg-warning" },
+          { label: "Docs", color: "bg-primary" },
+          { label: "Tasks", color: "bg-success" },
+          { label: "Completed", color: "bg-purple" },
         ].map(({ label, color }) => (
           <div key={label} className="flex items-center gap-1.5">
             <span className={cn("size-2 rounded-sm shrink-0", color)} style={{ opacity: 0.7 }} />
@@ -761,56 +725,13 @@ function ProjectEvolution() {
   );
 }
 
-// ─── Section 8: Cross-project Relationships ────────────────────────────────────
+// ─── Section 8: Knowledge Alerts ──────────────────────────────────────────────
 
-const STRENGTH_CLS = {
-  high: "bg-success/10 text-success border-success/25",
-  medium: "bg-warning/10 text-warning border-warning/25",
-  low: "bg-muted/40 text-muted-foreground border-border/40",
-};
-
-function CrossProjectRelationships() {
-  return (
-    <Card className="p-5">
-      <SectionHeader
-        title="Cross-project Relationships"
-        description="Shared code, systems, and patterns between projects"
-      />
-      <div className="flex flex-col gap-3">
-        {crossProjects.map((rel, i) => (
-          <motion.div
-            key={`${rel.from}-${rel.to}`}
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: i * 0.1, duration: 0.3 }}
-            className="p-4 rounded-xl border border-border/30 hover:border-border/60 hover:bg-surface-2 transition-all"
-          >
-            <div className="flex items-center gap-3 mb-3">
-              <span className="text-[13px] font-semibold text-foreground">{rel.from}</span>
-              <Link2 className="size-3.5 text-muted-foreground rotate-45" />
-              <span className="text-[13px] font-semibold text-foreground">{rel.to}</span>
-              <Pill className={STRENGTH_CLS[rel.strength]}>
-                {rel.strength} coupling
-              </Pill>
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {rel.shared.map((item) => (
-                <span
-                  key={item}
-                  className="text-[10px] px-2 py-0.5 rounded-md bg-primary/8 text-primary/70 border border-primary/15"
-                >
-                  {item}
-                </span>
-              ))}
-            </div>
-          </motion.div>
-        ))}
-      </div>
-    </Card>
-  );
+interface KnowledgeAlert {
+  type: "warning" | "error" | "info";
+  message: string;
+  action: string;
 }
-
-// ─── Section 9: Knowledge Alerts ──────────────────────────────────────────────
 
 const ALERT_CONFIG = {
   warning: { icon: AlertTriangle, cls: "text-warning bg-warning/8 border-warning/20", iconCls: "text-warning" },
@@ -818,53 +739,51 @@ const ALERT_CONFIG = {
   info: { icon: BookOpen, cls: "text-primary bg-primary/8 border-primary/20", iconCls: "text-primary" },
 };
 
-function KnowledgeAlerts() {
+function KnowledgeAlerts({ alerts }: Readonly<{ alerts: KnowledgeAlert[] }>) {
   const [dismissed, setDismissed] = useState<number[]>([]);
 
   return (
     <Card className="p-5">
-      <SectionHeader
-        title="Knowledge Alerts"
-        description="Issues and opportunities requiring attention"
-      />
-      <div className="flex flex-col gap-2.5">
-        {alerts.map((alert, i) => {
-          if (dismissed.includes(i)) return null;
-          const { icon: Icon, cls, iconCls } = ALERT_CONFIG[alert.type];
-          return (
-            <motion.div
-              key={alert.message}
-              layout
-              initial={{ opacity: 0, y: 6 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, x: -16 }}
-              transition={{ delay: i * 0.06, duration: 0.3 }}
-              className={cn("flex items-center gap-3 p-3.5 rounded-xl border transition-all", cls)}
-            >
-              <Icon className={cn("size-3.5 shrink-0", iconCls)} />
-              <p className="flex-1 text-[12px] leading-relaxed">{alert.message}</p>
-              <div className="flex items-center gap-2 shrink-0">
-                <button className="text-[11px] font-medium opacity-70 hover:opacity-100 transition-opacity underline underline-offset-2">
-                  {alert.action}
-                </button>
-                <button
-                  aria-label="Dismiss alert"
-                  onClick={() => setDismissed((prev) => prev.includes(i) ? prev : [...prev, i])}
-                  className="opacity-40 hover:opacity-70 transition-opacity text-[16px] leading-none"
-                >
-                  ×
-                </button>
-              </div>
-            </motion.div>
-          );
-        })}
-        {new Set(dismissed).size === alerts.length && (
-          <div className="flex flex-col items-center justify-center py-8 gap-2">
-            <CheckCircle2 className="size-6 text-success" />
-            <p className="text-[13px] text-muted-foreground">All alerts resolved</p>
-          </div>
-        )}
-      </div>
+      <SectionHeader title="Knowledge Alerts" description="Issues and opportunities requiring attention" />
+      {alerts.length === 0 || dismissed.length === alerts.length ? (
+        <div className="flex flex-col items-center justify-center py-8 gap-2">
+          <CheckCircle2 className="size-6 text-success" />
+          <p className="text-[13px] text-muted-foreground">All clear — no alerts</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {alerts.map((alert, i) => {
+            if (dismissed.includes(i)) return null;
+            const { icon: Icon, cls, iconCls } = ALERT_CONFIG[alert.type];
+            return (
+              <motion.div
+                key={alert.message}
+                layout
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, x: -16 }}
+                transition={{ delay: i * 0.06, duration: 0.3 }}
+                className={cn("flex items-center gap-3 p-3.5 rounded-xl border", cls)}
+              >
+                <Icon className={cn("size-3.5 shrink-0", iconCls)} />
+                <p className="flex-1 text-[12px] leading-relaxed">{alert.message}</p>
+                <div className="flex items-center gap-2 shrink-0">
+                  <button className="text-[11px] font-medium opacity-70 hover:opacity-100 transition-opacity underline underline-offset-2">
+                    {alert.action}
+                  </button>
+                  <button
+                    aria-label="Dismiss alert"
+                    onClick={() => setDismissed((prev) => [...prev, i])}
+                    className="opacity-40 hover:opacity-70 transition-opacity text-[16px] leading-none"
+                  >
+                    ×
+                  </button>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      )}
     </Card>
   );
 }
@@ -872,7 +791,52 @@ function KnowledgeAlerts() {
 // ─── Main component ────────────────────────────────────────────────────────────
 
 export function KnowledgeDashboardClient() {
+  const workspaceId = useWorkspaceId();
   const [dateRange, setDateRange] = useState<DateRange>("30d");
+
+  const { docsQuery } = useDocuments(workspaceId);
+  const { data: projectsData } = useGetProjects({ workspaceId });
+  const { data: membersData } = useGetMembers({ workspaceId });
+  const { data: tasksData } = useGetTasks({ workspaceId });
+
+  const docs = useMemo(() => docsQuery.data ?? [], [docsQuery.data]);
+  const projects = useMemo(() => projectsData?.documents ?? [], [projectsData]);
+  const members = useMemo(() => membersData?.documents ?? [], [membersData]);
+  const tasks = useMemo(() => tasksData?.documents ?? [], [tasksData]);
+
+  const staleDocs = useMemo(() => docs.filter((d) => Date.now() - d.updatedAt > THIRTY_DAYS), [docs]);
+
+  const healthStats = useMemo((): HealthStats => {
+    const linkedProjects = new Set(docs.filter((d) => d.projectId).map((d) => d.projectId)).size;
+    const contributors = new Set(docs.map((d) => d.createdBy)).size;
+    return {
+      score: computeHealthScore(docs, staleDocs),
+      staleDocs: staleDocs.length,
+      linkedProjects,
+      contributors,
+      totalDocs: docs.length,
+    };
+  }, [docs, staleDocs]);
+
+  const activeTopics = useMemo(() => buildActiveTopics(tasks), [tasks]);
+  const monthlyGrowth = useMemo(() => buildMonthlyGrowth(docs), [docs]);
+  const evolutionData = useMemo(() => buildEvolutionData(docs, tasks), [docs, tasks]);
+  const blockedTasks = useMemo(() => tasks.filter((t) => (t.blockedBy?.length ?? 0) > 0).length, [tasks]);
+
+  const alerts = useMemo((): KnowledgeAlert[] => {
+    const result: KnowledgeAlert[] = [];
+    if (staleDocs.length > 0) {
+      result.push({ type: "warning", message: `${staleDocs.length} doc${staleDocs.length > 1 ? "s" : ""} haven't been updated in over 30 days`, action: "Review stale docs" });
+    }
+    const unlinked = docs.filter((d) => (d.linkedWorkItems?.length ?? 0) === 0);
+    if (unlinked.length > 0) {
+      result.push({ type: "info", message: `${unlinked.length} doc${unlinked.length > 1 ? "s have" : " has"} no linked work items`, action: "Link work items" });
+    }
+    if (blockedTasks > 0) {
+      result.push({ type: "error", message: `${blockedTasks} task${blockedTasks > 1 ? "s are" : " is"} blocked by dependencies`, action: "Review blockers" });
+    }
+    return result;
+  }, [staleDocs, docs, blockedTasks]);
 
   const fadeUp = (delay: number) => ({
     initial: { opacity: 0, y: 18 },
@@ -893,7 +857,6 @@ export function KnowledgeDashboardClient() {
             </p>
           </div>
           <div className="flex items-center gap-2 flex-wrap">
-            {/* Date range */}
             <div className="flex items-center p-0.5 rounded-btn gap-0.5 bg-surface border border-border/40">
               {DATE_RANGES.map((r) => (
                 <button
@@ -901,9 +864,7 @@ export function KnowledgeDashboardClient() {
                   onClick={() => setDateRange(r)}
                   className={cn(
                     "px-3 py-1.5 text-[11px] font-medium rounded-md transition-all",
-                    dateRange === r
-                      ? "bg-surface-2 text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
+                    dateRange === r ? "bg-surface-2 text-foreground" : "text-muted-foreground hover:text-foreground"
                   )}
                 >
                   {r}
@@ -918,45 +879,42 @@ export function KnowledgeDashboardClient() {
       <motion.section {...fadeUp(0.06)}>
         <SectionLabel>Intelligence Overview</SectionLabel>
         <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mt-2">
-          <KnowledgeHealthCard />
-          <ActiveTopicsCard />
-          <KnowledgeGrowthCard />
-          <AiInsightCard />
+          <KnowledgeHealthCard stats={healthStats} />
+          <ActiveTopicsCard topics={activeTopics} />
+          <KnowledgeGrowthCard docs={docs.length} monthlyData={monthlyGrowth} />
+          <AiInsightCard staleDocs={staleDocs.length} blockedTasks={blockedTasks} totalDocs={docs.length} />
         </div>
       </motion.section>
 
-      {/* ── Section 2 + 3: Recent + Most Viewed ── */}
+      {/* ── Section 2 + 3: Recent + Projects ── */}
       <motion.section {...fadeUp(0.12)}>
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-4">
-          <RecentlyUpdated />
-          <MostViewedDocs />
+          <RecentlyUpdated docs={docs} projects={projects} members={members} />
+          <ProjectDocsOverview projects={projects} docs={docs} tasks={tasks} />
         </div>
       </motion.section>
 
       {/* ── Section 4: Knowledge Graph ── */}
       <motion.section {...fadeUp(0.16)}>
-        <KnowledgeGraph />
+        <KnowledgeGraph projects={projects} topics={activeTopics} />
       </motion.section>
 
       {/* ── Section 5 + 6: Timeline + Decisions ── */}
       <motion.section {...fadeUp(0.2)}>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <ArchitectureTimeline />
+          <ProjectTimeline projects={projects} />
           <DecisionRecords />
         </div>
       </motion.section>
 
       {/* ── Section 7: Project Evolution ── */}
       <motion.section {...fadeUp(0.24)}>
-        <ProjectEvolution />
+        <ProjectEvolution data={evolutionData} />
       </motion.section>
 
-      {/* ── Section 8 + 9: Cross-project + Alerts ── */}
+      {/* ── Section 8: Knowledge Alerts ── */}
       <motion.section {...fadeUp(0.28)}>
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_420px] gap-4">
-          <CrossProjectRelationships />
-          <KnowledgeAlerts />
-        </div>
+        <KnowledgeAlerts alerts={alerts} />
       </motion.section>
 
     </div>

--- a/src/app/(dashboard)/workspace/[workspaceId]/knowledge/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/knowledge/client.tsx
@@ -154,6 +154,8 @@ interface HealthStats {
 }
 
 function KnowledgeHealthCard({ stats }: Readonly<{ stats: HealthStats }>) {
+  const staleSuffix = stats.staleDocs === 1 ? "" : "s";
+  const staleLabel = stats.staleDocs === 0 ? "All docs current" : `${stats.staleDocs} stale doc${staleSuffix}`;
   return (
     <Card className="p-5 flex flex-col gap-4">
       <div className="flex items-center justify-between">
@@ -164,7 +166,7 @@ function KnowledgeHealthCard({ stats }: Readonly<{ stats: HealthStats }>) {
         <span className="text-4xl font-bold text-foreground">{stats.score}%</span>
         <div className={cn("flex items-center gap-1.5 text-[11px]", stats.score >= 70 ? "text-success" : "text-warning")}>
           {stats.score >= 70 ? <TrendingUp className="size-3" /> : <TrendingDown className="size-3" />}
-          <span>{stats.staleDocs === 0 ? "All docs current" : `${stats.staleDocs} stale doc${stats.staleDocs === 1 ? "" : "s"}`}</span>
+          <span>{staleLabel}</span>
         </div>
       </div>
       <div className="h-1.5 rounded-full overflow-hidden bg-border/40">
@@ -563,8 +565,10 @@ function KnowledgeGraph({ projects, topics }: Readonly<{ projects: Project[]; to
           {nodes.map((node) => {
             const active = isNodeActive(node.id);
             const isH = hovered === node.id;
-            const circleFillOpacity = active ? (isH ? 0.22 : 0.12) : 0.04;
-            const circleStrokeOpacity = active ? (isH ? 1 : 0.6) : 0.15;
+            let circleFillOpacity: number;
+            if (active) { circleFillOpacity = isH ? 0.22 : 0.12; } else { circleFillOpacity = 0.04; }
+            let circleStrokeOpacity: number;
+            if (active) { circleStrokeOpacity = isH ? 1 : 0.6; } else { circleStrokeOpacity = 0.15; }
             return (
               <g key={node.id} role="button" tabIndex={0} aria-label={`${node.label} node`}
                 transform={`translate(${node.x}, ${node.y})`}

--- a/src/app/(dashboard)/workspace/[workspaceId]/knowledge/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/knowledge/client.tsx
@@ -9,7 +9,7 @@ import {
 import {
   AlertTriangle, ArrowRight, BookOpen, CheckCircle2,
   Clock, Eye, FileText,
-  RefreshCw, Sparkles, TrendingUp, TrendingDown, XCircle,
+  RefreshCw, Sparkles, TrendingUp, TrendingDown,
   Activity, Zap, Shield, FolderKanban,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -164,7 +164,7 @@ function KnowledgeHealthCard({ stats }: Readonly<{ stats: HealthStats }>) {
         <span className="text-4xl font-bold text-foreground">{stats.score}%</span>
         <div className={cn("flex items-center gap-1.5 text-[11px]", stats.score >= 70 ? "text-success" : "text-warning")}>
           {stats.score >= 70 ? <TrendingUp className="size-3" /> : <TrendingDown className="size-3" />}
-          <span>{stats.staleDocs > 0 ? `${stats.staleDocs} stale doc${stats.staleDocs > 1 ? "s" : ""}` : "All docs current"}</span>
+          <span>{stats.staleDocs === 0 ? "All docs current" : `${stats.staleDocs} stale doc${stats.staleDocs === 1 ? "" : "s"}`}</span>
         </div>
       </div>
       <div className="h-1.5 rounded-full overflow-hidden bg-border/40">
@@ -435,7 +435,7 @@ function ProjectDocsOverview({
                   {row.name}
                 </p>
                 <p className="text-[10px] text-muted-foreground">
-                  {row.docCount} doc{row.docCount !== 1 ? "s" : ""} · {row.taskCount} task{row.taskCount !== 1 ? "s" : ""}
+                  {row.docCount} doc{row.docCount === 1 ? "" : "s"} · {row.taskCount} task{row.taskCount === 1 ? "" : "s"}
                 </p>
               </div>
               {row.taskCount > 0 && (
@@ -563,6 +563,8 @@ function KnowledgeGraph({ projects, topics }: Readonly<{ projects: Project[]; to
           {nodes.map((node) => {
             const active = isNodeActive(node.id);
             const isH = hovered === node.id;
+            const circleFillOpacity = active ? (isH ? 0.22 : 0.12) : 0.04;
+            const circleStrokeOpacity = active ? (isH ? 1 : 0.6) : 0.15;
             return (
               <g key={node.id} role="button" tabIndex={0} aria-label={`${node.label} node`}
                 transform={`translate(${node.x}, ${node.y})`}
@@ -572,8 +574,8 @@ function KnowledgeGraph({ projects, topics }: Readonly<{ projects: Project[]; to
               >
                 {isH && <circle r={node.r + 10} fill={node.color} fillOpacity={0.08} filter="url(#nodeGlow)" />}
                 <circle r={isH ? node.r + 2 : node.r}
-                  fill={node.color} fillOpacity={active ? (isH ? 0.22 : 0.12) : 0.04}
-                  stroke={node.color} strokeOpacity={active ? (isH ? 1 : 0.6) : 0.15}
+                  fill={node.color} fillOpacity={circleFillOpacity}
+                  stroke={node.color} strokeOpacity={circleStrokeOpacity}
                   strokeWidth={isH ? 2 : 1.5} style={{ transition: "all 0.2s" }}
                 />
                 <text textAnchor="middle" dy={node.r + 13} fill="white"

--- a/src/features/docs/hooks/use-documents.ts
+++ b/src/features/docs/hooks/use-documents.ts
@@ -51,7 +51,7 @@ export const useDocuments = (workspaceId: string, projectId?: string) => {
     mutationFn: async (data: Partial<ChronicleDocument>) => {
       return createDocument({
         workspaceId,
-        projectId,
+        ...(projectId !== undefined && { projectId }),
         title: data.title ?? "Untitled",
         content: data.content ?? { type: "doc", content: [] },
         icon: data.icon,

--- a/src/lib/docs-firestore.ts
+++ b/src/lib/docs-firestore.ts
@@ -31,11 +31,10 @@ export type ChronicleDocument = {
 const docsCollection = collection(db, "docs");
 
 export async function listDocuments(workspaceId: string, projectId?: string) {
-  const q = projectId
-    ? query(docsCollection, where("workspaceId", "==", workspaceId), where("projectId", "==", projectId))
-    : query(docsCollection, where("workspaceId", "==", workspaceId));
+  const q = query(docsCollection, where("workspaceId", "==", workspaceId));
   const snapshot = await getDocs(q);
-  const docs = snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<ChronicleDocument, "id">) }));
+  let docs = snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<ChronicleDocument, "id">) }));
+  if (projectId !== undefined) docs = docs.filter((d) => d.projectId === projectId);
   return docs.sort((a, b) => a.order - b.order);
 }
 
@@ -44,11 +43,10 @@ export function subscribeDocuments(
   projectId: string | undefined,
   onData: (docs: ChronicleDocument[]) => void,
 ) {
-  const q = projectId
-    ? query(docsCollection, where("workspaceId", "==", workspaceId), where("projectId", "==", projectId))
-    : query(docsCollection, where("workspaceId", "==", workspaceId));
+  const q = query(docsCollection, where("workspaceId", "==", workspaceId));
   return onSnapshot(q, (snapshot) => {
-    const docs = snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<ChronicleDocument, "id">) }));
+    let docs = snapshot.docs.map((d) => ({ id: d.id, ...(d.data() as Omit<ChronicleDocument, "id">) }));
+    if (projectId !== undefined) docs = docs.filter((d) => d.projectId === projectId);
     onData(docs.sort((a, b) => a.order - b.order));
   });
 }


### PR DESCRIPTION
## Summary

- **Docs broken**: `addDoc()` was called with `projectId: undefined` for workspace-level docs — Firestore rejects undefined field values. Fixed by conditionally spreading `projectId` only when it's defined.
- **Firestore index policy**: Changed `listDocuments` and `subscribeDocuments` to query by `workspaceId` only and filter `projectId` client-side, eliminating the need for composite Firestore indexes.
- **Activity page Open/Copy link buttons**: Wired up navigation and clipboard handlers. Each event type gets a deep-link URL (task → project/story|spike|bug|epic detail, doc → docs page with docId param, member → members page).
- **Knowledge Dashboard dummy data**: Replaced all hardcoded seed data with real data from Firestore (docs) and Appwrite (tasks, projects, members). Sections without a real data source (Decision Records) now show empty states instead of fabricated content.

## Test plan

- [ ] Create a workspace-level doc — no Firestore error in console
- [ ] Create a project-level doc — saves correctly with projectId
- [ ] Activity feed: hover an event, click Open — navigates to the correct item
- [ ] Activity feed: hover an event, click Copy link — copies URL to clipboard and shows toast
- [ ] Knowledge Dashboard: all cards show real counts from the database
- [ ] Knowledge Dashboard: empty states appear correctly when no data exists

https://claude.ai/code/session_015CiE2mVjptJNzHF17G2yq7

---
_Generated by [Claude Code](https://claude.ai/code/session_015CiE2mVjptJNzHF17G2yq7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Activity events now include "Open" and "Copy link" actions for task creation, task completion, member joins, and document edits.
  * Knowledge Dashboard now displays live workspace metrics including knowledge health scores, monthly growth trends, active topics, recently updated documents, and a new Knowledge Alerts section tracking stale and unlinked documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->