### PR TITLE
Strip undefined fields before writing to Firestore in docs

### DIFF
--- a/src/lib/docs-firestore.ts
+++ b/src/lib/docs-firestore.ts
@@ -51,19 +51,23 @@ export function subscribeDocuments(
   });
 }
 
+function stripUndefined<T extends object>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).filter(([, v]) => v !== undefined)) as T;
+}
+
 export async function createDocument(payload: Omit<ChronicleDocument, "id" | "createdAt" | "updatedAt">) {
   const now = Date.now();
-  const ref = await addDoc(docsCollection, {
+  const ref = await addDoc(docsCollection, stripUndefined({
     ...payload,
     createdAt: now,
     updatedAt: now,
     serverCreatedAt: serverTimestamp(),
-  });
+  }));
   return ref.id;
 }
 
 export async function updateDocument(id: string, patch: Partial<ChronicleDocument>) {
-  await updateDoc(doc(db, "docs", id), { ...patch, updatedAt: Date.now() });
+  await updateDoc(doc(db, "docs", id), stripUndefined({ ...patch, updatedAt: Date.now() }));
 }
 
 export async function deleteDocument(id: string) {


### PR DESCRIPTION
## Summary

- `addDoc()` was throwing `Unsupported field value: undefined (found in field coverImage)` — same class of bug as the earlier `projectId` fix
- Optional fields (`coverImage`, `icon`, `parentId`, `projectId`) can arrive as `undefined` from call sites
- Added a `stripUndefined` helper in `docs-firestore.ts` and applied it in both `createDocument` and `updateDocument`, fixing the problem at the persistence layer rather than requiring every call site to guard each optional field

## Test plan

- [ ] Create a blank doc — no Firestore error in console
- [ ] Create a doc from a template — no Firestore error
- [ ] Update a doc title — no Firestore error

https://claude.ai/code/session_015CiE2mVjptJNzHF17G2yq7

---
_Generated by [Claude Code](https://claude.ai/code/session_015CiE2mVjptJNzHF17G2yq7)_