### PR TITLE
Fix docs editor: slash command, save indicator, cursor reset, workspace doc creation

### DIFF
--- a/src/features/docs/components/chronicle-editor.tsx
+++ b/src/features/docs/components/chronicle-editor.tsx
@@ -84,6 +84,7 @@ export function ChronicleEditor({ content, onChange }: { content: any; onChange:
       <EditorContent editor={editor} />
       {open && (
         <div
+          role="menu"
           className="absolute left-4 top-14 w-[320px] rounded-lg border border-white/10 bg-[#0A0F1A] p-2 shadow-xl z-20"
           onMouseDown={(e) => e.preventDefault()}
         >

--- a/src/features/docs/components/chronicle-editor.tsx
+++ b/src/features/docs/components/chronicle-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -56,8 +56,12 @@ export function ChronicleEditor({ content, onChange }: { content: any; onChange:
         if (event.key === "/") {
           setOpen(true);
           setQuery("");
+          return true;
         }
-        if (open && event.key === "Escape") setOpen(false);
+        if (open && event.key === "Escape") {
+          setOpen(false);
+          return true;
+        }
         return false;
       },
     },
@@ -67,16 +71,6 @@ export function ChronicleEditor({ content, onChange }: { content: any; onChange:
   });
 
   const filtered = useMemo(() => slashItems.filter((i) => i.label.toLowerCase().includes(query.toLowerCase())), [query]);
-
-  useEffect(() => {
-    if (!editor) return;
-    const next = content ?? "";
-    const current = editor.getJSON();
-    const same = JSON.stringify(current) === JSON.stringify(next);
-    if (!same) {
-      editor.commands.setContent(next, { emitUpdate: false });
-    }
-  }, [editor, content]);
 
   if (!editor) return null;
 
@@ -89,11 +83,26 @@ export function ChronicleEditor({ content, onChange }: { content: any; onChange:
       </div>
       <EditorContent editor={editor} />
       {open && (
-        <div className="absolute left-4 top-14 w-[320px] rounded-lg border border-white/10 bg-[#0A0F1A] p-2 shadow-xl z-20">
-          <input className="w-full bg-transparent text-sm text-white/80 p-2 border-b border-white/10" placeholder="Search commands" value={query} onChange={(e)=>setQuery(e.target.value)} />
+        <div
+          className="absolute left-4 top-14 w-[320px] rounded-lg border border-white/10 bg-[#0A0F1A] p-2 shadow-xl z-20"
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          <input
+            autoFocus
+            className="w-full bg-transparent text-sm text-white/80 p-2 border-b border-white/10"
+            placeholder="Search commands"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onBlur={() => setOpen(false)}
+          />
           <div className="max-h-60 overflow-y-auto">
             {filtered.map((item) => (
-              <button key={item.label} className="w-full text-left text-sm px-2 py-1.5 hover:bg-white/10 rounded" onClick={() => { item.run(editor); setOpen(false); }}>
+              <button
+                key={item.label}
+                className="w-full text-left text-sm px-2 py-1.5 hover:bg-white/10 rounded"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => { item.run(editor); setOpen(false); }}
+              >
                 {item.label}
               </button>
             ))}

--- a/src/features/docs/components/chronicle-editor.tsx
+++ b/src/features/docs/components/chronicle-editor.tsx
@@ -86,7 +86,6 @@ export function ChronicleEditor({ content, onChange }: { content: any; onChange:
         <div
           role="menu"
           className="absolute left-4 top-14 w-[320px] rounded-lg border border-white/10 bg-[#0A0F1A] p-2 shadow-xl z-20"
-          onMouseDown={(e) => e.preventDefault()}
         >
           <input
             autoFocus

--- a/src/features/docs/components/docs-workspace.tsx
+++ b/src/features/docs/components/docs-workspace.tsx
@@ -134,7 +134,7 @@ function EmptyState({
 }
 
 export function DocsWorkspace({ workspaceId, projectId, initialDocId }: { workspaceId: string; projectId?: string; initialDocId?: string }) {
-  const { docsQuery, createDoc, updateDoc, removeDoc } = useDocuments(workspaceId, projectId);
+  const { docsQuery, createDoc, createWorkspaceDoc, updateDoc, removeDoc } = useDocuments(workspaceId, projectId);
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -220,6 +220,16 @@ export function DocsWorkspace({ workspaceId, projectId, initialDocId }: { worksp
 
   const handleTemplateCreate = async (templateName: string) => {
     await handleCreateDoc(templateName, templateHtml[templateName] ?? "");
+  };
+
+  const handleCreateWorkspaceDoc = async () => {
+    try {
+      const id = await createWorkspaceDoc.mutateAsync({ title: "Untitled", content: "", icon: "📄" });
+      handleSelectDoc(id);
+      toast.success("Document created");
+    } catch {
+      toast.error("Failed to create document");
+    }
   };
 
   useEffect(() => {
@@ -320,17 +330,29 @@ export function DocsWorkspace({ workspaceId, projectId, initialDocId }: { worksp
             { key: "project", label: "Project Docs", items: grouped.projectDocs },
           ].map((group) => (
             <div key={group.key} className="mb-4">
-              <button
-                className="text-xs text-white/50 mb-2 flex items-center gap-1 hover:text-white/70 transition-colors"
-                onClick={() => setOpen((p) => ({ ...p, [group.key]: !p[group.key] }))}
-              >
-                {open[group.key] ? (
-                  <ChevronDown className="size-3" />
-                ) : (
-                  <ChevronRight className="size-3" />
+              <div className="flex items-center justify-between mb-2">
+                <button
+                  className="text-xs text-white/50 flex items-center gap-1 hover:text-white/70 transition-colors"
+                  onClick={() => setOpen((p) => ({ ...p, [group.key]: !p[group.key] }))}
+                >
+                  {open[group.key] ? (
+                    <ChevronDown className="size-3" />
+                  ) : (
+                    <ChevronRight className="size-3" />
+                  )}
+                  {group.label}
+                </button>
+                {group.key === "workspace" && projectId && (
+                  <button
+                    onClick={() => void handleCreateWorkspaceDoc()}
+                    disabled={createWorkspaceDoc.isPending}
+                    className="p-0.5 rounded hover:bg-white/10 text-white/40 hover:text-white/70 transition-colors"
+                    title="New workspace doc"
+                  >
+                    <Plus className="size-3" />
+                  </button>
                 )}
-                {group.label}
-              </button>
+              </div>
               {open[group.key] && (
                 <div className="space-y-0.5">
                   {group.items.map((d) => (
@@ -382,14 +404,15 @@ export function DocsWorkspace({ workspaceId, projectId, initialDocId }: { worksp
               <span>Updated {new Date(selected.updatedAt).toLocaleString()}</span>
             </div>
             <ChronicleEditor
+              key={selected.id}
               content={selected.content}
               onChange={(content) => {
                 if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-                setSaveState("saving");
                 pendingContentRef.current = content;
                 saveTimerRef.current = setTimeout(() => {
                   pendingContentRef.current = null;
                   saveTimerRef.current = null;
+                  setSaveState("saving");
                   updateDoc.mutate(
                     { id: selected.id, patch: { content } },
                     {

--- a/src/features/docs/hooks/use-documents.ts
+++ b/src/features/docs/hooks/use-documents.ts
@@ -65,6 +65,23 @@ export const useDocuments = (workspaceId: string, projectId?: string) => {
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
   });
 
+  const createWorkspaceDoc = useMutation({
+    mutationFn: async (data: Partial<ChronicleDocument>) => {
+      return createDocument({
+        workspaceId,
+        title: data.title ?? "Untitled",
+        content: data.content ?? { type: "doc", content: [] },
+        icon: data.icon,
+        coverImage: data.coverImage,
+        parentId: data.parentId,
+        order: data.order ?? Date.now(),
+        createdBy: auth.currentUser?.uid ?? "unknown",
+        linkedWorkItems: data.linkedWorkItems ?? [],
+      });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["docs", workspaceId] }),
+  });
+
   const updateDoc = useMutation({
     mutationFn: ({ id, patch }: { id: string; patch: Partial<ChronicleDocument> }) => updateDocument(id, patch),
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
@@ -75,5 +92,5 @@ export const useDocuments = (workspaceId: string, projectId?: string) => {
     onSuccess: () => queryClient.invalidateQueries({ queryKey }),
   });
 
-  return { docsQuery, createDoc, updateDoc, removeDoc };
+  return { docsQuery, createDoc, createWorkspaceDoc, updateDoc, removeDoc };
 };


### PR DESCRIPTION
## Summary

- **Slash command**: `handleKeyDown` now returns `true` when `/` is pressed, consuming the event so TipTap does not insert the character into the document before the command menu opens. Escape also consumes the event.
- **Slash menu UX**: Search input auto-focuses on open; `onBlur` closes the menu; `onMouseDown` prevents focus loss when clicking commands.
- **Save indicator**: Moved `setSaveState("saving")` inside the 5 s debounce timeout so "Saving…" only appears when a Firestore write is actually in flight — not on every keystroke.
- **Cursor reset / words jumping to new line**: Removed the `useEffect` in `ChronicleEditor` that called `editor.commands.setContent()` whenever the `content` prop changed (which fired after every successful save, resetting cursor position). Added `key={selected.id}` on `<ChronicleEditor>` in `docs-workspace.tsx` so the editor instance recreates cleanly when switching documents.
- **Workspace doc creation from project window**: Added `createWorkspaceDoc` mutation to `useDocuments` (creates without `projectId`) and a `+` button on the **Workspace** section header in the project docs sidebar.

## Test plan

- [ ] Type `/` in the editor — command menu opens, no `/` appears in the document
- [ ] Select a command — it executes and the menu closes cleanly
- [ ] Press Escape — menu closes
- [ ] Type continuously — "Saving…" indicator stays hidden; it only appears ~5 s after you stop typing
- [ ] Switch between documents — cursor lands at the beginning of the new doc, no content bleed from the previous doc
- [ ] While editing, wait for the auto-save — cursor does not jump, words do not wrap unexpectedly
- [ ] Open a project's docs page — a `+` button appears in the **Workspace** section header; clicking it creates a new workspace-scoped doc visible in both the project sidebar and the workspace docs page

https://claude.ai/code/session_015CiE2mVjptJNzHF17G2yq7

---
_Generated by [Claude Code](https://claude.ai/code/session_015CiE2mVjptJNzHF17G2yq7)_