### PR TITLE
fix: render markdown content as formatted text in ChronicleEditor

### DIFF
--- a/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/epic/[taskId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/project/[projectId]/epic/[taskId]/client.tsx
@@ -27,12 +27,16 @@ import {
   RefreshCw,
   ChevronRight,
   MessageSquare,
+  Paperclip,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import Link from "next/link";
 import { getTaskRoute } from "@/lib/task-routes";
 import { cn } from "@/lib/utils";
 import { TaskComments } from "@/features/tasks/components/task-comments";
+import { TaskLinks } from "@/features/tasks/components/task-links";
+import { TaskAttachments } from "@/features/tasks/components/task-attachments";
+import { TaskDocLinks } from "@/features/tasks/components/task-doc-links";
 
 
 function ProgressBar({ value }: { readonly value: number }) {
@@ -284,6 +288,7 @@ export const EpicDetailClient = () => {
             { value: "overview",    icon: Circle,        label: "Overview" },
             { value: "work-items",  icon: LayoutList,    label: "Work Items", count: childTasks.length },
             { value: "comments",    icon: MessageSquare, label: "Comments" },
+            { value: "links",       icon: Paperclip,     label: "Links" },
             { value: "timeline",    icon: GitBranch,     label: "Timeline" },
             { value: "ai-notes",    icon: Sparkles,      label: "AI Notes" },
           ].map(({ value, icon: Icon, label, count }) => (
@@ -417,6 +422,15 @@ export const EpicDetailClient = () => {
         {/* Comments Tab */}
         <TabsContent value="comments" className="mt-6">
           <TaskComments taskId={epic.$id} />
+        </TabsContent>
+
+        {/* Links Tab */}
+        <TabsContent value="links" className="mt-6">
+          <div className="flex flex-col gap-5">
+            <TaskLinks taskId={epic.$id} workspaceId={workspaceId} projectId={projectId} />
+            <TaskDocLinks taskId={epic.$id} workspaceId={workspaceId} />
+            <TaskAttachments taskId={epic.$id} workspaceId={workspaceId} projectId={projectId} />
+          </div>
         </TabsContent>
 
         {/* Timeline Tab */}

--- a/src/app/(dashboard)/workspace/[workspaceId]/tasks/[taskId]/client.tsx
+++ b/src/app/(dashboard)/workspace/[workspaceId]/tasks/[taskId]/client.tsx
@@ -13,6 +13,7 @@ import { TaskOverview } from "@/features/tasks/components/task-overview";
 import { TaskComments } from "@/features/tasks/components/task-comments";
 import { TaskLinks } from "@/features/tasks/components/task-links";
 import { TaskAttachments } from "@/features/tasks/components/task-attachments";
+import { TaskDocLinks } from "@/features/tasks/components/task-doc-links";
 import { TaskActivity } from "@/features/tasks/components/task-activity";
 import { TaskTimeTracking } from "@/features/tasks/components/task-time-tracking";
 import { useTaskId } from "@/features/tasks/hooks/use-task-id";
@@ -266,6 +267,7 @@ export const TaskIdClient = () => {
           <TabsContent value="links" className="mt-6">
             <div className="flex flex-col gap-5">
               <TaskLinks taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
+              <TaskDocLinks taskId={data.$id} workspaceId={data.workspaceId} />
               <TaskAttachments taskId={data.$id} workspaceId={data.workspaceId} projectId={data.projectId} />
             </div>
           </TabsContent>

--- a/src/features/docs/components/chronicle-editor.tsx
+++ b/src/features/docs/components/chronicle-editor.tsx
@@ -16,6 +16,14 @@ import TableHeader from "@tiptap/extension-table-header";
 import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import { Button } from "@/components/ui/button";
+import { marked } from "marked";
+
+function resolveContent(content: unknown): unknown {
+  if (typeof content === "string" && content.trim()) {
+    return marked.parse(content) as string;
+  }
+  return content ?? "";
+}
 
 const lowlight = createLowlight(common);
 
@@ -47,7 +55,7 @@ export function ChronicleEditor({ content, onChange }: { content: any; onChange:
       Image,
       Link.configure({ openOnClick: false, autolink: true }),
     ],
-    content: content ?? "",
+    content: resolveContent(content),
     editorProps: {
       attributes: {
         class: "prose prose-invert max-w-none min-h-[360px] focus:outline-none",

--- a/src/features/docs/components/chronicle-editor.tsx
+++ b/src/features/docs/components/chronicle-editor.tsx
@@ -18,7 +18,8 @@ import Link from "@tiptap/extension-link";
 import { Button } from "@/components/ui/button";
 import { marked } from "marked";
 
-function resolveContent(content: unknown): unknown {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function resolveContent(content: any): any {
   if (typeof content === "string" && content.trim()) {
     return marked.parse(content) as string;
   }

--- a/src/features/tasks/components/task-doc-links.tsx
+++ b/src/features/tasks/components/task-doc-links.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ExternalLinkIcon, FileTextIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { useGetTask } from "../api/use-get-task";
+import { useUpdateTask } from "../api/use-update-task";
+import { useDocuments } from "@/features/docs/hooks/use-documents";
+import Link from "next/link";
+import type { ChronicleDocument } from "@/lib/docs-firestore";
+
+interface TaskDocLinksProps {
+	taskId: string;
+	workspaceId: string;
+}
+
+export const TaskDocLinks = ({ taskId, workspaceId }: TaskDocLinksProps) => {
+	const [showPicker, setShowPicker] = useState(false);
+
+	const { data: task } = useGetTask({ taskId });
+	const { mutate: updateTask, isPending } = useUpdateTask();
+	const { docsQuery } = useDocuments(workspaceId);
+
+	const linkedDocIds: string[] = task?.linkedDocs ?? [];
+	const allDocs: ChronicleDocument[] = docsQuery.data ?? [];
+
+	const linkedDocs = allDocs.filter((d) => linkedDocIds.includes(d.id));
+	const availableDocs = allDocs.filter((d) => !linkedDocIds.includes(d.id));
+
+	const getDocUrl = (doc: ChronicleDocument) =>
+		doc.projectId
+			? `/workspace/${workspaceId}/project/${doc.projectId}/docs/${doc.id}`
+			: `/workspace/${workspaceId}/docs/${doc.id}`;
+
+	const handleLink = (doc: ChronicleDocument) => {
+		updateTask(
+			{ param: { taskId }, json: { linkedDocs: [...linkedDocIds, doc.id] } },
+			{ onSuccess: () => setShowPicker(false) }
+		);
+	};
+
+	const handleUnlink = (docId: string) => {
+		updateTask({
+			param: { taskId },
+			json: { linkedDocs: linkedDocIds.filter((id) => id !== docId) },
+		});
+	};
+
+	return (
+		<div className="rounded-2xl p-5 flex flex-col gap-4 bg-surface border border-border/40">
+			<div className="flex items-center justify-between">
+				<h3 className="text-[14px] font-semibold text-foreground">Linked Docs</h3>
+				<Button
+					size="sm"
+					variant="ghost"
+					className="h-7 px-2.5 text-[12px] text-muted-foreground hover:text-foreground"
+					onClick={() => setShowPicker((v) => !v)}
+					disabled={isPending}
+				>
+					<PlusIcon className="size-3.5 mr-1" />
+					Link Doc
+				</Button>
+			</div>
+
+			{linkedDocs.length === 0 && !showPicker && (
+				<p className="text-[13px] italic text-muted-foreground/50">No linked docs.</p>
+			)}
+
+			<div className="flex flex-col gap-2">
+				{linkedDocs.map((doc) => (
+					<div
+						key={doc.id}
+						className="flex items-center gap-2 p-2 rounded-xl border border-border/40 bg-surface-2/50"
+					>
+						<span className="text-base shrink-0">{doc.icon ?? "📄"}</span>
+						<FileTextIcon className="size-3.5 shrink-0 text-primary/70" />
+						<span className="flex-1 text-sm font-medium truncate">{doc.title}</span>
+						<Link
+							href={getDocUrl(doc)}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-muted-foreground hover:text-foreground transition-colors shrink-0"
+						>
+							<ExternalLinkIcon className="size-3.5" />
+						</Link>
+						<button
+							onClick={() => handleUnlink(doc.id)}
+							disabled={isPending}
+							className="text-muted-foreground hover:text-destructive transition-colors disabled:opacity-50 shrink-0"
+						>
+							<TrashIcon className="size-3.5" />
+						</button>
+					</div>
+				))}
+			</div>
+
+			{showPicker && (
+				<div className="flex flex-col gap-2 pt-3 border-t border-border/40">
+					{availableDocs.length === 0 ? (
+						<p className="text-[13px] italic text-muted-foreground/50">
+							No other docs available in this workspace.
+						</p>
+					) : (
+						<div className="flex flex-col gap-1.5 max-h-48 overflow-y-auto">
+							{availableDocs.map((doc) => (
+								<button
+									key={doc.id}
+									onClick={() => handleLink(doc)}
+									disabled={isPending}
+									className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border/40 bg-surface hover:bg-surface-2 text-left transition-colors disabled:opacity-50"
+								>
+									<span className="text-base shrink-0">{doc.icon ?? "📄"}</span>
+									<span className="flex-1 text-sm truncate">{doc.title}</span>
+									<span className="text-xs text-muted-foreground shrink-0">
+										{doc.projectId ? "Project" : "Workspace"}
+									</span>
+								</button>
+							))}
+						</div>
+					)}
+					<Button size="sm" variant="ghost" className="w-fit" onClick={() => setShowPicker(false)}>
+						Cancel
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+};

--- a/src/features/tasks/components/task-links.tsx
+++ b/src/features/tasks/components/task-links.tsx
@@ -11,11 +11,12 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { TrashIcon, PlusIcon } from "lucide-react";
+import { TrashIcon, PlusIcon, SearchIcon, XIcon } from "lucide-react";
 import { useGetLinks } from "../api/use-get-links";
 import { useAddLink } from "../api/use-add-link";
 import { useRemoveLink } from "../api/use-remove-link";
-import { LinkType, TaskLink } from "../types";
+import { useGetTasks } from "../api/use-get-tasks";
+import { LinkType, Task, TaskLink } from "../types";
 import { snakeCaseToTitleCase } from "@/lib/utils";
 
 interface TaskLinksProps {
@@ -28,7 +29,8 @@ const LINK_TYPE_OPTIONS = Object.values(LinkType);
 
 export const TaskLinks = ({ taskId, workspaceId, projectId }: TaskLinksProps) => {
 	const [showForm, setShowForm] = useState(false);
-	const [targetTaskId, setTargetTaskId] = useState("");
+	const [search, setSearch] = useState("");
+	const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 	const [linkType, setLinkType] = useState<LinkType>(LinkType.RELATES_TO);
 	const [removingId, setRemovingId] = useState<string | null>(null);
 
@@ -36,13 +38,26 @@ export const TaskLinks = ({ taskId, workspaceId, projectId }: TaskLinksProps) =>
 	const { mutate: addLink, isPending: isAdding } = useAddLink();
 	const { mutate: removeLink } = useRemoveLink();
 
+	const { data: searchResults, isFetching: isSearching } = useGetTasks({
+		workspaceId,
+		projectId,
+		search: search.trim().length > 1 ? search.trim() : null,
+		enabled: showForm && search.trim().length > 1,
+	});
+
+	const matchedTasks = (searchResults?.documents ?? []).filter((t) => t.$id !== taskId);
+
 	const handleAdd = () => {
-		if (!targetTaskId.trim()) return;
+		if (!selectedTask) return;
 		addLink(
-			{ param: { taskId }, json: { targetTaskId: targetTaskId.trim(), type: linkType, workspaceId, projectId } },
+			{
+				param: { taskId },
+				json: { targetTaskId: selectedTask.$id, type: linkType, workspaceId, projectId: selectedTask.projectId },
+			},
 			{
 				onSuccess: () => {
-					setTargetTaskId("");
+					setSearch("");
+					setSelectedTask(null);
 					setLinkType(LinkType.RELATES_TO);
 					setShowForm(false);
 				},
@@ -50,10 +65,17 @@ export const TaskLinks = ({ taskId, workspaceId, projectId }: TaskLinksProps) =>
 		);
 	};
 
+	const resetForm = () => {
+		setShowForm(false);
+		setSearch("");
+		setSelectedTask(null);
+		setLinkType(LinkType.RELATES_TO);
+	};
+
 	return (
 		<div className="rounded-2xl p-5 flex flex-col gap-4 bg-surface border border-border/40">
 			<div className="flex items-center justify-between">
-				<h3 className="text-[14px] font-semibold text-foreground">Links</h3>
+				<h3 className="text-[14px] font-semibold text-foreground">Linked Tickets</h3>
 				<Button
 					size="sm"
 					variant="ghost"
@@ -67,12 +89,12 @@ export const TaskLinks = ({ taskId, workspaceId, projectId }: TaskLinksProps) =>
 
 			{isLoading && <p className="text-[13px] text-muted-foreground">Loading...</p>}
 			{!isLoading && (!data?.documents || data.documents.length === 0) && !showForm && (
-				<p className="text-[13px] italic text-muted-foreground/50">No linked tasks.</p>
+				<p className="text-[13px] italic text-muted-foreground/50">No linked tickets.</p>
 			)}
 
-			<div className="flex flex-col gap-y-2">
+			<div className="flex flex-col gap-2">
 				{(data?.documents as TaskLink[] | undefined)?.map((link) => (
-					<div key={link.$id} className="flex items-center gap-x-2 p-2 rounded-xl border border-border/40 bg-surface-2/50">
+					<div key={link.$id} className="flex items-center gap-2 p-2 rounded-xl border border-border/40 bg-surface-2/50">
 						<Badge variant="outline" className="shrink-0 text-xs">
 							{snakeCaseToTitleCase(link.type)}
 						</Badge>
@@ -106,36 +128,73 @@ export const TaskLinks = ({ taskId, workspaceId, projectId }: TaskLinksProps) =>
 			</div>
 
 			{showForm && (
-				<>
-					<div className="flex flex-col gap-y-2 pt-2 border-t border-border/40">
-						<Select value={linkType} onValueChange={(v) => setLinkType(v as LinkType)}>
-							<SelectTrigger className="h-8 text-sm">
-								<SelectValue placeholder="Link type" />
-							</SelectTrigger>
-							<SelectContent>
-								{LINK_TYPE_OPTIONS.map((t) => (
-									<SelectItem key={t} value={t}>
-										{snakeCaseToTitleCase(t)}
-									</SelectItem>
-								))}
-							</SelectContent>
-						</Select>
-						<Input
-							placeholder="Target task ID"
-							value={targetTaskId}
-							onChange={(e) => setTargetTaskId(e.target.value)}
-							className="h-8 text-sm"
-						/>
-						<div className="flex gap-x-2">
-							<Button size="sm" onClick={handleAdd} disabled={isAdding || !targetTaskId.trim()}>
-								{isAdding ? "Adding..." : "Add"}
-							</Button>
-							<Button size="sm" variant="outline" onClick={() => setShowForm(false)}>
-								Cancel
-							</Button>
+				<div className="flex flex-col gap-3 pt-3 border-t border-border/40">
+					<Select value={linkType} onValueChange={(v) => setLinkType(v as LinkType)}>
+						<SelectTrigger className="h-8 text-sm">
+							<SelectValue placeholder="Link type" />
+						</SelectTrigger>
+						<SelectContent>
+							{LINK_TYPE_OPTIONS.map((t) => (
+								<SelectItem key={t} value={t}>
+									{snakeCaseToTitleCase(t)}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+
+					{selectedTask ? (
+						<div className="flex items-center gap-2 px-3 py-2 rounded-lg border border-primary/30 bg-primary/5">
+							<span className="flex-1 text-sm text-foreground truncate">{selectedTask.name}</span>
+							<span className="text-xs text-muted-foreground font-mono shrink-0">{selectedTask.$id}</span>
+							<button
+								onClick={() => { setSelectedTask(null); setSearch(""); }}
+								className="text-muted-foreground hover:text-destructive transition-colors"
+							>
+								<XIcon className="size-3.5" />
+							</button>
 						</div>
+					) : (
+						<div className="relative">
+							<SearchIcon className="absolute left-2.5 top-2 size-3.5 text-muted-foreground pointer-events-none" />
+							<Input
+								placeholder="Search tickets by name…"
+								value={search}
+								onChange={(e) => setSearch(e.target.value)}
+								className="h-8 text-sm pl-8"
+							/>
+							{search.trim().length > 1 && (
+								<div className="absolute top-full left-0 right-0 mt-1 rounded-lg border border-border/40 bg-background shadow-lg z-10 max-h-48 overflow-y-auto">
+									{isSearching && (
+										<p className="text-xs text-muted-foreground px-3 py-2">Searching…</p>
+									)}
+									{!isSearching && matchedTasks.length === 0 && (
+										<p className="text-xs text-muted-foreground px-3 py-2">No tickets found</p>
+									)}
+									{matchedTasks.map((t) => (
+										<button
+											key={t.$id}
+											className="w-full text-left px-3 py-2 text-sm hover:bg-surface-2 flex items-center gap-2 transition-colors"
+											onMouseDown={(e) => e.preventDefault()}
+											onClick={() => { setSelectedTask(t); setSearch(""); }}
+										>
+											<span className="flex-1 truncate">{t.name}</span>
+											<span className="text-xs text-muted-foreground font-mono shrink-0">{t.$id}</span>
+										</button>
+									))}
+								</div>
+							)}
+						</div>
+					)}
+
+					<div className="flex gap-2">
+						<Button size="sm" onClick={handleAdd} disabled={isAdding || !selectedTask}>
+							{isAdding ? "Adding…" : "Add Link"}
+						</Button>
+						<Button size="sm" variant="outline" onClick={resetForm}>
+							Cancel
+						</Button>
 					</div>
-				</>
+				</div>
 			)}
 		</div>
 	);


### PR DESCRIPTION
## Summary

- TipTap doesn't parse raw markdown strings — it treats them as plain text, causing `# heading`, `**bold**`, `---` etc. to appear verbatim in the editor
- Use `marked` (already a project dependency) to convert any string content to HTML before handing it to TipTap's `content` prop
- TipTap JSON objects (saved by the editor) are passed through unchanged — only legacy string content is affected

## Test plan

- [ ] Open an existing doc that was saved as raw markdown — verify headings, bold, lists, code blocks etc. render correctly instead of showing raw syntax
- [ ] Create a new doc from a template (Meeting Notes, PRD, etc.) — verify it opens with formatted content, not raw markdown
- [ ] Edit and save a doc — verify subsequent loads still render correctly (TipTap saves as JSON, so the conversion path is only hit for legacy string content)
- [ ] Create a blank doc — verify empty content still works

https://claude.ai/code/session_014TEU9TrAn14cEmzQtnrjXJ

---
_Generated by [Claude Code](https://claude.ai/code/session_014TEU9TrAn14cEmzQtnrjXJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Link documentation to tasks with a searchable document picker
  * Improved task linking experience with searchable task selection instead of manual ID entry
  * Epic details now display a Links tab showing linked items, documents, and attachments

* **Improvements**
  * Enhanced document content rendering in editor

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->