### PR TITLE
fix: persist linkedDocs when updating a task via PATCH

### DIFF
--- a/src/features/tasks/server/route.ts
+++ b/src/features/tasks/server/route.ts
@@ -549,6 +549,7 @@ workspaceId,
 				originalEstimate,
 				remainingEstimate,
 				rca,
+				linkedDocs,
 			} = c.req.valid("json");
 			const { taskId } = c.req.param();
 
@@ -604,7 +605,7 @@ workspaceId,
 				assigneeName: updatedAssigneeName,
 				description, acceptanceCriteria, issueType, priority, parentId,
 				labels, sprintId, storyPoints, epicId, fixVersionId,
-				originalEstimate, remainingEstimate, rca,
+				originalEstimate, remainingEstimate, rca, linkedDocs,
 			}));
 
 			// Write activity entries after main update


### PR DESCRIPTION
## Summary

- The PATCH task handler was missing `linkedDocs` in its destructuring of the validated request body
- As a result, when only `linkedDocs` was sent (e.g. when linking/unlinking a doc on an epic), `filterDefined()` received an entirely-undefined object and passed `{}` to `Firestore.update()` — which throws an error, causing the 500 response
- Fix: add `linkedDocs` to both the destructuring block and the `filterDefined()` update call in `src/features/tasks/server/route.ts`

## Test plan

- [ ] Open an epic detail page → Links tab
- [ ] Click "+ Link Doc", select a doc — it should save immediately with no 500 error
- [ ] Verify the linked doc appears after saving
- [ ] Click the trash icon to unlink — should also save without error
- [ ] Confirm no regression on other PATCH task operations (status, assignee, description, etc.)

https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Tasks now support linking documents. Users can attach relevant documents to tasks when updating task information, and these links are automatically saved for future reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->