### PR TITLE
fix: include project-level docs in the linked docs picker

### DIFF
--- a/src/features/tasks/components/task-doc-links.tsx
+++ b/src/features/tasks/components/task-doc-links.tsx
@@ -19,7 +19,7 @@ export const TaskDocLinks = ({ taskId, workspaceId }: TaskDocLinksProps) => {
 
 	const { data: task } = useGetTask({ taskId });
 	const { mutate: updateTask, isPending } = useUpdateTask();
-	const { docsQuery } = useDocuments(workspaceId);
+	const { docsQuery } = useDocuments(workspaceId, task?.projectId);
 
 	const linkedDocIds: string[] = task?.linkedDocs ?? [];
 	const allDocs: ChronicleDocument[] = docsQuery.data ?? [];


### PR DESCRIPTION
## Summary

- `useDocuments` was called with only `workspaceId` in `TaskDocLinks`, so the picker only showed workspace-level docs
- Passing `task?.projectId` as the second argument makes the hook fetch both workspace and project docs, giving users the full set of available documents to link

## Test plan

- [ ] Open an epic/story/bug detail page → Links tab → click + Link Doc
- [ ] Verify both workspace-level and project-level docs appear in the picker
- [ ] Link a project doc and confirm it saves and displays correctly

https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs)_