### PR TITLE
fix: expose linkedDocs in MCP update_ticket tool

### DIFF
--- a/src/lib/mcp-schemas.ts
+++ b/src/lib/mcp-schemas.ts
@@ -83,6 +83,7 @@ export const updateTicketBaseSchema = z.object({
   remainingEstimate: z.number().optional().describe(D.remainingEstimate),
   labels: z.array(z.string()).optional(),
   rca: z.string().optional().describe(D.rca),
+  linkedDocs: z.array(z.string()).optional().describe("Array of doc IDs to link to this ticket. Replaces the current list."),
 });
 
 // ── Sprint schemas ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `linkedDocs` was missing from `updateTicketBaseSchema` in `mcp-schemas.ts`, so the MCP `update_ticket` tool had no way to set it
- The MCP handler spreads all validated args (minus `workspaceId`, `projectId`, `taskId`) directly into a Firestore update, so adding the field to the schema is sufficient — no handler changes needed

## Test plan

- [ ] Via MCP, call `update_ticket` with a `linkedDocs` array and verify the field is persisted in Firestore
- [ ] Verify the UI still shows the linked docs correctly after updating via MCP
- [ ] Verify other `update_ticket` fields are unaffected

https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs)_