### PR TITLE
fix: coerce JSON-stringified arrays in MCP schemas

### DIFF
--- a/src/lib/mcp-schemas.ts
+++ b/src/lib/mcp-schemas.ts
@@ -9,6 +9,14 @@ import { TaskStatus, IssueType, TaskPriority } from "../features/tasks/types";
 import { MemberRole } from "../features/members/types";
 import { D } from "./mcp-tool-descriptions";
 
+// mcp-handler passes every param as a string when it can't resolve the schema
+// type (e.g. when properties:{} is served). This preprocessor coerces a
+// JSON-stringified array back to a real array before Zod validates it.
+const coerceJsonArray = (v: unknown) => {
+  if (typeof v === "string") { try { return JSON.parse(v); } catch { /* fall through */ } }
+  return v;
+};
+
 // ── Status / type enum helpers ────────────────────────────────────────────────
 
 const statusEnum = z.enum([
@@ -57,7 +65,7 @@ export const createTicketBaseSchema = z.object({
   storyPoints: z.number().optional().describe(D.storyPoints),
   originalEstimate: z.number().optional().describe(D.originalEstimate),
   remainingEstimate: z.number().optional().describe(D.remainingEstimate),
-  labels: z.array(z.string()).optional().describe(D.labels),
+  labels: z.preprocess(coerceJsonArray, z.array(z.string()).optional()).describe(D.labels),
   rca: z.string().optional().describe(D.rca),
 });
 
@@ -81,9 +89,9 @@ export const updateTicketBaseSchema = z.object({
   storyPoints: z.number().optional().describe(D.storyPointsUpdate),
   originalEstimate: z.number().optional().describe(D.originalEstimateShort),
   remainingEstimate: z.number().optional().describe(D.remainingEstimate),
-  labels: z.array(z.string()).optional(),
+  labels: z.preprocess(coerceJsonArray, z.array(z.string()).optional()),
   rca: z.string().optional().describe(D.rca),
-  linkedDocs: z.array(z.string()).optional().describe("Array of doc IDs to link to this ticket. Replaces the current list."),
+  linkedDocs: z.preprocess(coerceJsonArray, z.array(z.string()).optional()).describe("Array of doc IDs to link to this ticket. Replaces the current list."),
 });
 
 // ── Sprint schemas ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `mcp-handler` expects JSON Schema format for `inputSchema` but receives Zod objects (cast via `as any`). It can't convert them, so it advertises `properties: {}` to MCP clients.
- With no type information, the framework serializes every parameter as a string — including array fields like `linkedDocs` and `labels`. Zod's `z.array()` then rejects `"[\"DOC-...\"]"`.
- Fix: add a `coerceJsonArray` preprocessor that `JSON.parse`s a string value before the inner schema validates. Applied to `labels` and `linkedDocs` in both `createTicketBaseSchema` and `updateTicketBaseSchema`.

## Note

The root cause (schema served as `properties: {}`) requires either installing `zod-to-json-schema` or rewriting `inputSchema` as plain JSON Schema objects — tracked separately. This PR fixes the symptom so `linkedDocs`/`labels` work correctly in the meantime.

## Test plan

- [ ] Via MCP, call `update_ticket` passing `linkedDocs` as a JSON string `"[\"DOC-xxx\"]"` — should be coerced and saved correctly
- [ ] Via MCP, call `update_ticket` passing `linkedDocs` as a real array — should also work
- [ ] Same checks for `labels`

https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs)_