### PR TITLE
fix: resolve member doc ID when MCP posts a comment

### DIFF
--- a/src/lib/mcp-shared.ts
+++ b/src/lib/mcp-shared.ts
@@ -169,9 +169,17 @@ export async function addComment(
   const ref = taskDocRef(db, args.workspaceId, args.projectId, args.taskId);
   if (!(await ref.get()).exists) throw new Error(TASK_NOT_FOUND);
 
+  // Resolve member doc ID so the GET comments handler can look up the author name
+  const memberSnap = await db.collection(MEMBERS)
+    .where(WORKSPACE_ID, "==", args.workspaceId)
+    .where(USER_ID, "==", userId)
+    .limit(1)
+    .get();
+  const authorId = memberSnap.empty ? userId : memberSnap.docs[0].id;
+
   const commentRef = await ref.collection(COMMENTS).add({
     content: args.content,
-    authorId: userId,
+    authorId,
     workspaceId: args.workspaceId,
     projectId: args.projectId,
     $createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- `addComment` in `mcp-shared.ts` was storing `authorId: userId` where `userId` is a Firebase Auth UID
- The GET comments handler queries members by Firestore document ID (`where("__name__", "in", chunk)`), so the lookup fails when the stored ID is an Auth UID
- This caused `comment.author` to be `null`, and the UI fell back to displaying "Unknown"
- Fix: look up the member document by `workspaceId + userId` before writing the comment, and store the member doc ID as `authorId`

## Test plan

- [ ] Post a comment via MCP `add_comment` — author name should display correctly in the UI
- [ ] Post a comment via the UI — still works correctly (unaffected)
- [ ] Pre-existing "Unknown" comments are unaffected (historical data)

https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2Te2SdDypQUg5htk46EKs)_