### PR TITLE
Separate description/AC sections and auto-resize textarea

### DIFF
--- a/src/components/markdown-editor.tsx
+++ b/src/components/markdown-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -18,9 +18,18 @@ export function MarkdownEditor({
 	value,
 	onChange,
 	placeholder = "Write your content here...",
-	minRows = 4,
+	minRows = 5,
 	className,
 }: MarkdownEditorProps) {
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	useEffect(() => {
+		const textarea = textareaRef.current;
+		if (!textarea) return;
+		textarea.style.height = "auto";
+		textarea.style.height = `${textarea.scrollHeight}px`;
+	}, [value]);
+
 	return (
 		<Tabs defaultValue="write" className={cn("w-full", className)}>
 			<TabsList className="grid grid-cols-2 w-fit mb-2">
@@ -29,11 +38,12 @@ export function MarkdownEditor({
 			</TabsList>
 			<TabsContent value="write" className="mt-0">
 				<Textarea
+					ref={textareaRef}
 					value={value}
 					onChange={(e) => onChange(e.target.value)}
 					placeholder={placeholder}
 					rows={minRows}
-					className="resize-none font-mono text-sm"
+					className="resize-none font-mono text-sm overflow-hidden"
 				/>
 			</TabsContent>
 			<TabsContent value="preview" className="mt-0">

--- a/src/features/tasks/components/task-description.tsx
+++ b/src/features/tasks/components/task-description.tsx
@@ -64,19 +64,22 @@ export const TaskDescription = ({ task }: TaskDescriptionProps) => {
 							value={descriptionValue}
 							onChange={setDescriptionValue}
 							placeholder="Describe the task"
-							minRows={4}
+							minRows={5}
 						/>
 					</div>
 					{showAc && (
-						<div>
-							<p className="text-sm font-medium mb-2">Acceptance Criteria</p>
-							<MarkdownEditor
-								value={acValue}
-								onChange={setAcValue}
-								placeholder="Define the conditions that must be met for this to be considered done"
-								minRows={3}
-							/>
-						</div>
+						<>
+							<hr className="border-border/40" />
+							<div>
+								<p className="text-sm font-medium mb-2">Acceptance Criteria</p>
+								<MarkdownEditor
+									value={acValue}
+									onChange={setAcValue}
+									placeholder="Define the conditions that must be met for this to be considered done"
+									minRows={5}
+								/>
+							</div>
+						</>
 					)}
 					<Button
 						size="sm"
@@ -99,16 +102,19 @@ export const TaskDescription = ({ task }: TaskDescriptionProps) => {
 						)}
 					</div>
 					{showAc && (
-						<div>
-							<p className="text-sm font-medium mb-2">Acceptance Criteria</p>
-							{task.acceptanceCriteria ? (
-								<MarkdownRenderer content={task.acceptanceCriteria} />
-							) : (
-								<span className="text-muted-foreground text-sm italic">
-									No Acceptance Criteria
-								</span>
-							)}
-						</div>
+						<>
+							<hr className="border-border/40" />
+							<div>
+								<p className="text-sm font-medium mb-2">Acceptance Criteria</p>
+								{task.acceptanceCriteria ? (
+									<MarkdownRenderer content={task.acceptanceCriteria} />
+								) : (
+									<span className="text-muted-foreground text-sm italic">
+										No Acceptance Criteria
+									</span>
+								)}
+							</div>
+						</>
 					)}
 				</div>
 			)}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Added `<hr>` divider between Description and Acceptance Criteria in both view mode and edit mode, so they are visually distinct sections within the same card
- Made `MarkdownEditor` textarea auto-resize from a 5-row minimum: uses a `ref` + `useEffect` that sets `height: auto` then `height: scrollHeight` whenever `value` changes, with `overflow-hidden` to prevent scrollbar flash

## Test plan

- [ ] Open a Bug/Story/Epic detail page — confirm Description and Acceptance Criteria are separated by a horizontal rule in view mode
- [ ] Click Edit — confirm the divider also appears between the two editor sections
- [ ] Type multiple lines into a textarea — confirm it grows vertically and doesn't show a scrollbar
- [ ] Open a task with no Acceptance Criteria (e.g. a Spike) — confirm no divider appears

https://claude.ai/code/session_01EUpbs7LYJFwG5n1vJDzGKN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUpbs7LYJFwG5n1vJDzGKN)_