### PR TITLE
fix: include credentials in Hono RPC client to resolve 401 on API calls

### DIFF
--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,4 +1,6 @@
 import { AppType } from "@/app/api/[[...route]]/route";
 import { hc } from "hono/client";
 
-export const client = hc<AppType>(process.env.NEXT_PUBLIC_APP_URL!);
+export const client = hc<AppType>(process.env.NEXT_PUBLIC_APP_URL!, {
+	init: { credentials: "include" },
+});


### PR DESCRIPTION
## Summary

- The Hono `hc()` RPC client in `src/lib/rpc.ts` was initialized without `credentials: 'include'`, so the browser never sent the `mp-flowboard-session` cookie with API requests
- The `sessionMiddleware` found no cookie and returned 401 on every protected route (e.g. `/api/projects`)
- Fix: pass `{ init: { credentials: 'include' } }` as the second argument to `hc()`

## Test plan

- [ ] Log in and verify the workspace overview loads projects without a 401 in the network tab
- [ ] Confirm the `mp-flowboard-session` cookie appears in request headers for `/api/projects` calls

https://claude.ai/code/session_01WFXAr1UvzQFoMoiyySx9kw

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFXAr1UvzQFoMoiyySx9kw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API client configuration to support cookie-based authentication for secure credential handling in API requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatrimPathak/Flowboard/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->